### PR TITLE
feat: [CDP-17623]: Support terraform destroy -auto-approve in newer versions

### DIFF
--- a/400-rest/src/main/java/software/wings/delegatetasks/TerraformProvisionTask.java
+++ b/400-rest/src/main/java/software/wings/delegatetasks/TerraformProvisionTask.java
@@ -69,6 +69,7 @@ import io.harness.logging.PlanJsonLogOutputStream;
 import io.harness.secretmanagerclient.EncryptDecryptHelper;
 import io.harness.security.encryption.EncryptedDataDetail;
 import io.harness.security.encryption.EncryptedRecordData;
+import io.harness.terraform.TerraformClient;
 import io.harness.terraform.TerraformHelperUtils;
 import io.harness.terraform.expression.TerraformPlanExpressionInterface;
 import io.harness.terraform.request.TerraformExecuteStepRequest;
@@ -147,6 +148,7 @@ public class TerraformProvisionTask extends AbstractDelegateRunnableTask {
   @Inject private EncryptDecryptHelper planEncryptDecryptHelper;
   @Inject private TerraformBaseHelper terraformBaseHelper;
   @Inject private AwsHelperService awsHelperService;
+  @Inject private TerraformClient terraformClient;
 
   private static final String AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID";
   private static final String AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
@@ -429,8 +431,10 @@ public class TerraformProvisionTask extends AbstractDelegateRunnableTask {
                 }
               } else {
                 if (parameters.getEncryptedTfPlan() == null) {
-                  command = format("terraform destroy -force %s %s", targetArgs, varParams);
-                  commandToLog = format("terraform destroy -force %s %s", targetArgs, uiLogs);
+                  String autoApproveArg = TerraformHelperUtils.getAutoApproveArgument(
+                      terraformClient.version(parameters.getTimeoutInMillis(), scriptDirectory));
+                  command = format("terraform destroy %s %s %s", autoApproveArg, targetArgs, varParams);
+                  commandToLog = format("terraform destroy %s %s %s", autoApproveArg, targetArgs, uiLogs);
                   saveExecutionLog(commandToLog, CommandExecutionStatus.RUNNING, INFO, logCallback);
                   code = executeShellCommand(command, scriptDirectory, parameters, envVars, activityLogOutputStream);
                 } else {

--- a/960-api-services/src/main/java/io/harness/terraform/TerraformClient.java
+++ b/960-api-services/src/main/java/io/harness/terraform/TerraformClient.java
@@ -13,6 +13,7 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.cli.CliResponse;
 import io.harness.logging.LogCallback;
 import io.harness.logging.PlanJsonLogOutputStream;
+import io.harness.terraform.beans.TerraformVersion;
 import io.harness.terraform.request.TerraformApplyCommandRequest;
 import io.harness.terraform.request.TerraformDestroyCommandRequest;
 import io.harness.terraform.request.TerraformInitCommandRequest;
@@ -68,5 +69,9 @@ public interface TerraformClient {
   @Nonnull
   CliResponse output(String tfOutputsFile, long timeoutInMillis, Map<String, String> envVariables,
       String scriptDirectory, @Nonnull LogCallback executionLogCallback)
+      throws InterruptedException, TimeoutException, IOException;
+
+  @Nonnull
+  TerraformVersion version(long timeoutInMillis, String scriptDirectory)
       throws InterruptedException, TimeoutException, IOException;
 }

--- a/960-api-services/src/main/java/io/harness/terraform/TerraformHelperUtils.java
+++ b/960-api-services/src/main/java/io/harness/terraform/TerraformHelperUtils.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.exception.ExceptionUtils;
 import io.harness.filesystem.FileIo;
+import io.harness.terraform.beans.TerraformVersion;
 
 import com.google.common.base.Throwables;
 import java.io.File;
@@ -88,5 +89,9 @@ public class TerraformHelperUtils {
     Path filePath = Files.createFile(Paths.get(scriptDirectory + "/" + format(fileName, uuid)));
     Files.write(filePath, fileContent.getBytes());
     return filePath.toString();
+  }
+
+  public String getAutoApproveArgument(TerraformVersion version) {
+    return version.minVersion(0, 15) ? "-auto-approve" : "-force";
   }
 }

--- a/960-api-services/src/test/java/io/harness/terraform/TerraformClientImplTest.java
+++ b/960-api-services/src/test/java/io/harness/terraform/TerraformClientImplTest.java
@@ -9,6 +9,7 @@ package io.harness.terraform;
 
 import static io.harness.annotations.dev.HarnessTeam.CDP;
 import static io.harness.provision.TerraformConstants.TERRAFORM_PLAN_FILE_OUTPUT_NAME;
+import static io.harness.rule.OwnerRule.ABOSII;
 import static io.harness.rule.OwnerRule.ROHITKARELIA;
 import static io.harness.terraform.TerraformConstants.DEFAULT_TERRAFORM_COMMAND_TIMEOUT;
 
@@ -27,8 +28,10 @@ import io.harness.exception.runtime.TerraformCliRuntimeException;
 import io.harness.filesystem.FileIo;
 import io.harness.logging.CommandExecutionStatus;
 import io.harness.logging.LogCallback;
+import io.harness.logging.NoopExecutionCallback;
 import io.harness.logging.PlanJsonLogOutputStream;
 import io.harness.rule.Owner;
+import io.harness.terraform.beans.TerraformVersion;
 import io.harness.terraform.request.TerraformApplyCommandRequest;
 import io.harness.terraform.request.TerraformDestroyCommandRequest;
 import io.harness.terraform.request.TerraformInitCommandRequest;
@@ -91,14 +94,26 @@ public class TerraformClientImplTest extends CategoryTest {
   @Test
   @Owner(developers = ROHITKARELIA)
   @Category(UnitTests.class)
-  public void testDestroyCommand() throws InterruptedException, IOException, TimeoutException {
+  public void testDestroyCommandUsingTf012() throws InterruptedException, IOException, TimeoutException {
+    testDestroyCommandUsingVersion(TerraformVersion.create(0, 12, 3));
+  }
+
+  @Test
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testDestroyCommandUsingTf015() throws InterruptedException, IOException, TimeoutException {
+    testDestroyCommandUsingVersion(TerraformVersion.create(0, 15, 3));
+  }
+
+  private void testDestroyCommandUsingVersion(TerraformVersion version)
+      throws InterruptedException, IOException, TimeoutException {
     CliResponse cliResponse = getCliResponse();
     TerraformDestroyCommandRequest terraformDestroyCommandRequest =
         TerraformDestroyCommandRequest.builder()
             .targets(Arrays.asList("10.0.10.1", "10.0.10.2"))
             .varFilePaths(Arrays.asList("variableParams"))
             .build();
-    String command = format("terraform destroy -force %s %s",
+    String command = format("terraform destroy %s %s %s", TerraformHelperUtils.getAutoApproveArgument(version),
         TerraformHelperUtils.generateCommandFlagsString(terraformDestroyCommandRequest.getTargets(), "-target="),
         TerraformHelperUtils.generateCommandFlagsString(
             terraformDestroyCommandRequest.getVarFilePaths(), "-var-file="));
@@ -106,6 +121,11 @@ public class TerraformClientImplTest extends CategoryTest {
         .when(cliHelper)
         .executeCliCommand(eq(command), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT), eq(Collections.emptyMap()),
             eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any());
+
+    doReturn(getCliResponseTfVersion(version.getMajor(), version.getMinor(), version.getPatch()))
+        .when(cliHelper)
+        .executeCliCommand(eq("terraform version"), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT), eq(Collections.emptyMap()),
+            eq(SCRIPT_FILES_DIRECTORY), any(LogCallback.class));
 
     CliResponse actualResponse = terraformClientImpl.destroy(terraformDestroyCommandRequest,
         DEFAULT_TERRAFORM_COMMAND_TIMEOUT, Collections.emptyMap(), SCRIPT_FILES_DIRECTORY, logCallback);
@@ -281,5 +301,48 @@ public class TerraformClientImplTest extends CategoryTest {
 
     CliResponse actualResponse = terraformClientImpl.output(
         tfOutputsFile, DEFAULT_TERRAFORM_COMMAND_TIMEOUT, Collections.emptyMap(), SCRIPT_FILES_DIRECTORY, logCallback);
+  }
+
+  @Test
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testVersionSuccess() throws InterruptedException, TimeoutException, IOException {
+    doReturn(getCliResponseTfVersion(0, 13, 4))
+        .when(cliHelper)
+        .executeCliCommand(eq("terraform version"), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT), eq(Collections.emptyMap()),
+            eq(SCRIPT_FILES_DIRECTORY), any(NoopExecutionCallback.class));
+
+    TerraformVersion version = terraformClientImpl.version(DEFAULT_TERRAFORM_COMMAND_TIMEOUT, SCRIPT_FILES_DIRECTORY);
+
+    assertThat(version.getMajor()).isEqualTo(0);
+    assertThat(version.getMinor()).isEqualTo(13);
+    assertThat(version.getPatch()).isEqualTo(4);
+  }
+
+  @Test
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testVersionFailed() throws InterruptedException, TimeoutException, IOException {
+    doReturn(CliResponse.builder().commandExecutionStatus(CommandExecutionStatus.FAILURE).build())
+        .when(cliHelper)
+        .executeCliCommand(eq("terraform version"), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT), eq(Collections.emptyMap()),
+            eq(SCRIPT_FILES_DIRECTORY), any(NoopExecutionCallback.class));
+
+    TerraformVersion version = terraformClientImpl.version(DEFAULT_TERRAFORM_COMMAND_TIMEOUT, SCRIPT_FILES_DIRECTORY);
+
+    assertThat(version.getMajor()).isNull();
+    assertThat(version.getMinor()).isNull();
+    assertThat(version.getPatch()).isNull();
+  }
+
+  private CliResponse getCliResponseTfVersion(int major, int minor, int patch) {
+    return CliResponse.builder()
+        .commandExecutionStatus(CommandExecutionStatus.SUCCESS)
+        .output(format("Terraform v%d.%d.%d\n"
+                + "\n"
+                + "Your version of Terraform is out of date! The latest version\n"
+                + "is 1.1.4. You can update by downloading from www.terraform.io",
+            major, minor, patch))
+        .build();
   }
 }

--- a/960-api-services/src/test/java/io/harness/terraform/TerraformHelperUtilsTest.java
+++ b/960-api-services/src/test/java/io/harness/terraform/TerraformHelperUtilsTest.java
@@ -8,6 +8,7 @@
 package io.harness.terraform;
 
 import static io.harness.annotations.dev.HarnessTeam.CDP;
+import static io.harness.rule.OwnerRule.ABOSII;
 import static io.harness.rule.OwnerRule.ROHITKARELIA;
 
 import static java.lang.String.format;
@@ -18,6 +19,7 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.category.element.UnitTests;
 import io.harness.filesystem.FileIo;
 import io.harness.rule.Owner;
+import io.harness.terraform.beans.TerraformVersion;
 
 import java.io.File;
 import java.io.IOException;
@@ -53,5 +55,16 @@ public class TerraformHelperUtilsTest extends CategoryTest {
     assertThat(tfFile).isNotNull();
     assertThat(tfFile.getName()).isEqualTo("terraform.tfstate");
     Files.deleteIfExists(Paths.get(tfFile.getPath()));
+  }
+
+  @Test
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testGetAutoApproveArgument() {
+    assertThat(TerraformHelperUtils.getAutoApproveArgument(TerraformVersion.create(0, 7, 3))).isEqualTo("-force");
+    assertThat(TerraformHelperUtils.getAutoApproveArgument(TerraformVersion.create(0, 15, 2)))
+        .isEqualTo("-auto-approve");
+    assertThat(TerraformHelperUtils.getAutoApproveArgument(TerraformVersion.create(1, 4, 1)))
+        .isEqualTo("-auto-approve");
   }
 }

