### PR TITLE
fix: [DEL-3001]: Deprecate system executor threadpool and use common threadpool for task execution

### DIFF
--- a/260-delegate/src/main/java/io/harness/delegate/app/modules/DelegateModule.java
+++ b/260-delegate/src/main/java/io/harness/delegate/app/modules/DelegateModule.java
@@ -783,6 +783,14 @@ public class DelegateModule extends AbstractModule {
 
   @Provides
   @Singleton
+  @Named("taskExecutor")
+  public ExecutorService taskExecutor() {
+    return ThreadPool.create(10, 400, 1, TimeUnit.SECONDS,
+        new ThreadFactoryBuilder().setNameFormat("task-exec-%d").setPriority(Thread.MIN_PRIORITY).build());
+  }
+
+  @Provides
+  @Singleton
   @Named("asyncExecutor")
   public ExecutorService asyncExecutor() {
     return ThreadPool.create(10, 400, 1, TimeUnit.SECONDS,

--- a/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
+++ b/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
@@ -912,7 +912,7 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
             taskExecutor.submit(() -> abortDelegateTask((DelegateTaskAbortEvent) delegateTaskEvent));
           }
         }
-      } catch (Throwable e) {
+      } catch (Exception e) {
         log.error("Exception while decoding task", e);
       }
       return;

--- a/260-delegate/src/main/java/io/harness/delegate/service/DelegateTaskExecutionData.java
+++ b/260-delegate/src/main/java/io/harness/delegate/service/DelegateTaskExecutionData.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.delegate.service;
+
+import io.harness.annotations.dev.HarnessModule;
+import io.harness.annotations.dev.TargetModule;
+
+import java.util.concurrent.Future;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@TargetModule(HarnessModule._420_DELEGATE_AGENT)
+public class DelegateTaskExecutionData {
+  private long executionStartTime;
+  private Future<?> taskFuture;
+}

--- a/420-delegate-service/src/main/java/io/harness/service/impl/DelegateTaskServiceImpl.java
+++ b/420-delegate-service/src/main/java/io/harness/service/impl/DelegateTaskServiceImpl.java
@@ -103,8 +103,6 @@ public class DelegateTaskServiceImpl implements DelegateTaskService {
       throw new InvalidArgumentsException(Pair.of("args", "response cannot be null"));
     }
 
-    log.debug("Response received for task with responseCode [{}]", response.getResponseCode());
-
     Query<DelegateTask> taskQuery = persistence.createQuery(DelegateTask.class)
                                         .filter(DelegateTaskKeys.accountId, response.getAccountId())
                                         .filter(DelegateTaskKeys.uuid, taskId);
@@ -125,6 +123,7 @@ public class DelegateTaskServiceImpl implements DelegateTaskService {
             return;
           }
         }
+        log.info("Response received for task: {}", taskId);
         handleResponse(delegateTask, taskQuery, response);
 
         updateDelegateTaskInsightsEvent(accountId, delegateId, taskId, response.getResponseCode());

--- a/420-delegate-service/src/main/java/io/harness/service/impl/DelegateTaskServiceImpl.java
+++ b/420-delegate-service/src/main/java/io/harness/service/impl/DelegateTaskServiceImpl.java
@@ -123,7 +123,7 @@ public class DelegateTaskServiceImpl implements DelegateTaskService {
             return;
           }
         }
-        log.info("Response received for task: {}", taskId);
+        log.info("Response received for task: {} from Delegate: {}", taskId, delegateId);
         handleResponse(delegateTask, taskQuery, response);
 
         updateDelegateTaskInsightsEvent(accountId, delegateId, taskId, response.getResponseCode());


### PR DESCRIPTION
common threadpool to execute both sync and async tasks.

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30058)
<!-- Reviewable:end -->
