### PR TITLE
fix: [BT-712]: Allowing build number and patch to get modified in single c…

### DIFF
--- a/scripts/jenkins/buildMetadataPRCheck.sh
+++ b/scripts/jenkins/buildMetadataPRCheck.sh
@@ -28,13 +28,7 @@ echo "INFO: $?: VERSION_DIFF=$VERSION_DIFF"
 PATCH_DIFF=$(git diff temp246_test..${ghprbTargetBranch} -- ${VERSION_FILE} | { grep  "+build.patch=$PATCH" || true;})
 echo "INFO: $?: PATCH_DIFF=$PATCH_DIFF"
 
-if [ "${BRANCH_PREFIX}" = "release/" ] && [ $VERSION_DIFF ] && [ $PATCH_DIFF ]
-then
-
-  echo "ERROR: Both build.number and build.patch cannot be modified."
-  exit 1
-
-elif [ "${BRANCH_PREFIX}" = "release/" ] && [ ! $VERSION_DIFF ] && [ ! $PATCH_DIFF ]
+if [ "${BRANCH_PREFIX}" = "release/" ] && [ ! $VERSION_DIFF ] && [ ! $PATCH_DIFF ]
 then
 
   echo "ERROR:  Either build.number or build.patch must be incremented."


### PR DESCRIPTION
…ommit.

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30096)
<!-- Reviewable:end -->
