### PR TITLE
fix: [CCM-5504]: activeInstanceIterator update with StartEvent

### DIFF
--- a/280-batch-processing/src/main/java/io/harness/batch/processing/schedule/EventJobScheduler.java
+++ b/280-batch-processing/src/main/java/io/harness/batch/processing/schedule/EventJobScheduler.java
@@ -33,6 +33,7 @@ import io.harness.batch.processing.service.impl.InstanceDataServiceImpl;
 import io.harness.batch.processing.service.intfc.BillingDataPipelineHealthStatusService;
 import io.harness.batch.processing.shard.AccountShardService;
 import io.harness.batch.processing.tasklet.support.HarnessServiceInfoFetcher;
+import io.harness.batch.processing.tasklet.support.K8SWorkloadService;
 import io.harness.batch.processing.tasklet.support.K8sLabelServiceInfoFetcher;
 import io.harness.batch.processing.view.CEMetaDataRecordUpdateService;
 import io.harness.batch.processing.view.ViewCostUpdateService;
@@ -87,6 +88,7 @@ public class EventJobScheduler {
   @Autowired private CfClient cfClient;
   @Autowired private FeatureFlagService featureFlagService;
   @Autowired private ConnectorsHealthUpdateService connectorsHealthUpdateService;
+  @Autowired private K8SWorkloadService k8SWorkloadService;
 
   @PostConstruct
   public void orderJobs() {
@@ -300,6 +302,7 @@ public class EventJobScheduler {
     harnessServiceInfoFetcher.logCacheStats();
     instanceDataService.logCacheStats();
     k8sLabelServiceInfoFetcher.logCacheStats();
+    k8SWorkloadService.logCacheStats();
   }
 
   @Scheduled(cron = "0 0 6 * * ?")

--- a/280-batch-processing/src/main/java/io/harness/batch/processing/service/impl/InstanceDataBulkWriteServiceImpl.java
+++ b/280-batch-processing/src/main/java/io/harness/batch/processing/service/impl/InstanceDataBulkWriteServiceImpl.java
@@ -298,7 +298,10 @@ public class InstanceDataBulkWriteServiceImpl implements InstanceDataBulkWriteSe
       }
     }
     result = bulkWriteOperation.execute();
-    log.info("BulkWriteExecutor result: {}", result.toString());
+    log.info(
+        "BulkWriteExecutor result [acknowledged:{}, insertedCount:{}, matchedCount:{}, modifiedCount:{}, removedCount:{}]",
+        result.isAcknowledged(), result.getInsertedCount(), result.getMatchedCount(), result.getModifiedCount(),
+        result.getRemovedCount());
     return result;
   }
 }

--- a/280-batch-processing/src/main/java/io/harness/batch/processing/service/impl/InstanceDataBulkWriteServiceImpl.java
+++ b/280-batch-processing/src/main/java/io/harness/batch/processing/service/impl/InstanceDataBulkWriteServiceImpl.java
@@ -112,7 +112,9 @@ public class InstanceDataBulkWriteServiceImpl implements InstanceDataBulkWriteSe
 
           BasicDBObject updateOperations =
               new BasicDBObject(InstanceDataKeys.instanceState, InstanceState.RUNNING.name())
-                  .append(InstanceDataKeys.lastUpdatedAt, Instant.now().toEpochMilli());
+                  .append(InstanceDataKeys.lastUpdatedAt, Instant.now().toEpochMilli())
+                  .append(InstanceDataKeys.activeInstanceIterator,
+                      ActiveInstanceIterator.getActiveInstanceIteratorFromStartTime(instanceTime));
 
           bulkWriteOperation.find(filter).update(
               new BasicDBObject("$set", updateOperations)

--- a/280-batch-processing/src/main/java/io/harness/batch/processing/tasklet/support/K8SWorkloadService.java
+++ b/280-batch-processing/src/main/java/io/harness/batch/processing/tasklet/support/K8SWorkloadService.java
@@ -8,6 +8,7 @@
 package io.harness.batch.processing.tasklet.support;
 
 import io.harness.batch.processing.service.intfc.WorkloadRepository;
+import io.harness.batch.processing.tasklet.util.CacheUtils;
 import io.harness.ccm.commons.entities.k8s.K8sWorkload;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -25,7 +26,7 @@ import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-public class K8SWorkloadService {
+public class K8SWorkloadService extends CacheUtils {
   @Autowired private WorkloadRepository workloadRepository;
   private Cache<CacheKey, Map<String, String>> workloadLabelCache =
       Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build();

--- a/280-batch-processing/src/main/java/io/harness/batch/processing/tasklet/util/CacheUtils.java
+++ b/280-batch-processing/src/main/java/io/harness/batch/processing/tasklet/util/CacheUtils.java
@@ -9,7 +9,7 @@ package io.harness.batch.processing.tasklet.util;
 
 import io.harness.logging.AutoLogContext;
 
-import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Cache;
 import java.lang.reflect.Field;
 import lombok.extern.slf4j.Slf4j;
 
@@ -17,9 +17,9 @@ import lombok.extern.slf4j.Slf4j;
 public abstract class CacheUtils {
   public void logCacheStats() throws IllegalAccessException {
     for (Field field : this.getClass().getDeclaredFields()) {
-      if (LoadingCache.class.equals(field.getType())) {
+      if (Cache.class.isAssignableFrom(field.getType())) {
         field.setAccessible(true);
-        LoadingCache loadingCache = (LoadingCache) field.get(this);
+        Cache loadingCache = (Cache) field.get(this);
         try (AutoLogContext ignore1 = new LoadingCacheLogContext(field.getName(),
                  String.valueOf(loadingCache.estimatedSize()), AutoLogContext.OverrideBehavior.OVERRIDE_ERROR)) {
           log.info(loadingCache.stats().toString());


### PR DESCRIPTION
Please note that the `InstanceDataKeys.activeInstanceIterator` value is updated as `instanceSyncTime + 50yrs` and not `usageStartTime+50yrs`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30620)
<!-- Reviewable:end -->
