### PR TITLE
[fix]: [GIT-488]: Gitops View perms should be included in all rules similar to other permissions

### DIFF
--- a/925-access-control-service/src/main/resources/io/harness/accesscontrol/permissions/permissions.yml
+++ b/925-access-control-service/src/main/resources/io/harness/accesscontrol/permissions/permissions.yml
@@ -652,7 +652,7 @@ permissions:
   - identifier: gitops_agent_view
     name: View a Gitops Agent
     status: STAGING
-    includeInAllRoles: false
+    includeInAllRoles: true
     allowedScopeLevels:
        - project
        - organization
@@ -676,7 +676,7 @@ permissions:
   - identifier: gitops_application_view
     name: View a Gitops Application
     status: STAGING
-    includeInAllRoles: false
+    includeInAllRoles: true
     allowedScopeLevels:
       - project
   - identifier: gitops_application_create
@@ -712,7 +712,7 @@ permissions:
   - identifier: gitops_repository_view
     name: View a Gitops Repository
     status: STAGING
-    includeInAllRoles: false
+    includeInAllRoles: true
     allowedScopeLevels:
       - project
   - identifier: gitops_repository_edit
@@ -730,7 +730,7 @@ permissions:
   - identifier: gitops_cluster_view
     name: View a Gitops Cluster
     status: STAGING
-    includeInAllRoles: false
+    includeInAllRoles: true
     allowedScopeLevels:
       - project
   - identifier: gitops_cluster_edit
@@ -748,7 +748,7 @@ permissions:
   - identifier: gitops_gpgkey_view
     name: View a Gitops Gpgkey
     status: STAGING
-    includeInAllRoles: false
+    includeInAllRoles: true
     allowedScopeLevels:
       - project
   - identifier: gitops_gpgkey_edit
@@ -766,7 +766,7 @@ permissions:
   - identifier: gitops_cert_view
     name: View a Gitops Cert
     status: STAGING
-    includeInAllRoles: false
+    includeInAllRoles: true
     allowedScopeLevels:
       - project
   - identifier: gitops_cert_edit


### PR DESCRIPTION


You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30260)
<!-- Reviewable:end -->
