### PR TITLE
[feat]: [PL-21845]: Add event monitoring on event framework consumers

### DIFF
--- a/953-events-api/src/main/java/io/harness/eventsframework/impl/redis/RedisProducer.java
+++ b/953-events-api/src/main/java/io/harness/eventsframework/impl/redis/RedisProducer.java
@@ -38,7 +38,7 @@ import org.redisson.api.StreamMessageId;
 @Slf4j
 public class RedisProducer extends AbstractProducer {
   private static final String PRODUCER = "producer";
-  private static final String REDIS_PUSH_EVENT_METRIC = "redis_push_event_metric";
+  private static final String REDIS_PRODUCER_EVENT_METRIC = "redis_producer_event_metric";
   private RStream<String, String> stream;
   private RedissonClient redissonClient;
   @Inject private RedisEventMetricPublisher redisEventMetricPublisher;
@@ -150,7 +150,7 @@ public class RedisProducer extends AbstractProducer {
   private void addMonitoring(Message message) {
     try {
       redisEventMetricPublisher.sendMetricWithEventContext(
-          RedisEventMetricDTOMapper.prepareRedisEventMetricDTO(message, getTopicName()), REDIS_PUSH_EVENT_METRIC);
+          RedisEventMetricDTOMapper.prepareRedisEventMetricDTO(message, getTopicName()), REDIS_PRODUCER_EVENT_METRIC);
     } catch (Exception ex) {
       log.warn("Error while sending metrics for redis producer events :", ex);
     }

--- a/953-events-api/src/main/resources/metrics/metricDefinitions/redis_event_metrics.yaml
+++ b/953-events-api/src/main/resources/metrics/metricDefinitions/redis_event_metrics.yaml
@@ -2,7 +2,11 @@ name: Get stats of redis event
 identifier: redis_event_stats
 metricGroup: redis_event
 metrics:
-  - metricName: redis_push_event_metric
-    metricDefinition: redis push event metric
+  - metricName: redis_producer_event_metric
+    metricDefinition: redis producer event metric
+    type: Count
+    unit: "1"
+  - metricName: redis_consumer_event_metric
+    metricDefinition: redis consumer event metric
     type: Count
     unit: "1"

--- a/scripts/jenkins/authorsList.txt
+++ b/scripts/jenkins/authorsList.txt
@@ -137,6 +137,7 @@ Rama Tummala rama@harness.io
 Rathnakara Malatesha rathna@harness.io
 Raunak Agrawal raunak.agrawal@harness.io
 Reetika mallavarapu.reetika@harness.io
+Richa Jajoo richa.jajoo@harness.io
 Rihaz Zahir rihaz.zahir@harness.io
 Rishi Singh rishi@harness.io
 Riyas P riyas.yash@harness.io


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30093)
<!-- Reviewable:end -->
