### PR TITLE
[CI-3328]: add retry logic to call graph uploading

### DIFF
--- a/product/ci/engine/grpc/tiproxy_handler.go
+++ b/product/ci/engine/grpc/tiproxy_handler.go
@@ -228,11 +228,15 @@ func (h *tiProxyHandler) UploadCg(ctx context.Context, req *pb.UploadCgRequest) 
 	if err != nil {
 		return res, errors.Wrap(err, "failed to get avro encoded callgraph")
 	}
-	err = client.UploadCg(org, project, pipeline, build, stage, step, repo, sha, source, target, timeMs, encCg)
-	if err != nil {
-		return res, errors.Wrap(err, "failed to upload cg to ti server")
+	for retry := 0; retry < 3; retry ++ {
+		err = client.UploadCg(org, project, pipeline, build, stage, step, repo, sha, source, target, timeMs, encCg)
+		if err != nil {
+			err =  errors.Wrap(err, "failed to upload cg to ti server")
+		} else {
+			return res, nil
+		}
 	}
-	return res, nil
+	return res, err
 }
 
 // getCgFiles return list of cg files in given directory


### PR DESCRIPTION
There might be better way of doing this. Please let me know

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
