### PR TITLE
[fix]: [PIE-1997]: fixing recast error while using secrets in notific…

### DIFF
--- a/800-pipeline-service/src/main/java/io/harness/pms/notification/NotificationHelper.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/notification/NotificationHelper.java
@@ -147,9 +147,9 @@ public class NotificationHelper {
 
   List<NotificationRules> getNotificationRulesFromYaml(String yaml, Ambiance ambiance) throws IOException {
     BasicPipeline basicPipeline = YamlUtils.read(yaml, BasicPipeline.class);
-    return RecastOrchestrationUtils.fromJson(
-        (String) pmsEngineExpressionService.resolve(
-            ambiance, RecastOrchestrationUtils.toJson(basicPipeline.getNotificationRules()), true),
+    return RecastOrchestrationUtils.fromMap(
+        (Map<String, Object>) pmsEngineExpressionService.resolve(
+            ambiance, RecastOrchestrationUtils.toMap(basicPipeline.getNotificationRules()), true),
         List.class);
   }
 

--- a/800-pipeline-service/src/test/java/io/harness/pms/notification/NotificationHelperTest.java
+++ b/800-pipeline-service/src/test/java/io/harness/pms/notification/NotificationHelperTest.java
@@ -47,10 +47,12 @@ import io.harness.pms.contracts.plan.ExecutionMetadata;
 import io.harness.pms.contracts.steps.StepCategory;
 import io.harness.pms.contracts.steps.StepType;
 import io.harness.pms.expression.PmsEngineExpressionService;
+import io.harness.pms.serializer.recaster.RecastOrchestrationUtils;
 import io.harness.rule.Owner;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -138,6 +140,9 @@ public class NotificationHelperTest extends CategoryTest {
 
   String notificationRulesString =
       "{\"__recast\":\"java.util.ArrayList\",\"__encodedValue\":[{\"__recast\":\"io.harness.notification.bean.NotificationRules\",\"name\":\"N2\",\"enabled\":true,\"pipelineEvents\":[{\"__recast\":\"io.harness.notification.bean.PipelineEvent\",\"type\":\"ALL_EVENTS\",\"forStages\":null},{\"__recast\":\"io.harness.notification.bean.PipelineEvent\",\"type\":\"STAGE_FAILED\",\"forStages\":[\"stage1\"]}],\"notificationChannelWrapper\":{\"__recast\":\"parameterField\",\"__encodedValue\":{\"__recast\":\"io.harness.pms.yaml.ParameterDocumentField\",\"expressionValue\":null,\"expression\":false,\"valueDoc\":{\"__recast\":\"io.harness.pms.yaml.ParameterFieldValueWrapper\",\"value\":{\"__recast\":\"io.harness.notification.bean.NotificationChannelWrapper\",\"type\":\"Email\",\"notificationChannel\":{\"__recast\":\"io.harness.notification.channelDetails.PmsEmailChannel\",\"userGroups\":[],\"recipients\":[\"admin@harness.io\",\"test@harness.io\"]}}},\"valueClass\":\"io.harness.notification.bean.NotificationChannelWrapper\",\"typeString\":false,\"skipAutoEvaluation\":false,\"jsonResponseField\":false,\"responseField\":null}}}]}";
+  Map<String, Object> notificationRulesMap =
+      RecastOrchestrationUtils.toMap(RecastOrchestrationUtils.fromJson(notificationRulesString));
+
   @Before
   public void setup() {
     notificationClient = mock(NotificationClientImpl.class);
@@ -222,7 +227,7 @@ public class NotificationHelperTest extends CategoryTest {
         .thenReturn(Optional.of(PlanExecutionMetadata.builder().yaml(emailNotificationYaml).build()));
     ArgumentCaptor<NotificationChannel> notificationChannelArgumentCaptor =
         ArgumentCaptor.forClass(NotificationChannel.class);
-    doReturn(notificationRulesString).when(pmsEngineExpressionService).resolve(eq(ambiance), any(), eq(true));
+    doReturn(notificationRulesMap).when(pmsEngineExpressionService).resolve(eq(ambiance), any(), eq(true));
 
     notificationHelper.sendNotification(ambiance, PipelineEventType.PIPELINE_SUCCESS, nodeExecution, 1L);
     verify(notificationClient, times(1)).sendNotificationAsync(notificationChannelArgumentCaptor.capture());
@@ -253,7 +258,7 @@ public class NotificationHelperTest extends CategoryTest {
         .thenReturn(PlanExecution.builder().status(Status.SUCCEEDED).startTs(0L).endTs(0L).build());
     when(planExecutionMetadataService.findByPlanExecutionId(anyString()))
         .thenReturn(Optional.of(PlanExecutionMetadata.builder().yaml(allEventsYaml).build()));
-    doReturn(notificationRulesString).when(pmsEngineExpressionService).resolve(eq(ambiance), any(), eq(true));
+    doReturn(notificationRulesMap).when(pmsEngineExpressionService).resolve(eq(ambiance), any(), eq(true));
     for (int idx = 0; idx < pipelineEventTypeList.size(); idx++) {
       notificationHelper.sendNotification(ambiance, pipelineEventTypeList.get(idx), nodeExecution, 1L);
       verify(notificationClient, times(idx + 1)).sendNotificationAsync(any());


### PR DESCRIPTION
…ations rules

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30008)
<!-- Reviewable:end -->
