### PR TITLE
[fix]: [CDS-7642]: Adding command flag disable statefiles in chartmuseum com…

### DIFF
--- a/960-api-services/src/main/java/io/harness/chartmuseum/ChartMuseumClientHelper.java
+++ b/960-api-services/src/main/java/io/harness/chartmuseum/ChartMuseumClientHelper.java
@@ -8,7 +8,25 @@
 package io.harness.chartmuseum;
 
 import static io.harness.annotations.dev.HarnessTeam.CDP;
-import static io.harness.chartmuseum.ChartMuseumConstants.*;
+import static io.harness.chartmuseum.ChartMuseumConstants.AMAZON_S3_COMMAND_TEMPLATE;
+import static io.harness.chartmuseum.ChartMuseumConstants.AMAZON_S3_COMMAND_TEMPLATE_LATEST_CM_BIN;
+import static io.harness.chartmuseum.ChartMuseumConstants.AWS_ACCESS_KEY_ID;
+import static io.harness.chartmuseum.ChartMuseumConstants.AWS_SECRET_ACCESS_KEY;
+import static io.harness.chartmuseum.ChartMuseumConstants.BUCKET_REGION_ERROR_CODE;
+import static io.harness.chartmuseum.ChartMuseumConstants.CHART_MUSEUM_SERVER_START_RETRIES;
+import static io.harness.chartmuseum.ChartMuseumConstants.GCS_COMMAND_TEMPLATE;
+import static io.harness.chartmuseum.ChartMuseumConstants.GCS_COMMAND_TEMPLATE_LATEST_CM_BIN;
+import static io.harness.chartmuseum.ChartMuseumConstants.GOOGLE_APPLICATION_CREDENTIALS;
+import static io.harness.chartmuseum.ChartMuseumConstants.HEALTH_CHECK_TIME_GAP_SECONDS;
+import static io.harness.chartmuseum.ChartMuseumConstants.INVALID_ACCESS_KEY_ID_ERROR;
+import static io.harness.chartmuseum.ChartMuseumConstants.INVALID_ACCESS_KEY_ID_ERROR_CODE;
+import static io.harness.chartmuseum.ChartMuseumConstants.NO_SUCH_BBUCKET_ERROR;
+import static io.harness.chartmuseum.ChartMuseumConstants.NO_SUCH_BBUCKET_ERROR_CODE;
+import static io.harness.chartmuseum.ChartMuseumConstants.PORTS_BOUND;
+import static io.harness.chartmuseum.ChartMuseumConstants.PORTS_START_POINT;
+import static io.harness.chartmuseum.ChartMuseumConstants.SERVER_HEALTH_CHECK_RETRIES;
+import static io.harness.chartmuseum.ChartMuseumConstants.SIGNATURE_DOES_NOT_MATCH_ERROR;
+import static io.harness.chartmuseum.ChartMuseumConstants.SIGNATURE_DOES_NOT_MATCH_ERROR_CODE;
 import static io.harness.exception.ExceptionUtils.getMessage;
 import static io.harness.k8s.kubectl.Utils.encloseWithQuotesIfNeeded;
 import static io.harness.threading.Morpheus.sleep;

--- a/960-api-services/src/test/java/io/harness/chartmuseum/ChartMuseumClientHelperTest.java
+++ b/960-api-services/src/test/java/io/harness/chartmuseum/ChartMuseumClientHelperTest.java
@@ -163,7 +163,7 @@ public class ChartMuseumClientHelperTest extends CategoryTest {
   }
 
   @Test
-  @Owner(developers = ABOSII)
+  @Owner(developers = NAMAN_TALAYCHA)
   @Category(UnitTests.class)
   public void testStartGCSChartMuseumServerLatestChartMuseumBin() throws Exception {
     final String bucketName = "gcs-bucket";

--- a/970-api-services-beans/src/main/java/io/harness/chartmuseum/ChartMuseumConstants.java
+++ b/970-api-services-beans/src/main/java/io/harness/chartmuseum/ChartMuseumConstants.java
@@ -41,10 +41,10 @@ public class ChartMuseumConstants {
   public final String AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
 
   public final String AMAZON_S3_COMMAND_TEMPLATE =
-      " --port=${PORT} --storage=amazon --storage-amazon-bucket=${BUCKET_NAME} --storage-amazon-prefix=${FOLDER_PATH} --storage-amazon-region=${REGION}";
+      " --disable-statefiles --port=${PORT} --storage=amazon --storage-amazon-bucket=${BUCKET_NAME} --storage-amazon-prefix=${FOLDER_PATH} --storage-amazon-region=${REGION}";
 
   public final String GOOGLE_APPLICATION_CREDENTIALS = "GOOGLE_APPLICATION_CREDENTIALS";
 
   public final String GCS_COMMAND_TEMPLATE =
-      " --port=${PORT} --storage=google --storage-google-bucket=${BUCKET_NAME} --storage-google-prefix=${FOLDER_PATH}";
+      " --disable-statefiles --port=${PORT} --storage=google --storage-google-bucket=${BUCKET_NAME} --storage-google-prefix=${FOLDER_PATH}";
 }

--- a/970-api-services-beans/src/main/java/io/harness/chartmuseum/ChartMuseumConstants.java
+++ b/970-api-services-beans/src/main/java/io/harness/chartmuseum/ChartMuseumConstants.java
@@ -41,10 +41,16 @@ public class ChartMuseumConstants {
   public final String AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
 
   public final String AMAZON_S3_COMMAND_TEMPLATE =
+      " --port=${PORT} --storage=amazon --storage-amazon-bucket=${BUCKET_NAME} --storage-amazon-prefix=${FOLDER_PATH} --storage-amazon-region=${REGION}";
+
+  public final String AMAZON_S3_COMMAND_TEMPLATE_LATEST_CM_BIN =
       " --disable-statefiles --port=${PORT} --storage=amazon --storage-amazon-bucket=${BUCKET_NAME} --storage-amazon-prefix=${FOLDER_PATH} --storage-amazon-region=${REGION}";
 
   public final String GOOGLE_APPLICATION_CREDENTIALS = "GOOGLE_APPLICATION_CREDENTIALS";
 
   public final String GCS_COMMAND_TEMPLATE =
+      " --port=${PORT} --storage=google --storage-google-bucket=${BUCKET_NAME} --storage-google-prefix=${FOLDER_PATH}";
+
+  public final String GCS_COMMAND_TEMPLATE_LATEST_CM_BIN =
       " --disable-statefiles --port=${PORT} --storage=google --storage-google-bucket=${BUCKET_NAME} --storage-google-prefix=${FOLDER_PATH}";
 }


### PR DESCRIPTION
…mand

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30598)
<!-- Reviewable:end -->
