### PR TITLE
fix: [CDP-20260]: Remove KUBECTL_VERSION dependency in tools install

### DIFF
--- a/270-delegate-service-app/container/scripts/replace_configs.sh
+++ b/270-delegate-service-app/container/scripts/replace_configs.sh
@@ -228,11 +228,6 @@ if [[ "" != "$DEPLOY_MODE" ]]; then
   yq write -i $CONFIG_FILE deployMode "$DEPLOY_MODE"
 fi
 
-if [[ "" != "$KUBECTL_VERSION" ]]; then
-  yq write -i $CONFIG_FILE kubectlVersion "$KUBECTL_VERSION"
-fi
-
-
 if [[ "" != "$jwtPasswordSecret" ]]; then
   yq write -i $CONFIG_FILE portal.jwtPasswordSecret "$jwtPasswordSecret"
 fi

--- a/270-delegate-service-app/delegate-service-config.yml
+++ b/270-delegate-service-app/delegate-service-config.yml
@@ -200,7 +200,6 @@ deployMode: KUBERNETES
 deployVariant: SAAS
 envPath: ""
 
-kubectlVersion: v1.13.2
 scmVersion: 0e23b6f1
 
 portal:

--- a/360-cg-manager/config.yml
+++ b/360-cg-manager/config.yml
@@ -322,7 +322,6 @@ deployMode: KUBERNETES
 deployVariant: SAAS
 envPath: ""
 
-kubectlVersion: v1.13.2
 scmVersion: 3ac4cefa
 
 ngAuthUIEnabled: false

--- a/360-cg-manager/container/scripts/replace_configs.sh
+++ b/360-cg-manager/container/scripts/replace_configs.sh
@@ -281,10 +281,6 @@ if [[ "" != "$DEPLOY_MODE" ]]; then
   yq write -i $CONFIG_FILE deployMode "$DEPLOY_MODE"
 fi
 
-if [[ "" != "$KUBECTL_VERSION" ]]; then
-  yq write -i $CONFIG_FILE kubectlVersion "$KUBECTL_VERSION"
-fi
-
 yq write -i $NEWRELIC_FILE common.license_key "$NEWRELIC_LICENSE_KEY"
 
 if [[ "$DISABLE_NEW_RELIC" == "true" ]]; then

