### PR TITLE
feat: [DEL-2767]: send delegate down alert properly

### DIFF
--- a/400-rest/src/main/java/software/wings/scheduler/AlertCheckJob.java
+++ b/400-rest/src/main/java/software/wings/scheduler/AlertCheckJob.java
@@ -129,7 +129,7 @@ public class AlertCheckJob implements Job {
       }
     }
     if (!isEmpty(delegates)
-        && !delegates.stream().allMatch(
+        && delegates.stream().anyMatch(
             delegate -> System.currentTimeMillis() - delegate.getLastHeartBeat() > MAX_HB_TIMEOUT)) {
       checkIfAnyDelegatesAreDown(accountId, delegates);
     }
@@ -162,6 +162,7 @@ public class AlertCheckJob implements Job {
       if (primaryConnections.contains(delegate.getUuid())) {
         alertService.closeAlert(accountId, GLOBAL_APP_ID, AlertType.DelegatesDown, alertData);
       } else {
+        // we currently dont have notification support in NG
         if (isEmpty(delegate.getDelegateGroupName())) {
           alertService.openAlert(accountId, GLOBAL_APP_ID, AlertType.DelegatesDown, alertData);
         }

--- a/400-rest/src/main/resources/notificationtemplates/notification_templates.yml
+++ b/400-rest/src/main/resources/notificationtemplates/notification_templates.yml
@@ -67,21 +67,13 @@ DELEGATE_STATE_NOTIFICATION:
       pagerDuty:
         summary: ${COUNT} ${ENTITY_AFFECTED} down with following ${DESCRIPTION_FIELD} ${HOST_NAMES}
 
-ALL_DELEGATE_DOWN_NOTIFICATION:
-      web: No Active Delegates for Account ${ACCOUNT_ID}
-      slack: No Active Delegates for Account ${ACCOUNT_ID}
-      email:
-          subject: No Active Delegates
-          body: All delegates are down. No Active Delegates for Account ${ACCOUNT_ID}
-      pagerDuty :
-        summary: No Active Delegates for Account ${ACCOUNT_ID}
 
 DELEGATE_DOWN_ALERT_NOTIFICATION:
     web: ${alert_message}
     slack: >
         *Harness Alert:* :small_red_triangle_down: ${alert_message}
     email:
-        subject: One of your Harness Delegates went down
+        subject: Delegate ?? is down
         body: ${alert_message}
     pagerDuty:
       summary: ${alert_message}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30343)
<!-- Reviewable:end -->