--- a/970-api-services-beans/src/main/java/io/harness/terraform/beans/TerraformVersion.java
+++ b/970-api-services-beans/src/main/java/io/harness/terraform/beans/TerraformVersion.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.terraform.beans;
+
+import static io.harness.annotations.dev.HarnessTeam.CDP;
+
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+
+import io.harness.annotations.dev.OwnedBy;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@OwnedBy(CDP)
+public class TerraformVersion {
+  private static final Pattern TF_VERSION_REGEX = Pattern.compile("Terraform v(\\d+).(\\d+).(\\d+)", CASE_INSENSITIVE);
+
+  @Nullable Integer patch;
+  @Nullable Integer minor;
+  @Nullable Integer major;
+
+  public boolean minVersion(int major, int minor) {
+    int diff = this.major != null ? this.major - major : 0;
+    if (diff == 0) {
+      return this.minor == null || this.minor >= minor;
+    }
+
+    return diff > 0;
+  }
+
+  public static TerraformVersion create(String output) {
+    Matcher match = TF_VERSION_REGEX.matcher(output);
+    if (!match.find()) {
+      return createDefault();
+    }
+
+    return TerraformVersion.builder()
+        .major(Integer.valueOf(match.group(1)))
+        .minor(Integer.valueOf(match.group(2)))
+        .patch(Integer.valueOf(match.group(3)))
+        .build();
+  }
+
+  public static TerraformVersion create(int major, int minor, int patch) {
+    return TerraformVersion.builder().major(major).minor(minor).patch(patch).build();
+  }
+
+  public static TerraformVersion createDefault() {
+    return TerraformVersion.builder().build();
+  }
+}

