### PR TITLE
feat: [COMP-3486]: Propagate step output even if step fails

### DIFF
--- a/product/ci/addon/tasks/plugin.go
+++ b/product/ci/addon/tasks/plugin.go
@@ -115,7 +115,7 @@ func (t *pluginTask) Run(ctx context.Context) (map[string]string, *pb.Artifact, 
 				// If there's an error in collecting reports, we won't retry but
 				// the step will be marked as an error
 				t.log.Errorw("unable to collect test reports", zap.Error(err))
-				return nil, nil, t.numRetries, err
+				return so, nil, t.numRetries, err
 			}
 			if len(t.reports) > 0 {
 				t.log.Infow(fmt.Sprintf("collected test reports in %s time", time.Since(st)))
@@ -130,9 +130,9 @@ func (t *pluginTask) Run(ctx context.Context) (map[string]string, *pb.Artifact, 
 		if errc != nil {
 			t.log.Errorw("error while collecting test reports", zap.Error(errc))
 		}
-		return nil, nil, t.numRetries, err
+		return so, nil, t.numRetries, err
 	}
-	return nil, nil, t.numRetries, err
+	return so, nil, t.numRetries, err
 }
 
 // resolveExprInEnv resolves JEXL expressions & env var present in plugin settings environment variables


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30538)
<!-- Reviewable:end -->
