### PR TITLE
fix: [DEL-3320]: alert notification rules are not working because of …

### DIFF
--- a/390-db-migration/src/main/java/io/harness/migrations/MigrationBackgroundList.java
+++ b/390-db-migration/src/main/java/io/harness/migrations/MigrationBackgroundList.java
@@ -364,7 +364,7 @@ public class MigrationBackgroundList {
         .add(Pair.of(207, DeleteDelegateAlertsExceptDelegateDown.class))
         .add(Pair.of(208, MigrationSMCredentialsFromLocalToGlobalKMS.class))
         .add(Pair.of(209, NullAppFilterPermissionMigration.class))
-        .add(Pair.of(210, DefaultDelegateNgTokenMigration.class))
+        .add(Pair.of(210, BaseMigration.class))
         .add(Pair.of(211, AddRingsToAccountMigration.class))
         .add(Pair.of(212, AddRingDetailsToDelegateRing.class))
         .add(Pair.of(213, RemoveUsageRestrictionForApplicationDefaultsMigration.class))

--- a/390-db-migration/src/main/java/io/harness/migrations/all/DeleteDelegateAlertsExceptDelegateDown.java
+++ b/390-db-migration/src/main/java/io/harness/migrations/all/DeleteDelegateAlertsExceptDelegateDown.java
@@ -53,6 +53,8 @@ public class DeleteDelegateAlertsExceptDelegateDown implements Migration {
         persistence.delete(persistence.createQuery(Alert.class).field(AlertKeys.uuid).in(idsToDelete));
         log.info("deleted: " + deleted);
       }
+    } catch (Exception e) {
+      log.error("Error occurred during migration for deleting all delegate alerts except DelegateDown alert.", e);
     }
     log.info(
         "Migration complete for deleting delegate alerts except DELEGATE_DOWN alert. Deleted " + deleted + " records.");

--- a/400-rest/src/main/java/software/wings/beans/alert/AlertType.java
+++ b/400-rest/src/main/java/software/wings/beans/alert/AlertType.java
@@ -26,7 +26,13 @@ import lombok.Getter;
 public enum AlertType {
   ApprovalNeeded(Approval, Warning),
   ManualInterventionNeeded(ManualIntervention, Warning),
+  NoActiveDelegates(Setup, Error), // deprecated
+  NoInstalledDelegates(Setup, Error), // deprecated
   DelegatesDown(Setup, Error, 2),
+  DelegatesScalingGroupDownAlert(Setup, Error), // deprecated
+  DelegateProfileError(Setup, Error), // deprecated
+  NoEligibleDelegates(Setup, Error), // deprecated
+  PerpetualTaskAlert(Setup, Error), // deprecated
   InvalidKMS(Setup, Error),
   GitSyncError(Setup, Error),
   GitConnectionError(Setup, Error),

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=73903
+build.number=73904
 build.patch=000
 delegate.version=22.02.10
 delegate.patch=000


### PR DESCRIPTION
…deletion of some alertTypes from enum

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30770)
<!-- Reviewable:end -->
