### PR TITLE
[DEL-2868]: Remove color formatting from Delegate log files

### DIFF
--- a/260-delegate/src/main/resources/logback-test.xml
+++ b/260-delegate/src/main/resources/logback-test.xml
@@ -29,7 +29,7 @@
         <withJansi>true</withJansi>
 
         <encoder>
-            <pattern>%date{ISO8601} %blue([%version]) %boldGreen(%process_id) %green([%thread]) %highlight(%-5level) %cyan(%logger) - %msg %yellow(%replace(%mdc){'(.+)', '[$1]'}) %n</pattern>
+            <pattern>%date{ISO8601} [%version] %process_id [%thread] %-5level %logger - %msg %replace(%mdc){'(.+)', '[$1]'} %n</pattern>
         </encoder>
     </appender>
 

--- a/960-watcher/src/main/resources/logback.xml
+++ b/960-watcher/src/main/resources/logback.xml
@@ -20,7 +20,7 @@
         <withJansi>true</withJansi>
 
         <encoder>
-            <pattern>%date{ISO8601} %blue([%version]) %boldGreen(%process_id) %green([%thread]) %highlight(%-5level) %cyan(%logger) - %msg %yellow(%replace(%mdc){'(.+)', '[$1]'}) %n</pattern>
+            <pattern>%date{ISO8601} [%version] %process_id [%thread] %-5level %logger - %msg %replace(%mdc){'(.+)', '[$1]'} %n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- tibootstrap-ti0: `trigger ti0`
- tibootstrap-ti1: `trigger ti1`
- tibootstrap2backup-ti2: `trigger ti2`
- tibootstrap-ti3: `trigger ti3`
- tibootstrap-ti4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/29136)
<!-- Reviewable:end -->
