### PR TITLE
feat: [COMP-3486]: add security step to lite engine

### DIFF
--- a/product/ci/addon/grpc/handler.go
+++ b/product/ci/addon/grpc/handler.go
@@ -32,6 +32,7 @@ var (
 	newRunTask          = tasks.NewRunTask
 	newRunTestsTask     = tasks.NewRunTestsTask
 	newPluginTask       = tasks.NewPluginTask
+	newSecurityTask		= tasks.NewSecurityTask
 )
 
 // NewAddonHandler returns a GRPC handler that implements pb.AddonServer
@@ -68,6 +69,15 @@ func (h *handler) ExecuteStep(ctx context.Context, in *pb.ExecuteStepRequest) (*
 	switch x := in.GetStep().GetStep().(type) {
 	case *enginepb.UnitStep_Run:
 		stepOutput, numRetries, err := newRunTask(in.GetStep(), in.GetPrevStepOutputs(), in.GetTmpFilePath(), rl.BaseLogger,
+			rl.Writer, false, h.log).Run(ctx)
+		response := &pb.ExecuteStepResponse{
+			Output:     stepOutput,
+			NumRetries: numRetries,
+		}
+		err = close(rl.Writer, err)
+		return response, err
+	case *enginepb.UnitStep_Security:
+		stepOutput, numRetries, err := newSecurityTask(in.GetStep(), in.GetPrevStepOutputs(), rl.BaseLogger,
 			rl.Writer, false, h.log).Run(ctx)
 		response := &pb.ExecuteStepResponse{
 			Output:     stepOutput,

--- a/product/ci/addon/grpc/handler.go
+++ b/product/ci/addon/grpc/handler.go
@@ -77,8 +77,8 @@ func (h *handler) ExecuteStep(ctx context.Context, in *pb.ExecuteStepRequest) (*
 		err = close(rl.Writer, err)
 		return response, err
 	case *enginepb.UnitStep_Security:
-		stepOutput, numRetries, err := newSecurityTask(in.GetStep(), in.GetPrevStepOutputs(), rl.BaseLogger,
-			rl.Writer, false, h.log).Run(ctx)
+		stepOutput, numRetries, err := newSecurityTask(in.GetStep(), in.GetPrevStepOutputs(),
+			in.GetTmpFilePath(), rl.BaseLogger, rl.Writer, false, h.log).Run(ctx)
 		response := &pb.ExecuteStepResponse{
 			Output:     stepOutput,
 			NumRetries: numRetries,

--- a/product/ci/addon/tasks/BUILD.bazel
+++ b/product/ci/addon/tasks/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "plugin.go",
         "run.go",
         "runtests.go",
+        "security.go",
         "ti_helper.go",
     ],
     importpath = "github.com/wings-software/portal/product/ci/addon/tasks",

--- a/product/ci/addon/tasks/BUILD.bazel
+++ b/product/ci/addon/tasks/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     srcs = [
         "plugin_test.go",
         "run_test.go",
+        "security_test.go",
         "runtests_test.go",
         "security_test.go",
     ],

--- a/product/ci/addon/tasks/BUILD.bazel
+++ b/product/ci/addon/tasks/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "plugin_test.go",
         "run_test.go",
         "runtests_test.go",
+        "security_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":tasks"],

--- a/product/ci/addon/tasks/BUILD.bazel
+++ b/product/ci/addon/tasks/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
     srcs = [
         "plugin_test.go",
         "run_test.go",
-        "security_test.go",
         "runtests_test.go",
         "security_test.go",
     ],

--- a/product/ci/addon/tasks/security.go
+++ b/product/ci/addon/tasks/security.go
@@ -1,0 +1,214 @@
+// Copyright 2021 Harness Inc. All rights reserved.
+// Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+// that can be found in the licenses directory at the root of this repository, also available at
+// https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/wings-software/portal/commons/go/lib/exec"
+	"github.com/wings-software/portal/commons/go/lib/images"
+	"github.com/wings-software/portal/commons/go/lib/utils"
+	"github.com/wings-software/portal/product/ci/addon/resolver"
+	pb "github.com/wings-software/portal/product/ci/engine/proto"
+	"go.uber.org/zap"
+)
+
+//go:generate mockgen -source security.go -package=tasks -destination mocks/security_mock.go SecurityTask
+
+const (
+	defaultSecurityTimeout    int64         = 14400 // 4 hour
+	defaultSecurityNumRetries int32         = 1
+	securityCmdExitWaitTime   time.Duration = time.Duration(0)
+	securityOutputPrefix	  string		= "SECURITY_"
+)
+
+// SecurityTask represents interface to execute a security step
+type SecurityTask interface {
+	Run(ctx context.Context) (map[string]string, int32, error)
+}
+
+type securityTask struct {
+	id                string
+	displayName       string
+	timeoutSecs       int64
+	numRetries        int32
+	image             string
+	entrypoint        []string
+	environment       map[string]string
+	envVarOutputs     []string
+	prevStepOutputs   map[string]*pb.StepOutput
+	logMetrics        bool
+	log               *zap.SugaredLogger
+	addonLogger       *zap.SugaredLogger
+	procWriter        io.Writer
+	cmdContextFactory exec.CmdContextFactory
+	artifactFilePath  string
+	reports           []*pb.Report
+}
+
+// NewSecurityTask creates a security step executor
+func NewSecurityTask(step *pb.UnitStep, prevStepOutputs map[string]*pb.StepOutput,
+	log *zap.SugaredLogger, w io.Writer, logMetrics bool, addonLogger *zap.SugaredLogger) SecurityTask {
+	r := step.GetSecurity()
+	timeoutSecs := r.GetContext().GetExecutionTimeoutSecs()
+	if timeoutSecs == 0 {
+		timeoutSecs = defaultSecurityTimeout
+	}
+
+	numRetries := r.GetContext().GetNumRetries()
+	if numRetries == 0 {
+		numRetries = defaultSecurityNumRetries
+	}
+	return &securityTask{
+		id:                step.GetId(),
+		displayName:       step.GetDisplayName(),
+		image:             r.GetImage(),
+		entrypoint:        r.GetEntrypoint(),
+		environment:       r.GetEnvironment(),
+		envVarOutputs:     r.GetEnvVarOutputs(),
+		reports:           r.GetReports(),
+		timeoutSecs:       timeoutSecs,
+		numRetries:        numRetries,
+		prevStepOutputs:   prevStepOutputs,
+		cmdContextFactory: exec.OsCommandContextGracefulWithLog(log),
+		logMetrics:        logMetrics,
+		log:               log,
+		procWriter:        w,
+		addonLogger:       addonLogger,
+		artifactFilePath:  r.GetArtifactFilePath(),
+	}
+}
+
+// Executes customer provided security with retries and timeout handling
+func (t *securityTask) Run(ctx context.Context) (map[string]string, int32, error) {
+	var err error
+	var o map[string]string
+	for i := int32(1); i <= t.numRetries; i++ {
+		if o, err = t.execute(ctx, i); err == nil {
+			st := time.Now()
+			err = collectTestReports(ctx, t.reports, t.id, t.log)
+			if err != nil {
+				// If there's an error in collecting reports, we won't retry but
+				// the step will be marked as an error
+				t.log.Errorw("unable to collect test reports", zap.Error(err))
+				return nil, t.numRetries, err
+			}
+			if len(t.reports) > 0 {
+				t.log.Infow(fmt.Sprintf("collected test reports in %s time", time.Since(st)))
+			}
+			return o, i, nil
+		}
+	}
+	if err != nil {
+		// Run step did not execute successfully
+		// Try and collect reports, ignore any errors during report collection itself
+		errc := collectTestReports(ctx, t.reports, t.id, t.log)
+		if errc != nil {
+			t.log.Errorw("error while collecting test reports", zap.Error(errc))
+		}
+		return nil, t.numRetries, err
+	}
+	return nil, t.numRetries, err
+}
+
+// resolveExprInEnv resolves JEXL expressions & env var present in security settings environment variables
+func (t *securityTask) resolveExprInEnv(ctx context.Context) (map[string]string, error) {
+	envVarMap := getEnvVars()
+	for k, v := range t.environment {
+		envVarMap[k] = v
+	}
+
+	// Resolves secret in environment variables e.g. foo-${ngSecretManager.obtain("secret", 1234)}
+	resolvedSecretMap, err := resolver.ResolveSecretInMapValues(envVarMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return resolvedSecretMap, nil
+}
+
+func (t *securityTask) execute(ctx context.Context, retryCount int32) (map[string]string, error) {
+	start := time.Now()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*time.Duration(t.timeoutSecs))
+	defer cancel()
+
+	commands, err := t.getEntrypoint(ctx)
+	if err != nil {
+		logSecurityErr(t.log, "failed to find entrypoint for security", t.id, commands, retryCount, start, err)
+		return nil, err
+	}
+
+	if len(commands) == 0 {
+		err := fmt.Errorf("security entrypoint is empty")
+		logSecurityErr(t.log, "entrypoint fetched from remote for security is empty", t.id, commands, retryCount, start, err)
+		return nil, err
+	}
+
+	envVarsMap, err := t.resolveExprInEnv(ctx)
+	if err != nil {
+		logSecurityErr(t.log, "failed to evaluate JEXL expression for settings", t.id, commands, retryCount, start, err)
+		return nil, err
+	}
+
+	cmd := t.cmdContextFactory.CmdContextWithSleep(ctx, securityCmdExitWaitTime, commands[0], commands[1:]...).
+		WithStdout(t.procWriter).WithStderr(t.procWriter).WithEnvVarsMap(envVarsMap)
+	err = runCmd(ctx, cmd, t.id, commands, retryCount, start, t.logMetrics, t.addonLogger)
+	if err != nil {
+		return nil, err
+	}
+
+	stepOutput := make(map[string]string)
+
+	envVarMap := getEnvVars()
+	for k, v := range envVarMap {
+		if strings.HasPrefix(k, securityOutputPrefix) {
+			stepOutput[strings.TrimPrefix(k, securityOutputPrefix)] = v
+		}
+	}
+
+	t.addonLogger.Infow(
+		"Successfully executed security",
+		"arguments", commands,
+		"output", stepOutput,
+		"elapsed_time_ms", utils.TimeSince(start),
+	)
+	return stepOutput, err
+}
+
+func (t *securityTask) getEntrypoint(ctx context.Context) ([]string, error) {
+	if len(t.entrypoint) != 0 {
+		return t.entrypoint, nil
+	}
+
+	imageSecret, _ := os.LookupEnv(imageSecretEnv)
+	return t.combinedEntrypoint(getImgMetadata(ctx, t.id, t.image, imageSecret, t.log))
+}
+
+func (t *securityTask) combinedEntrypoint(ep, cmds []string, err error) ([]string, error) {
+	if err != nil {
+		return nil, err
+	}
+	return images.CombinedEntrypoint(ep, cmds), nil
+}
+
+func (t *securityTask) readSecurityOutput() (map[string]string, error) {
+	return make(map[string]string), nil
+}
+
+func logSecurityErr(log *zap.SugaredLogger, errMsg, stepID string, cmds []string, retryCount int32, startTime time.Time, err error) {
+	log.Errorw(
+		errMsg,
+		"retry_count", retryCount,
+		"commands", cmds,
+		"elapsed_time_ms", utils.TimeSince(startTime),
+		zap.Error(err),
+	)
+}

--- a/product/ci/addon/tasks/security_test.go
+++ b/product/ci/addon/tasks/security_test.go
@@ -1,0 +1,181 @@
+// Copyright 2021 Harness Inc. All rights reserved.
+// Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+// that can be found in the licenses directory at the root of this repository, also available at
+// https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+
+package tasks
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"syscall"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	mexec "github.com/wings-software/portal/commons/go/lib/exec"
+	"github.com/wings-software/portal/commons/go/lib/logs"
+	pb "github.com/wings-software/portal/product/ci/engine/proto"
+	"go.uber.org/zap"
+)
+
+func TestSecuritySuccess(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+	defer ctrl.Finish()
+
+	var buf bytes.Buffer
+	numRetries := int32(1)
+	commands := []string{"git"}
+	cmdFactory := mexec.NewMockCmdContextFactory(ctrl)
+	cmd := mexec.NewMockCommand(ctrl)
+	pstate := mexec.NewMockProcessState(ctrl)
+	log, _ := logs.GetObservedLogger(zap.InfoLevel)
+	e := securityTask{
+		id:                "step1",
+		image:             "plugin/sto",
+		timeoutSecs:       5,
+		numRetries:        numRetries,
+		log:               log.Sugar(),
+		addonLogger:       log.Sugar(),
+		cmdContextFactory: cmdFactory,
+		procWriter:        &buf,
+	}
+
+	oldImgMetadata := getImgMetadata
+	getImgMetadata = func(ctx context.Context, id, image, secret string, log *zap.SugaredLogger) ([]string, []string, error) {
+		return commands, nil, nil
+	}
+	defer func() { getImgMetadata = oldImgMetadata }()
+
+	cmdFactory.EXPECT().CmdContextWithSleep(gomock.Any(), cmdExitWaitTime, gomock.Any()).Return(cmd)
+	cmd.EXPECT().WithStdout(&buf).Return(cmd)
+	cmd.EXPECT().WithStderr(&buf).Return(cmd)
+	cmd.EXPECT().WithEnvVarsMap(gomock.Any()).Return(cmd)
+	cmd.EXPECT().Start().Return(nil)
+	cmd.EXPECT().ProcessState().Return(pstate)
+	pstate.EXPECT().SysUsageUnit().Return(&syscall.Rusage{Maxrss: 100}, nil)
+	cmd.EXPECT().Wait().Return(nil)
+
+	_, retries, err := e.Run(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, retries, numRetries)
+}
+
+func TestSecurityNonZeroStatus(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+	defer ctrl.Finish()
+
+	numRetries := int32(1)
+	var buf bytes.Buffer
+	commands := []string{"git"}
+	cmdFactory := mexec.NewMockCmdContextFactory(ctrl)
+	cmd := mexec.NewMockCommand(ctrl)
+	pstate := mexec.NewMockProcessState(ctrl)
+	log, _ := logs.GetObservedLogger(zap.InfoLevel)
+	e := securityTask{
+		id:                "step1",
+		image:             "plugin/sto",
+		timeoutSecs:       5,
+		numRetries:        numRetries,
+		log:               log.Sugar(),
+		addonLogger:       log.Sugar(),
+		cmdContextFactory: cmdFactory,
+		procWriter:        &buf,
+	}
+
+	oldImgMetadata := getImgMetadata
+	getImgMetadata = func(ctx context.Context, id, image, secret string, log *zap.SugaredLogger) ([]string, []string, error) {
+		return commands, nil, nil
+	}
+	defer func() { getImgMetadata = oldImgMetadata }()
+
+	cmdFactory.EXPECT().CmdContextWithSleep(gomock.Any(), cmdExitWaitTime, gomock.Any()).Return(cmd)
+	cmd.EXPECT().WithStdout(&buf).Return(cmd)
+	cmd.EXPECT().WithStderr(&buf).Return(cmd)
+	cmd.EXPECT().WithEnvVarsMap(gomock.Any()).Return(cmd)
+	cmd.EXPECT().Start().Return(nil)
+	cmd.EXPECT().ProcessState().Return(pstate)
+	pstate.EXPECT().SysUsageUnit().Return(&syscall.Rusage{Maxrss: 100}, nil)
+	cmd.EXPECT().Wait().Return(&exec.ExitError{})
+
+	_, retries, err := e.Run(ctx)
+	assert.NotNil(t, err)
+	if _, ok := err.(*exec.ExitError); !ok {
+		t.Fatalf("Expected err of type exec.ExitError")
+	}
+	assert.Equal(t, retries, numRetries)
+}
+
+func TestSecurityTaskCreate(t *testing.T) {
+	tmpPath := "/tmp/"
+	log, _ := logs.GetObservedLogger(zap.InfoLevel)
+	step := &pb.UnitStep{
+		Id: "test",
+		Step: &pb.UnitStep_Security{
+			Security: &pb.SecurityStep{
+				Image: "plugin/sto",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	executor := NewSecurityTask(step, nil, tmpPath, log.Sugar(), &buf, false, log.Sugar())
+	assert.NotNil(t, executor)
+}
+
+func TestSecurityEntrypointErr(t *testing.T) {
+	tmpPath := "/tmp/"
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+	defer ctrl.Finish()
+
+	log, _ := logs.GetObservedLogger(zap.InfoLevel)
+	step := &pb.UnitStep{
+		Id: "test",
+		Step: &pb.UnitStep_Security{
+			Security: &pb.SecurityStep{
+				Image: "plugin/sto",
+			},
+		},
+	}
+
+	oldImgMetadata := getImgMetadata
+	getImgMetadata = func(ctx context.Context, id, image, secret string, log *zap.SugaredLogger) ([]string, []string, error) {
+		return nil, nil, fmt.Errorf("entrypoint not found")
+	}
+	defer func() { getImgMetadata = oldImgMetadata }()
+
+	var buf bytes.Buffer
+
+	executor := NewSecurityTask(step, nil, tmpPath, log.Sugar(), &buf, false, log.Sugar())
+	_, _, err := executor.Run(ctx)
+	assert.NotNil(t, err)
+}
+
+func TestSecurityEmptyEntrypointErr(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+	defer ctrl.Finish()
+	tmpPath := "/tmp/"
+
+	log, _ := logs.GetObservedLogger(zap.InfoLevel)
+	step := &pb.UnitStep{
+		Id: "test",
+		Step: &pb.UnitStep_Security{
+			Security: &pb.SecurityStep{
+				Image: "plugin/sto",
+			},
+		},
+	}
+
+	oldImgMetadata := getImgMetadata
+	getImgMetadata = func(ctx context.Context, id, image, secret string, log *zap.SugaredLogger) ([]string, []string, error) {
+		return nil, nil, nil
+	}
+	defer func() { getImgMetadata = oldImgMetadata }()
+
+	var buf bytes.Buffer
+	executor := NewSecurityTask(step, nil, tmpPath, log.Sugar(), &buf, false, log.Sugar())
+	_, _, err := executor.Run(ctx)
+	assert.NotNil(t, err)
+}

--- a/product/ci/engine/legacy/steps/BUILD.bazel
+++ b/product/ci/engine/legacy/steps/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "run.go",
         "runtests.go",
         "save_cache.go",
+        "security.go",
     ],
     importpath = "github.com/wings-software/portal/product/ci/engine/legacy/steps",
     visibility = ["//visibility:public"],

--- a/product/ci/engine/legacy/steps/BUILD.bazel
+++ b/product/ci/engine/legacy/steps/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
         "publish_artifacts_test.go",
         "restore_cache_test.go",
         "run_test.go",
+        "security_test.go",
         "save_cache_test.go",
         "security_test.go",
     ],

--- a/product/ci/engine/legacy/steps/BUILD.bazel
+++ b/product/ci/engine/legacy/steps/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
         "restore_cache_test.go",
         "run_test.go",
         "save_cache_test.go",
+        "security_test.go",
     ],
     embed = [":steps"],
     deps = [

--- a/product/ci/engine/legacy/steps/BUILD.bazel
+++ b/product/ci/engine/legacy/steps/BUILD.bazel
@@ -44,7 +44,6 @@ go_test(
         "publish_artifacts_test.go",
         "restore_cache_test.go",
         "run_test.go",
-        "security_test.go",
         "save_cache_test.go",
         "security_test.go",
     ],

--- a/product/ci/engine/legacy/steps/security.go
+++ b/product/ci/engine/legacy/steps/security.go
@@ -1,0 +1,107 @@
+// Copyright 2021 Harness Inc. All rights reserved.
+// Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+// that can be found in the licenses directory at the root of this repository, also available at
+// https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+
+package steps
+
+import (
+	"context"
+	"time"
+
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
+	"github.com/pkg/errors"
+	"github.com/wings-software/portal/commons/go/lib/utils"
+	addonpb "github.com/wings-software/portal/product/ci/addon/proto"
+	"github.com/wings-software/portal/product/ci/engine/output"
+	pb "github.com/wings-software/portal/product/ci/engine/proto"
+	"go.uber.org/zap"
+)
+
+// go:generate mockgen -source security.go -package=steps -destination mocks/security_mock.go SecurityStep
+
+// SecurityStep represents interface to execute a security step
+type SecurityStep interface {
+	Run(ctx context.Context) (*output.StepOutput, int32, error)
+}
+
+type securityStep struct {
+	id            string
+	image         string
+	step          *pb.UnitStep
+	containerPort uint32
+	stageOutput   output.StageOutput
+	log           *zap.SugaredLogger
+}
+
+// NewSecurityStep creates a security step executor
+func NewSecurityStep(step *pb.UnitStep, stageOutput output.StageOutput,
+	log *zap.SugaredLogger) SecurityStep {
+	r := step.GetSecurity()
+	return &securityStep{
+		id:            step.GetId(),
+		image:         r.GetImage(),
+		step:          step,
+		containerPort: r.GetContainerPort(),
+		stageOutput:   stageOutput,
+		log:           log,
+	}
+}
+
+// Executes customer provided security step
+func (e *securityStep) Run(ctx context.Context) (*output.StepOutput, int32, error) {
+	if err := e.validate(); err != nil {
+		e.log.Errorw("failed to validate security step", "step_id", e.id, zap.Error(err))
+		return nil, int32(1), err
+	}
+	return e.execute(ctx)
+}
+
+func (e *securityStep) validate() error {
+	if e.image == "" {
+		err := errors.New("security image is not set")
+		return err
+	}
+	if e.containerPort == 0 {
+		err := errors.New("security step container port is not set")
+		return err
+	}
+	return nil
+}
+
+func (e *securityStep) execute(ctx context.Context) (*output.StepOutput, int32, error) {
+	st := time.Now()
+
+	addonClient, err := newAddonClient(uint(e.containerPort), e.log)
+	if err != nil {
+		e.log.Errorw("Unable to create CI addon client", "step_id", e.id, "elapsed_time_ms", utils.TimeSince(st), zap.Error(err))
+		return nil, int32(1), errors.Wrap(err, "Could not create CI Addon client")
+	}
+	defer addonClient.CloseConn()
+
+	c := addonClient.Client()
+	arg := e.getExecuteStepArg()
+	ret, err := c.ExecuteStep(ctx, arg, grpc_retry.WithMax(maxAddonRetries))
+	if err != nil {
+		e.log.Errorw("Security step RPC failed", "step_id", e.id, "elapsed_time_ms", utils.TimeSince(st), zap.Error(err))
+		return nil, int32(1), err
+	}
+	e.log.Infow("Successfully executed step", "step_id", e.id, "elapsed_time_ms", utils.TimeSince(st))
+	stepOutput := &output.StepOutput{}
+	stepOutput.Output.Variables = ret.GetOutput()
+	return stepOutput, ret.GetNumRetries(), nil
+}
+
+func (e *securityStep) getExecuteStepArg() *addonpb.ExecuteStepRequest {
+	prevStepOutputs := make(map[string]*pb.StepOutput)
+	for stepID, stepOutput := range e.stageOutput {
+		if stepOutput != nil {
+			prevStepOutputs[stepID] = &pb.StepOutput{Output: stepOutput.Output.Variables}
+		}
+	}
+
+	return &addonpb.ExecuteStepRequest{
+		Step:            e.step,
+		PrevStepOutputs: prevStepOutputs,
+	}
+}

--- a/product/ci/engine/legacy/steps/security_test.go
+++ b/product/ci/engine/legacy/steps/security_test.go
@@ -1,0 +1,157 @@
+// Copyright 2021 Harness Inc. All rights reserved.
+// Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+// that can be found in the licenses directory at the root of this repository, also available at
+// https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+
+package steps
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/wings-software/portal/commons/go/lib/logs"
+	caddon "github.com/wings-software/portal/product/ci/addon/grpc/client"
+	amgrpc "github.com/wings-software/portal/product/ci/addon/grpc/client/mocks"
+	addonpb "github.com/wings-software/portal/product/ci/addon/proto"
+	"github.com/wings-software/portal/product/ci/engine/output"
+	pb "github.com/wings-software/portal/product/ci/engine/proto"
+	"go.uber.org/zap"
+)
+
+func TestSecurityStepValidate(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+	defer ctrl.Finish()
+
+	log, _ := logs.GetObservedLogger(zap.InfoLevel)
+	e := securityStep{
+		log: log.Sugar(),
+	}
+	_, _, err := e.Run(ctx)
+	assert.NotNil(t, err)
+
+	e = securityStep{
+		image: "plugin/sto",
+		log:   log.Sugar(),
+	}
+	_, _, err = e.Run(ctx)
+	assert.NotNil(t, err)
+
+	e = securityStep{
+		image:         "plugin/sto",
+		containerPort: uint32(8000),
+		log:           log.Sugar(),
+	}
+	err = e.validate()
+	assert.Nil(t, err)
+}
+
+// Client creation failing
+func TestSecurityExecuteClientErr(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+	defer ctrl.Finish()
+
+	port := uint32(8000)
+	log, _ := logs.GetObservedLogger(zap.InfoLevel)
+	step := &pb.UnitStep{
+		Id: "test",
+		Step: &pb.UnitStep_Security{
+			Security: &pb.SecurityStep{
+				Image:         "plugin/sto",
+				ContainerPort: port,
+			},
+		},
+	}
+
+	oldClient := newAddonClient
+	defer func() { newAddonClient = oldClient }()
+	newAddonClient = func(port uint, log *zap.SugaredLogger) (caddon.AddonClient, error) {
+		return nil, errors.New("client create error")
+	}
+
+	executor := NewSecurityStep(step, nil, log.Sugar())
+	_, numRetries, err := executor.Run(ctx)
+	assert.NotNil(t, err)
+	assert.Equal(t, numRetries, int32(1))
+}
+
+// Failed to send GRPC request
+func TestSecurityExecuteServerErr(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+	defer ctrl.Finish()
+
+	port := uint32(8000)
+	log, _ := logs.GetObservedLogger(zap.InfoLevel)
+	step := &pb.UnitStep{
+		Id: "test",
+		Step: &pb.UnitStep_Security{
+			Security: &pb.SecurityStep{
+				Image:         "plugin/sto",
+				ContainerPort: port,
+			},
+		},
+	}
+
+	c := &mockClient{
+		response: nil,
+		err:      errors.New("server not running"),
+	}
+	mClient := amgrpc.NewMockAddonClient(ctrl)
+	mClient.EXPECT().CloseConn().Return(nil)
+	mClient.EXPECT().Client().Return(c)
+
+	oldClient := newAddonClient
+	defer func() { newAddonClient = oldClient }()
+	newAddonClient = func(port uint, log *zap.SugaredLogger) (caddon.AddonClient, error) {
+		return mClient, nil
+	}
+
+	executor := NewSecurityStep(step, nil, log.Sugar())
+	_, numRetries, err := executor.Run(ctx)
+	assert.NotNil(t, err)
+	assert.Equal(t, numRetries, int32(1))
+}
+
+// Success
+func TestSecurityExecuteSuccess(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+	defer ctrl.Finish()
+
+	port := uint32(8000)
+	so := make(map[string]*output.StepOutput)
+	so["step1"] = &output.StepOutput{}
+	log, _ := logs.GetObservedLogger(zap.InfoLevel)
+	step := &pb.UnitStep{
+		Id: "test",
+		Step: &pb.UnitStep_Security{
+			Security: &pb.SecurityStep{
+				Image:         "plugin/sto",
+				ContainerPort: port,
+			},
+		},
+	}
+
+	numRetries := int32(3)
+	c := &mockClient{
+		response: &addonpb.ExecuteStepResponse{
+			NumRetries: numRetries,
+		},
+		err: nil,
+	}
+	mClient := amgrpc.NewMockAddonClient(ctrl)
+	mClient.EXPECT().CloseConn().Return(nil)
+	mClient.EXPECT().Client().Return(c)
+
+	oldClient := newAddonClient
+	defer func() { newAddonClient = oldClient }()
+	newAddonClient = func(port uint, log *zap.SugaredLogger) (caddon.AddonClient, error) {
+		return mClient, nil
+	}
+
+	executor := NewSecurityStep(step, so, log.Sugar())
+	_, n, err := executor.Run(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, n, numRetries)
+}

--- a/product/ci/engine/proto/execution.proto
+++ b/product/ci/engine/proto/execution.proto
@@ -77,6 +77,19 @@ message PluginStep {
   repeated Report reports = 7;
 }
 
+message SecurityStep {
+  string image = 1;
+  StepContext context = 2;
+  // Deprecated. Port of the container on which plugin step needs to be executed
+  uint32 container_port = 3;
+  // Optional. Entrypoint for plugin step. If empty, it calls docker registry to retrieve the entrypoint
+  repeated string entrypoint = 4;
+  map<string, string> environment = 5;
+  string artifact_file_path = 6;  // file path to store generated artifact file
+  repeated Report reports = 7;
+  repeated string env_var_outputs = 8;  // output variables to export as step outcome
+}
+
 message SaveCacheStep {
   string key = 1;
   repeated string paths = 2;
@@ -97,6 +110,7 @@ message UnitStep {
     PublishArtifactsStep publish_artifacts = 6;
     PluginStep plugin = 9;
     RunTestsStep runTests = 10;
+    SecurityStep security = 15;
   }
   string callback_token = 7;
   string task_id = 8;


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30392)
<!-- Reviewable:end -->
