### PR TITLE
fix: [PL-21658]: SMTP NG name does not have restrictions

### DIFF
--- a/960-ng-core-beans/src/main/java/io/harness/ng/core/dto/NgSmtpDTO.java
+++ b/960-ng-core-beans/src/main/java/io/harness/ng/core/dto/NgSmtpDTO.java
@@ -10,6 +10,7 @@ package io.harness.ng.core.dto;
 import static io.harness.annotations.dev.HarnessTeam.PL;
 
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.data.validator.NGEntityName;
 import io.harness.data.validator.Trimmed;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -27,6 +28,6 @@ import org.hibernate.validator.constraints.NotEmpty;
 public class NgSmtpDTO {
   private String uuid;
   @NotEmpty String accountId;
-  @NotNull @NotBlank @Trimmed(message = "The name must not have trailing spaces.") private String name;
+  @NotNull @NotBlank @Trimmed(message = "The name must not have trailing spaces.") @NGEntityName private String name;
   @Valid @NotNull private SmtpConfigDTO value;
 }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30054)
<!-- Reviewable:end -->