--- a/970-api-services-beans/src/test/java/io/harness/terraform/beans/TerraformVersionTest.java
+++ b/970-api-services-beans/src/test/java/io/harness/terraform/beans/TerraformVersionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.terraform.beans;
+
+import static io.harness.annotations.dev.HarnessTeam.CDP;
+import static io.harness.rule.OwnerRule.ABOSII;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.harness.CategoryTest;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.rule.Owner;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@OwnedBy(CDP)
+public class TerraformVersionTest extends CategoryTest {
+  @Test
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testMinVersion0151() {
+    TerraformVersion version = TerraformVersion.create(0, 15, 1);
+
+    assertThat(version.minVersion(0, 7)).isTrue();
+    assertThat(version.minVersion(0, 15)).isTrue();
+    assertThat(version.minVersion(0, 16)).isFalse();
+    assertThat(version.minVersion(1, 1)).isFalse();
+  }
+
+  @Test
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testMinVersion111() {
+    TerraformVersion version = TerraformVersion.create(1, 1, 1);
+    assertThat(version.minVersion(0, 7)).isTrue();
+    assertThat(version.minVersion(0, 15)).isTrue();
+    assertThat(version.minVersion(1, 1)).isTrue();
+    assertThat(version.minVersion(1, 2)).isFalse();
+    assertThat(version.minVersion(2, 1)).isFalse();
+  }
+}


### PR DESCRIPTION

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30268)
<!-- Reviewable:end -->
