### PR TITLE
fix: [PIE-2531]: Delete setup usage if no setup usage are there

### DIFF
--- a/800-pipeline-service/src/main/java/io/harness/pms/events/PipelineDeleteEvent.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/events/PipelineDeleteEvent.java
@@ -32,12 +32,23 @@ public class PipelineDeleteEvent implements Event {
   private String accountIdentifier;
   private String projectIdentifier;
   private PipelineEntity pipeline;
+  private boolean isFromGit;
+
   public PipelineDeleteEvent(
       String accountIdentifier, String orgIdentifier, String projectIdentifier, PipelineEntity pipeline) {
     this.accountIdentifier = accountIdentifier;
     this.orgIdentifier = orgIdentifier;
     this.projectIdentifier = projectIdentifier;
     this.pipeline = pipeline;
+  }
+
+  public PipelineDeleteEvent(String accountIdentifier, String orgIdentifier, String projectIdentifier,
+      PipelineEntity pipeline, boolean isFromGit) {
+    this.accountIdentifier = accountIdentifier;
+    this.orgIdentifier = orgIdentifier;
+    this.projectIdentifier = projectIdentifier;
+    this.pipeline = pipeline;
+    this.isFromGit = isFromGit;
   }
 
   @JsonIgnore

--- a/800-pipeline-service/src/main/java/io/harness/pms/events/PipelineDeleteEvent.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/events/PipelineDeleteEvent.java
@@ -32,7 +32,7 @@ public class PipelineDeleteEvent implements Event {
   private String accountIdentifier;
   private String projectIdentifier;
   private PipelineEntity pipeline;
-  private boolean isFromGit;
+  private Boolean isFromGit;
 
   public PipelineDeleteEvent(
       String accountIdentifier, String orgIdentifier, String projectIdentifier, PipelineEntity pipeline) {
@@ -40,6 +40,7 @@ public class PipelineDeleteEvent implements Event {
     this.orgIdentifier = orgIdentifier;
     this.projectIdentifier = projectIdentifier;
     this.pipeline = pipeline;
+    this.isFromGit = false;
   }
 
   public PipelineDeleteEvent(String accountIdentifier, String orgIdentifier, String projectIdentifier,
@@ -67,6 +68,13 @@ public class PipelineDeleteEvent implements Event {
         .type(ResourceTypeConstants.PIPELINE)
         .labels(labels)
         .build();
+  }
+
+  public boolean getIsFromGit() {
+    if (isFromGit == null) {
+      return false;
+    }
+    return isFromGit;
   }
 
   @JsonIgnore

--- a/800-pipeline-service/src/main/java/io/harness/pms/outbox/PipelineOutboxEventHandler.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/outbox/PipelineOutboxEventHandler.java
@@ -49,7 +49,6 @@ public class PipelineOutboxEventHandler implements OutboxEventHandler {
   private final InputSetEventHandler inputSetEventHandler;
 
   @Getter private final Subject<PipelineActionObserver> pipelineActionObserverSubject = new Subject<>();
-  ;
 
   @Inject
   PipelineOutboxEventHandler(AuditClientService auditClientService, InputSetEventHandler inputSetEventHandler) {
@@ -106,6 +105,17 @@ public class PipelineOutboxEventHandler implements OutboxEventHandler {
   private boolean handlePipelineDeleteEvent(OutboxEvent outboxEvent) throws IOException {
     GlobalContext globalContext = outboxEvent.getGlobalContext();
     PipelineDeleteEvent event = objectMapper.readValue(outboxEvent.getEventData(), PipelineDeleteEvent.class);
+
+    Principal principal = null;
+    if (globalContext.get(PRINCIPAL_CONTEXT) == null) {
+      principal = new ServicePrincipal(PIPELINE_SERVICE.getServiceId());
+    } else if (globalContext.get(PRINCIPAL_CONTEXT) != null) {
+      principal = ((PrincipalContextData) globalContext.get(PRINCIPAL_CONTEXT)).getPrincipal();
+    }
+    pipelineActionObserverSubject.fireInform(PipelineActionObserver::onDelete, event);
+    if (event.isFromGit()) {
+      return true;
+    }
     AuditEntry auditEntry = AuditEntry.builder()
                                 .action(Action.DELETE)
                                 .module(ModuleType.CORE)
@@ -115,13 +125,6 @@ public class PipelineOutboxEventHandler implements OutboxEventHandler {
                                 .resourceScope(ResourceScopeDTO.fromResourceScope(outboxEvent.getResourceScope()))
                                 .insertId(outboxEvent.getId())
                                 .build();
-    Principal principal = null;
-    if (globalContext.get(PRINCIPAL_CONTEXT) == null) {
-      principal = new ServicePrincipal(PIPELINE_SERVICE.getServiceId());
-    } else if (globalContext.get(PRINCIPAL_CONTEXT) != null) {
-      principal = ((PrincipalContextData) globalContext.get(PRINCIPAL_CONTEXT)).getPrincipal();
-    }
-    pipelineActionObserverSubject.fireInform(PipelineActionObserver::onDelete, event);
     return auditClientService.publishAudit(auditEntry, fromSecurityPrincipal(principal), globalContext);
   }
 

--- a/800-pipeline-service/src/main/java/io/harness/pms/outbox/PipelineOutboxEventHandler.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/outbox/PipelineOutboxEventHandler.java
@@ -113,7 +113,7 @@ public class PipelineOutboxEventHandler implements OutboxEventHandler {
       principal = ((PrincipalContextData) globalContext.get(PRINCIPAL_CONTEXT)).getPrincipal();
     }
     pipelineActionObserverSubject.fireInform(PipelineActionObserver::onDelete, event);
-    if (event.isFromGit()) {
+    if (event.getIsFromGit()) {
       return true;
     }
     AuditEntry auditEntry = AuditEntry.builder()

--- a/800-pipeline-service/src/main/java/io/harness/pms/pipeline/PipelineSetupUsageHelper.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/pipeline/PipelineSetupUsageHelper.java
@@ -117,6 +117,7 @@ public class PipelineSetupUsageHelper implements PipelineActionObserver {
 
   public void publishSetupUsageEvent(PipelineEntity pipelineEntity, List<EntityDetailProtoDTO> referredEntities) {
     if (EmptyPredicate.isEmpty(referredEntities)) {
+      deleteSetupUsagesForGivenPipeline(pipelineEntity);
       return;
     }
     EntityDetailProtoDTO pipelineDetails =

--- a/800-pipeline-service/src/main/java/io/harness/repositories/pipeline/PMSPipelineRepositoryCustomImpl.java
+++ b/800-pipeline-service/src/main/java/io/harness/repositories/pipeline/PMSPipelineRepositoryCustomImpl.java
@@ -183,8 +183,14 @@ public class PMSPipelineRepositoryCustomImpl implements PMSPipelineRepositoryCus
       Supplier<OutboxEvent> supplier = ()
           -> outboxService.save(new PipelineDeleteEvent(pipelineToUpdate.getAccountIdentifier(),
               pipelineToUpdate.getOrgIdentifier(), pipelineToUpdate.getProjectIdentifier(), pipelineToUpdate));
-      return gitAwarePersistence.save(
+      PipelineEntity pipelineEntity = gitAwarePersistence.save(
           pipelineToUpdate, pipelineToUpdate.getYaml(), ChangeType.DELETE, PipelineEntity.class, supplier);
+      if (pipelineEntity.getDeleted()
+          && gitSyncSdkService.isGitSyncEnabled(pipelineToUpdate.getAccountIdentifier(),
+              pipelineToUpdate.getOrgIdentifier(), pipelineToUpdate.getProjectIdentifier())) {
+        outboxService.save(new PipelineDeleteEvent(pipelineToUpdate.getAccountIdentifier(),
+            pipelineToUpdate.getOrgIdentifier(), pipelineToUpdate.getProjectIdentifier(), pipelineToUpdate, true));
+      }
     }
     throw new InvalidRequestException("No such pipeline exists");
   }

--- a/800-pipeline-service/src/main/java/io/harness/repositories/pipeline/PMSPipelineRepositoryCustomImpl.java
+++ b/800-pipeline-service/src/main/java/io/harness/repositories/pipeline/PMSPipelineRepositoryCustomImpl.java
@@ -191,6 +191,7 @@ public class PMSPipelineRepositoryCustomImpl implements PMSPipelineRepositoryCus
         outboxService.save(new PipelineDeleteEvent(pipelineToUpdate.getAccountIdentifier(),
             pipelineToUpdate.getOrgIdentifier(), pipelineToUpdate.getProjectIdentifier(), pipelineToUpdate, true));
       }
+      return pipelineEntity;
     }
     throw new InvalidRequestException("No such pipeline exists");
   }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30482)
<!-- Reviewable:end -->
