### PR TITLE
[fix]: [CVS-9071]: returning empty list in case of no monitored service

### DIFF
--- a/300-cv-nextgen/src/main/java/io/harness/cvng/core/services/impl/monitoredService/MonitoredServiceServiceImpl.java
+++ b/300-cv-nextgen/src/main/java/io/harness/cvng/core/services/impl/monitoredService/MonitoredServiceServiceImpl.java
@@ -483,8 +483,7 @@ public class MonitoredServiceServiceImpl implements MonitoredServiceService {
   public List<MonitoredServiceWithHealthSources> getAllWithTimeSeriesHealthSources(ProjectParams projectParams) {
     List<MonitoredService> monitoredServiceEntities = getMonitoredServices(projectParams);
     if (isEmpty(monitoredServiceEntities)) {
-      throw new InvalidRequestException(String.format(
-          "There are no Monitored Services for the given project: %s", projectParams.getProjectIdentifier()));
+      return Collections.emptyList();
     }
     Map<String, Set<HealthSource>> healthSourceMap = healthSourceService.getHealthSource(monitoredServiceEntities);
     return monitoredServiceEntities.stream()
@@ -1109,7 +1108,7 @@ public class MonitoredServiceServiceImpl implements MonitoredServiceService {
         healthSourceService.get(projectParams.getAccountIdentifier(), projectParams.getOrgIdentifier(),
             projectParams.getProjectIdentifier(), monitoredServiceIdentifier, Arrays.asList(healthSourceIdentifier));
     return healthSources.stream()
-        .map(healthSource -> healthSource.getSpec())
+        .map(HealthSource::getSpec)
         .filter(spec -> spec instanceof MetricHealthSourceSpec)
         .map(spec -> (MetricHealthSourceSpec) spec)
         .filter(spec -> isNotEmpty(spec.getMetricDefinitions()))

--- a/300-cv-nextgen/src/test/java/io/harness/cvng/core/services/impl/monitoredService/MonitoredServiceServiceImplTest.java
+++ b/300-cv-nextgen/src/test/java/io/harness/cvng/core/services/impl/monitoredService/MonitoredServiceServiceImplTest.java
@@ -1203,6 +1203,17 @@ public class MonitoredServiceServiceImplTest extends CvNextGenTestBase {
   }
 
   @Test
+  @Owner(developers = DEEPAK_CHHIKARA)
+  @Category(UnitTests.class)
+  public void testGetAll_noMonitoredService() {
+    String serviceRef1 = "service1";
+    String identifier1 = "monitoredService1";
+    List<MonitoredServiceWithHealthSources> monitoredServiceWithHealthSourcesList =
+        monitoredServiceService.getAllWithTimeSeriesHealthSources(projectParams);
+    assertThat(monitoredServiceWithHealthSourcesList).isEmpty();
+  }
+
+  @Test
   @Owner(developers = PRAVEEN)
   @Category(UnitTests.class)
   public void testCreate_withDependency() {


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30606)
<!-- Reviewable:end -->
