### PR TITLE
fix: [CI-3464]: Handling .git in the end of ssh url

### DIFF
--- a/320-ci-execution/src/main/java/io/harness/ci/integrationstage/IntegrationStageUtils.java
+++ b/320-ci-execution/src/main/java/io/harness/ci/integrationstage/IntegrationStageUtils.java
@@ -255,7 +255,7 @@ public class IntegrationStageUtils {
   public String getGitURL(CodeBase ciCodebase, GitConnectionType connectionType, String url) {
     String gitUrl = retrieveGenericGitConnectorURL(ciCodebase, connectionType, url);
 
-    if (!url.endsWith(GIT_URL_SUFFIX) && !url.contains("dev.azure.com")) {
+    if (!gitUrl.endsWith(GIT_URL_SUFFIX) && !gitUrl.contains("dev.azure.com")) {
       gitUrl += GIT_URL_SUFFIX;
     }
     return gitUrl;

--- a/320-ci-execution/src/test/java/io/harness/ci/integrationstage/IntegrationStageUtilsTest.java
+++ b/320-ci-execution/src/test/java/io/harness/ci/integrationstage/IntegrationStageUtilsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.ci.integrationstage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.harness.category.element.UnitTests;
+import io.harness.delegate.beans.connector.scm.GitConnectionType;
+import io.harness.pms.yaml.YamlUtils;
+import io.harness.yaml.extended.ci.codebase.CodeBase;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class IntegrationStageUtilsTest {
+  @Test
+  @Category(UnitTests.class)
+  public void getGitURLTestWithoutGitSuffix() throws Exception {
+    String yamlNode =
+        "{\"connectorRef\":\"git_3464\",\"repoName\":\"harness-core\",\"build\":{\"type\":\"branch\",\"spec\":{\"branch\":\"develop\",\"__uuid\":\"YtRST1sGTMyuLgNvJYsInw\"},\"__uuid\":\"Sh-Z7OKrQkeeg35DDI8tHQ\"},\"__uuid\":\"Yl_HajezQ4yOIRqE6xWZYQ\"}";
+    CodeBase ciCodebase = YamlUtils.read(yamlNode, CodeBase.class);
+    GitConnectionType connectionType = GitConnectionType.ACCOUNT;
+    String url = "git@github.com:devkimittal";
+    String actual = IntegrationStageUtils.getGitURL(ciCodebase, connectionType, url);
+    String expected = "git@github.com:devkimittal/harness-core.git";
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  @Category(UnitTests.class)
+  public void getGitURLTestWithGitSuffix() throws Exception {
+    String yamlNode =
+        "{\"connectorRef\":\"git_3464\",\"repoName\":\"harness-core.git\",\"build\":{\"type\":\"branch\",\"spec\":{\"branch\":\"develop\",\"__uuid\":\"YtRST1sGTMyuLgNvJYsInw\"},\"__uuid\":\"Sh-Z7OKrQkeeg35DDI8tHQ\"},\"__uuid\":\"Yl_HajezQ4yOIRqE6xWZYQ\"}";
+    CodeBase ciCodebase = YamlUtils.read(yamlNode, CodeBase.class);
+    GitConnectionType connectionType = GitConnectionType.ACCOUNT;
+    String url = "git@github.com:devkimittal";
+    String actual = IntegrationStageUtils.getGitURL(ciCodebase, connectionType, url);
+    String expected = "git@github.com:devkimittal/harness-core.git";
+    assertThat(actual).isEqualTo(expected);
+  }
+}

--- a/scripts/jenkins/author-check.sh
+++ b/scripts/jenkins/author-check.sh
@@ -234,7 +234,8 @@ git log -1000 --oneline --format='%aN <%aE>' | sort -u |\
     grep -iv "^Sergey Bobrov sergey.bobrov@harness.io$" |\
     grep -iv "^William Wissemann william.wissemann@harness.io$" |\
     grep -iv "^Shubham Maheshwari <shubham.maheshwari@harness.io>$" |\
-    grep -iv "^Alexandru Ciofu <alexandru.ciofu@harness.io>$"` || :
+    grep -iv "^Alexandru Ciofu <alexandru.ciofu@harness.io>$" |\
+    grep -iv "^Dev Mittal <devki.mittal@harness.io>$"` || :
 
 if [ ! -z "$UNKNOWN_USERS" ]
 then

--- a/scripts/jenkins/authorsList.txt
+++ b/scripts/jenkins/authorsList.txt
@@ -239,3 +239,4 @@ Sergey Bobrov sergey.bobrov@harness.io
 William Wissemann william.wissemann@harness.io
 Shubham Maheshwari shubham.maheshwari@harness.io
 Scott Walker scott.walker@harness.io
+Dev Mittal devki.mittal@harness.io


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30762)
<!-- Reviewable:end -->
