### PR TITLE
[fix]: [CDC-16552]: add AzureServiceException to Kryo

### DIFF
--- a/980-commons/src/main/java/io/harness/serializer/kryo/CommonsKryoRegistrar.java
+++ b/980-commons/src/main/java/io/harness/serializer/kryo/CommonsKryoRegistrar.java
@@ -15,6 +15,7 @@ import io.harness.exception.ArtifactServerException;
 import io.harness.exception.ArtifactoryServerException;
 import io.harness.exception.AuthenticationException;
 import io.harness.exception.AuthorizationException;
+import io.harness.exception.AzureServiceException;
 import io.harness.exception.ConnectException;
 import io.harness.exception.ContextException;
 import io.harness.exception.DelegateErrorHandlerException;
@@ -116,5 +117,6 @@ public class CommonsKryoRegistrar implements KryoRegistrar {
     kryo.register(GitOperationException.class, 980017);
     kryo.register(TerraformCommandExecutionException.class, 980018);
     kryo.register(SimpleEncryption.class, 980019);
+    kryo.register(AzureServiceException.class, 980020);
   }
 }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
