### PR TITLE
fix: [PL-22447]: set the securityPrincipal

### DIFF
--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/sdk/HarnessToGitPushInfoGrpcService.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/sdk/HarnessToGitPushInfoGrpcService.java
@@ -34,6 +34,7 @@ import io.harness.security.SourcePrincipalContextData;
 import io.harness.security.dto.UserPrincipal;
 import io.harness.serializer.KryoSerializer;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.grpc.stub.StreamObserver;
@@ -85,7 +86,8 @@ public class HarnessToGitPushInfoGrpcService extends HarnessToGitPushInfoService
     responseObserver.onCompleted();
   }
 
-  private void setPrincipal(FileInfo request) {
+  @VisibleForTesting
+  void setPrincipal(FileInfo request) {
     final io.harness.security.dto.Principal principal = getPrincipal(request);
     GlobalContextManager.upsertGlobalContextRecord(PrincipalContextData.builder().principal(principal).build());
     GlobalContextManager.upsertGlobalContextRecord(SourcePrincipalContextData.builder().principal(principal).build());

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/sdk/HarnessToGitPushInfoGrpcService.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/sdk/HarnessToGitPushInfoGrpcService.java
@@ -29,6 +29,7 @@ import io.harness.gitsync.common.service.HarnessToGitHelperService;
 import io.harness.logging.MdcContextSetter;
 import io.harness.manage.GlobalContextManager;
 import io.harness.ng.core.entitydetail.EntityDetailProtoToRestMapper;
+import io.harness.security.PrincipalContextData;
 import io.harness.security.SourcePrincipalContextData;
 import io.harness.security.dto.UserPrincipal;
 import io.harness.serializer.KryoSerializer;
@@ -86,6 +87,7 @@ public class HarnessToGitPushInfoGrpcService extends HarnessToGitPushInfoService
 
   private void setPrincipal(FileInfo request) {
     final io.harness.security.dto.Principal principal = getPrincipal(request);
+    GlobalContextManager.upsertGlobalContextRecord(PrincipalContextData.builder().principal(principal).build());
     GlobalContextManager.upsertGlobalContextRecord(SourcePrincipalContextData.builder().principal(principal).build());
   }
 

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/sdk/HarnessToGitPushInfoGrpcServiceTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/sdk/HarnessToGitPushInfoGrpcServiceTest.java
@@ -1,0 +1,62 @@
+package io.harness.gitsync.sdk;
+
+import static io.harness.annotations.dev.HarnessTeam.PL;
+import static io.harness.rule.OwnerRule.BHAVYA;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.gitsync.FileInfo;
+import io.harness.gitsync.GitSyncTestBase;
+import io.harness.gitsync.Principal;
+import io.harness.gitsync.UserPrincipal;
+import io.harness.manage.GlobalContextManager;
+import io.harness.rule.Owner;
+import io.harness.security.SecurityContextBuilder;
+import io.harness.security.SourcePrincipalContextBuilder;
+import io.harness.security.dto.PrincipalType;
+
+import com.google.inject.Inject;
+import com.google.protobuf.StringValue;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.MockitoAnnotations;
+
+@OwnedBy(PL)
+public class HarnessToGitPushInfoGrpcServiceTest extends GitSyncTestBase {
+  private final String accountId = "accountId";
+  private final String email = "email";
+  private final String userName = "userName";
+  private final String name = "name";
+  private FileInfo fileInfo;
+  @Inject HarnessToGitPushInfoGrpcService harnessToGitPushInfoGrpcService;
+
+  @Before
+  public void setup() throws Exception {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  @Owner(developers = BHAVYA)
+  @Category(UnitTests.class)
+  public void testSetPrincipal() {
+    UserPrincipal userPrincipal = UserPrincipal.newBuilder()
+                                      .setUserId(StringValue.of(name))
+                                      .setUserName(StringValue.of(userName))
+                                      .setEmail(StringValue.of(email))
+                                      .build();
+    Principal principal = Principal.newBuilder().setUserPrincipal(userPrincipal).build();
+    FileInfo fileInfo = buildFileInfo(principal);
+    GlobalContextManager.GlobalContextGuard guard = GlobalContextManager.ensureGlobalContextGuard();
+    harnessToGitPushInfoGrpcService.setPrincipal(fileInfo);
+    assertThat(SecurityContextBuilder.getPrincipal().getType()).isEqualTo(PrincipalType.USER);
+    assertThat(SourcePrincipalContextBuilder.getSourcePrincipal().getName()).isEqualTo(name);
+  }
+
+  private FileInfo buildFileInfo(Principal principal) {
+    fileInfo = FileInfo.newBuilder().setAccountId(accountId).setPrincipal(principal).build();
+    return fileInfo;
+  }
+}

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/sdk/HarnessToGitPushInfoGrpcServiceTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/sdk/HarnessToGitPushInfoGrpcServiceTest.java
@@ -49,10 +49,11 @@ public class HarnessToGitPushInfoGrpcServiceTest extends GitSyncTestBase {
                                       .build();
     Principal principal = Principal.newBuilder().setUserPrincipal(userPrincipal).build();
     FileInfo fileInfo = buildFileInfo(principal);
-    GlobalContextManager.GlobalContextGuard guard = GlobalContextManager.ensureGlobalContextGuard();
-    harnessToGitPushInfoGrpcService.setPrincipal(fileInfo);
-    assertThat(SecurityContextBuilder.getPrincipal().getType()).isEqualTo(PrincipalType.USER);
-    assertThat(SourcePrincipalContextBuilder.getSourcePrincipal().getName()).isEqualTo(name);
+    try (GlobalContextManager.GlobalContextGuard guard = GlobalContextManager.ensureGlobalContextGuard()) {
+      harnessToGitPushInfoGrpcService.setPrincipal(fileInfo);
+      assertThat(SecurityContextBuilder.getPrincipal().getType()).isEqualTo(PrincipalType.USER);
+      assertThat(SourcePrincipalContextBuilder.getSourcePrincipal().getName()).isEqualTo(name);
+    }
   }
 
   private FileInfo buildFileInfo(Principal principal) {


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30578)
<!-- Reviewable:end -->
