### PR TITLE
[PIE-2379] adding missing accountId condition for NGTelemetryPublisher

### DIFF
--- a/120-ng-manager/src/main/java/io/harness/telemetry/NGTelemetryPublisher.java
+++ b/120-ng-manager/src/main/java/io/harness/telemetry/NGTelemetryPublisher.java
@@ -44,7 +44,7 @@ public class NGTelemetryPublisher {
 
       String accountId = getAccountId();
 
-      if (EmptyPredicate.isNotEmpty(accountId)) {
+      if (EmptyPredicate.isNotEmpty(accountId) || !accountId.equals(GLOBAL_ACCOUNT_ID)) {
         List<InstanceDTO> serviceInstancesInAMonth = cdPipelineInstrumentationHelper.getServiceInstancesInInterval(
             accountId, CURRENT_TIMESTAMP - MILLISECONDS_IN_A_MONTH, CURRENT_TIMESTAMP);
         totalNumberOfServiceInstancesInAMonth = (long) serviceInstancesInAMonth.size();


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
