### PR TITLE
fix: [CVS-9049]: Error budget reset to reset HealthIndicator.

### DIFF
--- a/300-cv-nextgen/src/main/java/io/harness/cvng/servicelevelobjective/services/impl/SLOErrorBudgetResetServiceImpl.java
+++ b/300-cv-nextgen/src/main/java/io/harness/cvng/servicelevelobjective/services/impl/SLOErrorBudgetResetServiceImpl.java
@@ -13,6 +13,7 @@ import io.harness.cvng.servicelevelobjective.entities.SLOErrorBudgetReset;
 import io.harness.cvng.servicelevelobjective.entities.SLOErrorBudgetReset.SLOErrorBudgetResetKeys;
 import io.harness.cvng.servicelevelobjective.entities.ServiceLevelObjective;
 import io.harness.cvng.servicelevelobjective.services.api.SLOErrorBudgetResetService;
+import io.harness.cvng.servicelevelobjective.services.api.SLOHealthIndicatorService;
 import io.harness.cvng.servicelevelobjective.services.api.ServiceLevelObjectiveService;
 import io.harness.persistence.HPersistence;
 
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
 public class SLOErrorBudgetResetServiceImpl implements SLOErrorBudgetResetService {
   @Inject private HPersistence hPersistence;
   @Inject private ServiceLevelObjectiveService serviceLevelObjectiveService;
+  @Inject private SLOHealthIndicatorService sloHealthIndicatorService;
   @Inject private Clock clock;
 
   @Override
@@ -46,6 +48,7 @@ public class SLOErrorBudgetResetServiceImpl implements SLOErrorBudgetResetServic
             .getEndTime()
             .toInstant(ZoneOffset.UTC));
     hPersistence.save(sloErrorBudgetReset);
+    sloHealthIndicatorService.upsert(serviceLevelObjective);
     return dtoFromEntity(sloErrorBudgetReset);
   }
 


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30542)
<!-- Reviewable:end -->