--- a/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
@@ -1240,7 +1240,6 @@ public class DelegateServiceImpl implements DelegateService {
               .put("delegateCheckLocation", delegateCheckLocation)
               .put("deployMode", mainConfiguration.getDeployMode().name())
               .put("ciEnabled", String.valueOf(isCiEnabled))
-              .put("kubectlVersion", mainConfiguration.getKubectlVersion())
               .put("scmVersion", mainConfiguration.getScmVersion())
               .put("delegateGrpcServicePort", String.valueOf(delegateGrpcConfig.getPort()))
               .put("kubernetesAccountLabel", getAccountIdentifier(templateParameters.getAccountId()));

--- a/400-rest/src/main/resources/delegatetemplates/delegate.sh.ftl
+++ b/400-rest/src/main/resources/delegatetemplates/delegate.sh.ftl
@@ -241,8 +241,6 @@ fi
 
 rm -f -- *.bak
 
-export KUBECTL_VERSION=${kubectlVersion}
-
 export SCM_VERSION=${scmVersion}
 
 <#if delegateName??>

--- a/400-rest/src/test/java/software/wings/service/delegate/DelegateServiceTest.java
+++ b/400-rest/src/test/java/software/wings/service/delegate/DelegateServiceTest.java
@@ -317,7 +317,6 @@ public class DelegateServiceTest extends WingsBaseTest {
     when(subdomainUrlHelper.getDelegateMetadataUrl(any(), any(), any()))
         .thenReturn("http://localhost:" + port + "/delegateci.txt");
     when(mainConfiguration.getDeployMode()).thenReturn(DeployMode.KUBERNETES);
-    when(mainConfiguration.getKubectlVersion()).thenReturn("v1.12.2");
     when(mainConfiguration.getScmVersion()).thenReturn("542f4642");
     when(mainConfiguration.getOcVersion()).thenReturn("v4.2.16");
     when(mainConfiguration.getCdnConfig()).thenReturn(cdnConfig);

--- a/400-rest/src/test/java/software/wings/service/delegate/DelegateTaskServiceClassicTest.java
+++ b/400-rest/src/test/java/software/wings/service/delegate/DelegateTaskServiceClassicTest.java
@@ -219,7 +219,6 @@ public class DelegateTaskServiceClassicTest extends WingsBaseTest {
     when(subdomainUrlHelper.getDelegateMetadataUrl(any(), any(), any()))
         .thenReturn("http://localhost:" + port + "/delegateci.txt");
     when(mainConfiguration.getDeployMode()).thenReturn(DeployMode.KUBERNETES);
-    when(mainConfiguration.getKubectlVersion()).thenReturn("v1.12.2");
     when(mainConfiguration.getScmVersion()).thenReturn("542f4642");
     when(mainConfiguration.getOcVersion()).thenReturn("v4.2.16");
     when(mainConfiguration.getCdnConfig()).thenReturn(cdnConfig);

--- a/400-rest/src/test/resources/expectedDelegateOpenJdk.sh
+++ b/400-rest/src/test/resources/expectedDelegateOpenJdk.sh
@@ -308,8 +308,6 @@ fi
 
 rm -f -- *.bak
 
-export KUBECTL_VERSION=v1.12.2
-
 export SCM_VERSION=542f4642
 
 export DELEGATE_NAME=harness-delegate

--- a/400-rest/src/test/resources/expectedDelegateWithoutDelegateName.sh
+++ b/400-rest/src/test/resources/expectedDelegateWithoutDelegateName.sh
@@ -297,8 +297,6 @@ fi
 
 rm -f -- *.bak
 
-export KUBECTL_VERSION=v1.12.2
-
 export SCM_VERSION=542f4642
 
 export DELEGATE_PROFILE=QFWin33JRlKWKBzpzE5A9A

--- a/960-api-services/src/main/java/io/harness/delegate/configuration/InstallUtils.java
+++ b/960-api-services/src/main/java/io/harness/delegate/configuration/InstallUtils.java
@@ -227,19 +227,12 @@ public class InstallUtils {
         return true;
       }
 
-      String version = System.getenv().get("KUBECTL_VERSION");
-
-      if (StringUtils.isEmpty(version)) {
-        version = kubectlVersion;
-        log.info("No version configured. Using kubectl version", version);
-      }
-
-      String kubectlDirectory = kubectlBaseDir + version;
+      String kubectlDirectory = kubectlBaseDir + kubectlVersion;
 
       if (validateKubectlExists(kubectlDirectory)) {
         String kubectlPath = Paths.get(kubectlDirectory + "/kubectl").toAbsolutePath().normalize().toString();
-        kubectlPaths.put(version, kubectlPath);
-        log.info("kubectl version {} already installed", version);
+        kubectlPaths.put(kubectlVersion, kubectlPath);
+        log.info("kubectl version {} already installed", kubectlVersion);
         return true;
       }
 
@@ -247,7 +240,7 @@ public class InstallUtils {
 
       createDirectoryIfDoesNotExist(kubectlDirectory);
 
-      String downloadUrl = getKubectlDownloadUrl(configuration, version);
+      String downloadUrl = getKubectlDownloadUrl(configuration, kubectlVersion);
 
       log.info("download Url is {}", downloadUrl);
 
@@ -264,7 +257,7 @@ public class InstallUtils {
 
       if (result.getExitValue() == 0) {
         String kubectlPath = Paths.get(kubectlDirectory + "/kubectl").toAbsolutePath().normalize().toString();
-        kubectlPaths.put(version, kubectlPath);
+        kubectlPaths.put(kubectlVersion, kubectlPath);
         log.info(result.outputUTF8());
         if (validateKubectlExists(kubectlDirectory)) {
           log.info("kubectl path: {}", kubectlPath);

--- a/dockerization/delegate-service-app/scripts/replace_configs.sh
+++ b/dockerization/delegate-service-app/scripts/replace_configs.sh
@@ -228,10 +228,6 @@ if [[ "" != "$DEPLOY_MODE" ]]; then
   yq write -i $CONFIG_FILE deployMode "$DEPLOY_MODE"
 fi
 
-if [[ "" != "$KUBECTL_VERSION" ]]; then
-  yq write -i $CONFIG_FILE kubectlVersion "$KUBECTL_VERSION"
-fi
-
 
 if [[ "" != "$jwtPasswordSecret" ]]; then
   yq write -i $CONFIG_FILE portal.jwtPasswordSecret "$jwtPasswordSecret"

--- a/dockerization/manager/scripts/replace_configs.sh
+++ b/dockerization/manager/scripts/replace_configs.sh
@@ -281,10 +281,6 @@ if [[ "" != "$DEPLOY_MODE" ]]; then
   yq write -i $CONFIG_FILE deployMode "$DEPLOY_MODE"
 fi
 
-if [[ "" != "$KUBECTL_VERSION" ]]; then
-  yq write -i $CONFIG_FILE kubectlVersion "$KUBECTL_VERSION"
-fi
-
 yq write -i $NEWRELIC_FILE common.license_key "$NEWRELIC_LICENSE_KEY"
 
 if [[ "$DISABLE_NEW_RELIC" == "true" ]]; then


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30148)
<!-- Reviewable:end -->
