### PR TITLE
fix: [DEL-2812]: Delegate/Watcher - Skip publishing stack driver logging based on config

### DIFF
--- a/260-delegate/src/main/java/io/harness/delegate/logging/DelegateStackdriverLogAppender.java
+++ b/260-delegate/src/main/java/io/harness/delegate/logging/DelegateStackdriverLogAppender.java
@@ -32,6 +32,7 @@ public class DelegateStackdriverLogAppender extends RemoteStackdriverLogAppender
   private static TimeLimiter timeLimiter;
   private static DelegateAgentManagerClient delegateAgentManagerClient;
   private static String delegateId;
+  private static boolean stopStackDriverLogging;
 
   @Getter @Setter private String accountId;
   @Getter @Setter private String managerHost;
@@ -44,6 +45,11 @@ public class DelegateStackdriverLogAppender extends RemoteStackdriverLogAppender
   @Override
   protected String getDelegateId() {
     return delegateId;
+  }
+
+  @Override
+  protected boolean isStopStackDriverLogging() {
+    return stopStackDriverLogging;
   }
 
   @Override
@@ -77,5 +83,10 @@ public class DelegateStackdriverLogAppender extends RemoteStackdriverLogAppender
 
   public static void setDelegateId(String delegateId) {
     DelegateStackdriverLogAppender.delegateId = delegateId;
+  }
+
+  public static void setStopStackDriverLogging() {
+    log.info("Delegate will stop publishing its logs to stack driver");
+    stopStackDriverLogging = true;
   }
 }

--- a/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
+++ b/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
@@ -457,8 +457,6 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
       log.info("Delegate will start running on JRE {}", System.getProperty(JAVA_VERSION));
       log.info("The deploy mode for delegate is [{}]", System.getenv().get("DEPLOY_MODE"));
       startTime = clock.millis();
-      DelegateStackdriverLogAppender.setTimeLimiter(timeLimiter);
-      DelegateStackdriverLogAppender.setManagerClient(delegateAgentManagerClient);
 
       logProxyConfiguration();
       if (delegateConfiguration.isVersionCheckDisabled()) {
@@ -578,7 +576,15 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
 
       delegateId = registerDelegate(builder);
       log.info("[New] Delegate registered in {} ms", clock.millis() - start);
-      DelegateStackdriverLogAppender.setDelegateId(delegateId);
+
+      if (delegateConfiguration.isStackDriverLoggingEnabeled()) {
+        DelegateStackdriverLogAppender.setTimeLimiter(timeLimiter);
+        DelegateStackdriverLogAppender.setManagerClient(delegateAgentManagerClient);
+        DelegateStackdriverLogAppender.setDelegateId(delegateId);
+      } else {
+        // Disable stack driver logging.
+        DelegateStackdriverLogAppender.setStopStackDriverLogging();
+      }
 
       if (isPollingForTasksEnabled()) {
         log.info("Polling is enabled for Delegate");

--- a/960-api-services/src/main/java/io/harness/delegate/configuration/DelegateConfiguration.java
+++ b/960-api-services/src/main/java/io/harness/delegate/configuration/DelegateConfiguration.java
@@ -52,6 +52,7 @@ public class DelegateConfiguration {
   private boolean grpcServiceEnabled;
   private Integer grpcServiceConnectorPort;
 
+  private boolean stackDriverLoggingEnabeled;
   private String logStreamingServiceBaseUrl;
   private boolean clientToolsDownloadDisabled;
   private boolean installClientToolsInBackground;

--- a/960-watcher/src/main/java/io/harness/watcher/app/WatcherConfiguration.java
+++ b/960-watcher/src/main/java/io/harness/watcher/app/WatcherConfiguration.java
@@ -27,4 +27,5 @@ public class WatcherConfiguration {
   private boolean fileHandlesMonitoringEnabled;
   private long fileHandlesMonitoringIntervalInMinutes;
   private long fileHandlesLogsRetentionInMinutes;
+  private boolean stackDriverLoggingEnabeled;
 }

--- a/960-watcher/src/main/java/io/harness/watcher/logging/WatcherStackdriverLogAppender.java
+++ b/960-watcher/src/main/java/io/harness/watcher/logging/WatcherStackdriverLogAppender.java
@@ -30,6 +30,7 @@ public class WatcherStackdriverLogAppender extends RemoteStackdriverLogAppender 
 
   private static TimeLimiter timeLimiter;
   private static ManagerClientV2 managerClient;
+  private static boolean stopStackDriverLogging;
 
   private String accountId = "";
   private String managerHost = "";
@@ -53,6 +54,11 @@ public class WatcherStackdriverLogAppender extends RemoteStackdriverLogAppender 
       managerHost = substringBefore(getConfiguration().getManagerUrl(), "/api/");
     }
     return managerHost;
+  }
+
+  @Override
+  protected boolean isStopStackDriverLogging() {
+    return stopStackDriverLogging;
   }
 
   @Override
@@ -87,5 +93,10 @@ public class WatcherStackdriverLogAppender extends RemoteStackdriverLogAppender 
 
   public static void setManagerClient(ManagerClientV2 managerClient) {
     WatcherStackdriverLogAppender.managerClient = managerClient;
+  }
+
+  public static void setStopStackDriverLogging() {
+    log.info("Watcher will stop publishing its logs to stack driver");
+    stopStackDriverLogging = true;
   }
 }

--- a/960-watcher/src/main/java/io/harness/watcher/service/WatcherServiceImpl.java
+++ b/960-watcher/src/main/java/io/harness/watcher/service/WatcherServiceImpl.java
@@ -82,6 +82,7 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.data.structure.UUIDGenerator;
 import io.harness.delegate.beans.DelegateConfiguration;
 import io.harness.delegate.beans.DelegateScripts;
+import io.harness.delegate.logging.DelegateStackdriverLogAppender;
 import io.harness.delegate.message.Message;
 import io.harness.delegate.message.MessageService;
 import io.harness.event.client.impl.tailer.ChronicleEventTailer;
@@ -226,8 +227,14 @@ public class WatcherServiceImpl implements WatcherService {
 
   @Override
   public void run(boolean upgrade) {
-    WatcherStackdriverLogAppender.setTimeLimiter(timeLimiter);
-    WatcherStackdriverLogAppender.setManagerClient(managerClient);
+    if (watcherConfiguration.isStackDriverLoggingEnabeled()) {
+      WatcherStackdriverLogAppender.setTimeLimiter(timeLimiter);
+      WatcherStackdriverLogAppender.setManagerClient(managerClient);
+    } else {
+      // Disable stack driver logging.
+      WatcherStackdriverLogAppender.setStopStackDriverLogging();
+    }
+
     log.info("Watcher will start running on JRE {}", watcherJreVersion);
 
     try {


### PR DESCRIPTION
…uration

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30376)
<!-- Reviewable:end -->
