### PR TITLE
feat: [CDC-16316]: Accept ROLLBACK_PROVISIONER_AFTER_PHASES as an interrupt

### DIFF
--- a/400-rest/src/main/java/software/wings/resources/ExecutionResource.java
+++ b/400-rest/src/main/java/software/wings/resources/ExecutionResource.java
@@ -377,7 +377,9 @@ public class ExecutionResource {
       @PathParam("workflowExecutionId") String workflowExecutionId, ExecutionInterrupt executionInterrupt) {
     executionInterrupt.setAppId(appId);
     executionInterrupt.setExecutionUuid(workflowExecutionId);
-    if (ExecutionInterruptType.ROLLBACK.equals(executionInterrupt.getExecutionInterruptType())) {
+    if (ExecutionInterruptType.ROLLBACK.equals(executionInterrupt.getExecutionInterruptType())
+        || ExecutionInterruptType.ROLLBACK_PROVISIONER_AFTER_PHASES.equals(
+            executionInterrupt.getExecutionInterruptType())) {
       deploymentAuthHandler.authorizeRollback(appId, workflowExecutionId);
     } else {
       deploymentAuthHandler.authorize(appId, workflowExecutionId);

--- a/400-rest/src/main/java/software/wings/sm/ExecutionInterruptManager.java
+++ b/400-rest/src/main/java/software/wings/sm/ExecutionInterruptManager.java
@@ -237,6 +237,7 @@ public class ExecutionInterruptManager {
       case MARK_FAILED:
       case MARK_SUCCESS:
       case ROLLBACK:
+      case ROLLBACK_PROVISIONER_AFTER_PHASES:
       case END_EXECUTION:
       case ROLLBACK_DONE:
         noop();
@@ -265,6 +266,7 @@ public class ExecutionInterruptManager {
         case RETRY:
         case IGNORE:
         case ROLLBACK:
+        case ROLLBACK_PROVISIONER_AFTER_PHASES:
         case ABORT:
         case MARK_EXPIRED:
         case RESUME_ALL:


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30045)
<!-- Reviewable:end -->
