### PR TITLE
fix: [PL-21993]: changed method name from get to fetch to remove ambiguity b/w getter for jackson

### DIFF
--- a/400-rest/src/test/java/software/wings/service/PluginServiceTest.java
+++ b/400-rest/src/test/java/software/wings/service/PluginServiceTest.java
@@ -422,7 +422,6 @@ public class PluginServiceTest extends CategoryTest {
   @Test
   @Owner(developers = RAGHU)
   @Category(UnitTests.class)
-  @Ignore("Not required now, since this is not used")
   public void shouldGetPluginSettingSchema() throws Exception {
     assertThat(pluginService.getPluginSettingSchema(accountId))
         .hasSize(37)

--- a/890-sm-core/src/main/java/io/harness/encryptors/clients/LocalEncryptor.java
+++ b/890-sm-core/src/main/java/io/harness/encryptors/clients/LocalEncryptor.java
@@ -46,9 +46,9 @@ public class LocalEncryptor implements KmsEncryptor {
   public EncryptedRecord encryptSecret(String accountId, String value, EncryptionConfig encryptionConfig) {
     if (Boolean.TRUE.equals(
             encryptionConfig.getEncryptionFeatureFlagStatus().get(FeatureName.LOCAL_AWS_ENCRYPTION_SDK_MODE.name()))) {
-      final byte[] awsEncryptedSecret = getAwsEncryptedSecret(accountId, value, encryptionConfig.getSecretKeySpec());
+      final byte[] awsEncryptedSecret = getAwsEncryptedSecret(accountId, value, encryptionConfig.fetchSecretKeySpec());
       return EncryptedRecordData.builder()
-          .encryptionKey(encryptionConfig.getSecretKeySpec().getUuid())
+          .encryptionKey(encryptionConfig.fetchSecretKeySpec().getUuid())
           .encryptedValueBytes(awsEncryptedSecret)
           .encryptedMech(EncryptedMech.AWS_ENCRYPTION_SDK_CRYPTO)
           .build();
@@ -56,14 +56,14 @@ public class LocalEncryptor implements KmsEncryptor {
     final char[] localJavaEncryptedSecret = getLocalJavaEncryptedSecret(accountId, value);
     if (Boolean.TRUE.equals(
             encryptionConfig.getEncryptionFeatureFlagStatus().get(FeatureName.LOCAL_MULTI_CRYPTO_MODE.name()))) {
-      final byte[] awsEncryptedSecret = getAwsEncryptedSecret(accountId, value, encryptionConfig.getSecretKeySpec());
+      final byte[] awsEncryptedSecret = getAwsEncryptedSecret(accountId, value, encryptionConfig.fetchSecretKeySpec());
       return EncryptedRecordData.builder()
           .encryptionKey(accountId)
           .encryptedValue(localJavaEncryptedSecret)
           .encryptedMech(EncryptedMech.MULTI_CRYPTO)
           .additionalMetadata(
               AdditionalMetadata.builder()
-                  .value(AdditionalMetadata.SECRET_KEY_UUID_KEY, encryptionConfig.getSecretKeySpec().getUuid())
+                  .value(AdditionalMetadata.SECRET_KEY_UUID_KEY, encryptionConfig.fetchSecretKeySpec().getUuid())
                   .value(AdditionalMetadata.AWS_ENCRYPTED_SECRET, awsEncryptedSecret)
                   .build())
           .build();
@@ -93,7 +93,7 @@ public class LocalEncryptor implements KmsEncryptor {
       return getLocalJavaDecryptedSecret(encryptedRecord);
     }
 
-    return getAwsDecryptedSecret(accountId, encryptedSecret, encryptionConfig.getSecretKeySpec()).toCharArray();
+    return getAwsDecryptedSecret(accountId, encryptedSecret, encryptionConfig.fetchSecretKeySpec()).toCharArray();
   }
 
   @Override

--- a/890-sm-core/src/main/java/software/wings/beans/LocalEncryptionConfig.java
+++ b/890-sm-core/src/main/java/software/wings/beans/LocalEncryptionConfig.java
@@ -101,7 +101,7 @@ public class LocalEncryptionConfig extends SecretManagerConfig {
   }
 
   @Override
-  public SecretKeyDTO getSecretKeySpec() {
+  public SecretKeyDTO fetchSecretKeySpec() {
     return secretKey;
   }
 

--- a/970-api-services-beans/src/main/java/io/harness/security/encryption/EncryptionConfig.java
+++ b/970-api-services-beans/src/main/java/io/harness/security/encryption/EncryptionConfig.java
@@ -79,7 +79,7 @@ public interface EncryptionConfig {
   /**
    * Get secret key, currently added for local encryption
    */
-  default SecretKeyDTO getSecretKeySpec() {
+  default SecretKeyDTO fetchSecretKeySpec() {
     throw new UnsupportedOperationException("Secret Key isn't supported for this type of encryption");
   }
 

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=73600
+build.number=73601
 build.patch=000
 delegate.version=22.01.12
 delegate.patch=000


### PR DESCRIPTION


You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/29987)
<!-- Reviewable:end -->
