### PR TITLE
[PL-22132]: Supporting samAccountNameAttr as external User id

### DIFF
--- a/400-rest/src/main/java/software/wings/beans/sso/LdapUserSettings.java
+++ b/400-rest/src/main/java/software/wings/beans/sso/LdapUserSettings.java
@@ -36,6 +36,7 @@ public class LdapUserSettings implements LdapUserConfig {
   @JsonProperty @NotBlank String emailAttr = "mail";
   @JsonProperty @NotBlank String displayNameAttr = "cn";
   @JsonProperty @NotBlank String groupMembershipAttr = "memberOf";
+  @JsonProperty String samAccountNameAttr = "samAccountName";
 
   @JsonIgnore
   @Override
@@ -73,6 +74,6 @@ public class LdapUserSettings implements LdapUserConfig {
   @JsonIgnore
   @Override
   public String[] getReturnAttrs() {
-    return new String[] {emailAttr, displayNameAttr, uidAttr};
+    return new String[] {emailAttr, displayNameAttr, uidAttr, samAccountNameAttr};
   }
 }

--- a/400-rest/src/main/java/software/wings/helpers/ext/ldap/LdapUserConfig.java
+++ b/400-rest/src/main/java/software/wings/helpers/ext/ldap/LdapUserConfig.java
@@ -27,4 +27,6 @@ public interface LdapUserConfig extends LdapSearchConfig {
   String getGroupMembershipFilter(String groupDn);
 
   String getFallbackGroupMembershipFilter(String groupName);
+
+  String getSamAccountNameAttr();
 }

--- a/400-rest/src/main/java/software/wings/service/impl/ldap/LdapDelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/ldap/LdapDelegateServiceImpl.java
@@ -150,6 +150,9 @@ public class LdapDelegateServiceImpl implements LdapDelegateService {
     if (Arrays.asList(user.getAttributeNames()).contains(userConfig.getUidAttr())
         && user.getAttribute(userConfig.getUidAttr()) != null) {
       externalUserId = user.getAttribute(userConfig.getUidAttr()).getStringValue();
+    } else if (Arrays.asList(user.getAttributeNames()).contains(userConfig.getSamAccountNameAttr())
+        && user.getAttribute(userConfig.getSamAccountNameAttr()) != null) {
+      externalUserId = user.getAttribute(userConfig.getSamAccountNameAttr()).getStringValue();
     }
     log.info("LDAP user response with name {} and email {} and userId {}", name, email, externalUserId);
 


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30213)
<!-- Reviewable:end -->
