### PR TITLE
[CI-3416]: Preflight check & Pipeline execution fails for a pipeline with AWS VM Pool Id set as Run time input

### DIFF
--- a/320-ci-execution/src/main/java/io/harness/stateutils/buildstate/VmInitializeTaskUtils.java
+++ b/320-ci-execution/src/main/java/io/harness/stateutils/buildstate/VmInitializeTaskUtils.java
@@ -94,7 +94,7 @@ public class VmInitializeTaskUtils {
     }
     VmBuildJobInfo vmBuildJobInfo = (VmBuildJobInfo) initializeStepInfo.getBuildJobEnvInfo();
     VmPoolYaml vmPoolYaml = (VmPoolYaml) vmInfraYaml.getSpec();
-    String poolId = vmPoolYaml.getSpec().getIdentifier();
+    String poolId = RunTimeInputHandler.resolveStringParameter("identifier", "Infrastructure", "poolIdentifier", vmPoolYaml.getSpec().getIdentifier(), true);
     consumeSweepingOutput(ambiance,
         VmStageInfraDetails.builder()
             .poolId(poolId)

--- a/330-ci-beans/src/main/java/io/harness/beans/yaml/extended/infrastrucutre/VmPoolYaml.java
+++ b/330-ci-beans/src/main/java/io/harness/beans/yaml/extended/infrastrucutre/VmPoolYaml.java
@@ -8,11 +8,15 @@
 package io.harness.beans.yaml.extended.infrastrucutre;
 
 import static io.harness.annotations.dev.HarnessTeam.CI;
+import static io.harness.beans.SwaggerConstants.STRING_CLASSPATH;
 
 import io.harness.annotations.dev.OwnedBy;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import javax.validation.constraints.NotNull;
+
+import io.harness.pms.yaml.ParameterField;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -35,6 +39,6 @@ public class VmPoolYaml implements VmInfraSpec {
   @NoArgsConstructor
   @AllArgsConstructor
   public static class VmPoolYamlSpec {
-    @NotNull private String identifier;
+    @NotNull @ApiModelProperty(dataType = STRING_CLASSPATH) private ParameterField<String> identifier;
   }
 }


### PR DESCRIPTION

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30738)
<!-- Reviewable:end -->
