### PR TITLE
[PL-22462]: Add fetchCommitId call for a given file for bitbucket cloud during file create/update/delete call on SCM

### DIFF
--- a/product/ci/scm/file/file.go
+++ b/product/ci/scm/file/file.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/drone/go-scm/scm"
 	"github.com/wings-software/portal/commons/go/lib/utils"
+	git "github.com/wings-software/portal/product/ci/scm/git"
 	"github.com/wings-software/portal/product/ci/scm/gitclient"
 	pb "github.com/wings-software/portal/product/ci/scm/proto"
 	"go.uber.org/zap"
@@ -130,7 +131,8 @@ func DeleteFile(ctx context.Context, fileRequest *pb.DeleteFileRequest, log *zap
 		return out, nil
 	}
 	// go-scm doesnt provide CRUD content parsing lets do it our self
-	commitID, blobID := parseCrudResponse(response.Body, *fileRequest.GetProvider(), log)
+	
+	commitID, blobID := parseCrudResponse(ctx, client, response.Body, *fileRequest.GetProvider(), requestContext{Slug: fileRequest.Slug, Branch: fileRequest.Branch, FilePath: fileRequest.Path}, log)
 	log.Infow("DeleteFile success", "slug", fileRequest.GetSlug(), "path", fileRequest.GetPath(), "elapsed_time_ms", utils.TimeSince(start))
 	out = &pb.DeleteFileResponse{
 		Status:   int32(response.Status),
@@ -184,7 +186,7 @@ func UpdateFile(ctx context.Context, fileRequest *pb.FileModifyRequest, log *zap
 		return out, nil
 	}
 	// go-scm doesnt provide CRUD content parsing lets do it our self
-	commitID, blobID := parseCrudResponse(response.Body, *fileRequest.GetProvider(), log)
+	commitID, blobID := parseCrudResponse(ctx, client, response.Body, *fileRequest.GetProvider(), requestContext{Slug: fileRequest.Slug, Branch: fileRequest.Branch, FilePath: fileRequest.Path}, log)
 	log.Infow("UpdateFile success", "slug", fileRequest.GetSlug(), "path", fileRequest.GetPath(), "branch", fileRequest.GetBranch(), "sha", inputParams.Sha, "branch", inputParams.Branch,
 		"elapsed_time_ms", utils.TimeSince(start))
 	out = &pb.UpdateFileResponse{
@@ -288,7 +290,7 @@ func CreateFile(ctx context.Context, fileRequest *pb.FileModifyRequest, log *zap
 		return out, nil
 	}
 	// go-scm doesnt provide CRUD content parsing lets do it our self
-	commitID, blobID := parseCrudResponse(response.Body, *fileRequest.GetProvider(), log)
+	commitID, blobID := parseCrudResponse(ctx, client, response.Body, *fileRequest.GetProvider(), requestContext{Slug: fileRequest.Slug, Branch: fileRequest.Branch, FilePath: fileRequest.Path}, log)
 	log.Infow("CreateFile success", "slug", fileRequest.GetSlug(), "path", fileRequest.GetPath(), "branch", inputParams.Branch, "elapsed_time_ms", utils.TimeSince(start))
 	out = &pb.CreateFileResponse{
 		Status:   int32(response.Status),
@@ -384,7 +386,7 @@ func convertContent(from *scm.ContentInfo) *pb.FileChange {
 }
 
 // this function is best effort ie if we cannot find the commit id or blob id do not error.
-func parseCrudResponse(body io.Reader, p pb.Provider, log *zap.SugaredLogger) (commitID, blobID string) {
+func parseCrudResponse(ctx context.Context, client *scm.Client, body io.Reader, p pb.Provider, request requestContext, log *zap.SugaredLogger) (commitID, blobID string) {
 	bodyBytes, readErr := ioutil.ReadAll(body)
 	if readErr != nil {
 		log.Errorw("parseCrudResponse unable to read response from provider %p", gitclient.GetProvider(p), zap.Error(readErr))
@@ -409,7 +411,22 @@ func parseCrudResponse(body io.Reader, p pb.Provider, log *zap.SugaredLogger) (c
 			return "", ""
 		}
 		return out.Commit.Sha, out.Content.Sha
+	case *pb.Provider_BitbucketCloud:
+		// Bitbucket doesn't work on blobId concept for a file, thus it will  always be empty
+		// We try to find out the latest commit on the file, which is most-likely the commit done by SCM itself
+		// It works on best-effort basis
+		commit, err := git.GetLatestCommitOnFile(ctx, request.Slug, request.Branch, request.FilePath, log)
+		if err != nil {
+			return "", ""
+		}
+		return commit, ""
 	default:
 		return "", ""
 	}
+}
+
+type requestContext struct {
+	Slug string
+	Branch string
+	FilePath string 
 }

--- a/product/ci/scm/git/git.go
+++ b/product/ci/scm/git/git.go
@@ -447,6 +447,14 @@ func GetUserRepos(ctx context.Context, request *pb.GetUserReposRequest, log *zap
 	return out, nil
 }
 
+func GetLatestCommitOnFile(ctx context.Context, slug, branch, filePath string, log *zap.SugaredLogger) (string, error) {
+	listCommitsResponse, err := ListCommits(ctx, &pb.ListCommitsRequest{Slug: slug, Type: &pb.ListCommitsRequest_Branch{Branch: branch}, FilePath: filePath}, log)
+	if err != nil {
+		return "", err
+	}
+	return listCommitsResponse.CommitIds[0], nil
+}
+
 func convertChangesList(from []*scm.Change) (to []*pb.PRFile) {
 	for _, v := range from {
 		to = append(to, convertChange(v))

--- a/product/ci/scm/proto/scm.proto
+++ b/product/ci/scm/proto/scm.proto
@@ -498,8 +498,9 @@ message ListCommitsRequest {
     string branch = 2;
     string ref = 3;
   }
-  PageRequest pagination = 4;
-  Provider provider = 5;
+  string filePath = 4;
+  PageRequest pagination = 5;
+  Provider provider = 6;
 }
 
 message ListCommitsResponse {


### PR DESCRIPTION


You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
