### PR TITLE
[fix]: [CVS-7927]: Pre-Validation when monitored service is created with empty params

### DIFF
--- a/300-cv-nextgen/src/main/java/io/harness/cvng/core/resources/MonitoredServiceResource.java
+++ b/300-cv-nextgen/src/main/java/io/harness/cvng/core/resources/MonitoredServiceResource.java
@@ -105,8 +105,8 @@ public class MonitoredServiceResource {
       @ApiParam(required = true) @NotNull @QueryParam("accountId") String accountId,
       @ApiParam(required = true) @NotNull @QueryParam("orgIdentifier") String orgIdentifier,
       @ApiParam(required = true) @NotNull @QueryParam("projectIdentifier") String projectIdentifier,
-      @ApiParam(required = true) @NotNull @QueryParam("environmentIdentifier") String environmentIdentifier,
-      @ApiParam(required = true) @NotNull @QueryParam("serviceIdentifier") String serviceIdentifier) {
+      @ApiParam(required = true) @NotEmpty @QueryParam("environmentIdentifier") String environmentIdentifier,
+      @ApiParam(required = true) @NotEmpty @QueryParam("serviceIdentifier") String serviceIdentifier) {
     ProjectParams projectParams = ProjectParams.builder()
                                       .accountIdentifier(accountId)
                                       .orgIdentifier(orgIdentifier)

--- a/300-cv-nextgen/src/test/java/io/harness/cvng/core/resources/MonitoredServiceResourceTest.java
+++ b/300-cv-nextgen/src/test/java/io/harness/cvng/core/resources/MonitoredServiceResourceTest.java
@@ -93,6 +93,52 @@ public class MonitoredServiceResourceTest extends CvNextGenTestBase {
   }
 
   @Test
+  @Owner(developers = DEEPAK_CHHIKARA)
+  @Category(UnitTests.class)
+  public void test_createDefaultFail() {
+    Response response = RESOURCES.client()
+                            .target("http://localhost:9998/monitored-service/create-default")
+                            .queryParam("accountId", builderFactory.getContext().getAccountId())
+                            .queryParam("projectIdentifier", "cvng_proj_fve79nRfOe")
+                            .queryParam("orgIdentifier", "cvng_org_gc5qeLWq1W")
+                            .queryParam("environmentIdentifier", "")
+                            .queryParam("serviceIdentifier", "")
+                            .request(MediaType.APPLICATION_JSON_TYPE)
+                            .post(Entity.json(null));
+    assertThat(response.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  @Owner(developers = DEEPAK_CHHIKARA)
+  @Category(UnitTests.class)
+  public void test_createDefaultFailWithNull() {
+    Response response = RESOURCES.client()
+                            .target("http://localhost:9998/monitored-service/create-default")
+                            .queryParam("accountId", builderFactory.getContext().getAccountId())
+                            .queryParam("projectIdentifier", "cvng_proj_fve79nRfOe")
+                            .queryParam("orgIdentifier", "cvng_org_gc5qeLWq1W")
+                            .request(MediaType.APPLICATION_JSON_TYPE)
+                            .post(Entity.json(null));
+    assertThat(response.getStatus()).isEqualTo(400);
+  }
+
+  @Test
+  @Owner(developers = DEEPAK_CHHIKARA)
+  @Category(UnitTests.class)
+  public void test_createDefault() {
+    Response response = RESOURCES.client()
+                            .target("http://localhost:9998/monitored-service/create-default")
+                            .queryParam("accountId", builderFactory.getContext().getAccountId())
+                            .queryParam("projectIdentifier", "cvng_proj_fve79nRfOe")
+                            .queryParam("orgIdentifier", "cvng_org_gc5qeLWq1W")
+                            .queryParam("environmentIdentifier", "environmentIdentifier")
+                            .queryParam("serviceIdentifier", "serviceIdentifier")
+                            .request(MediaType.APPLICATION_JSON_TYPE)
+                            .post(Entity.json(null));
+    assertThat(response.getStatus()).isEqualTo(200);
+  }
+
+  @Test
   @Owner(developers = KAMAL)
   @Category(UnitTests.class)
   public void testSaveMonitoredService_withMetricDefIdentifier() throws IOException {


### PR DESCRIPTION
…ty service

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30608)
<!-- Reviewable:end -->
