### PR TITLE
fix: [PIE-2797]: Publishing outcomes for rollback at stage level

### DIFF
--- a/125-cd-nextgen/src/main/java/io/harness/cdng/pipeline/steps/RollbackOptionalChildChainStep.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/pipeline/steps/RollbackOptionalChildChainStep.java
@@ -20,7 +20,6 @@ import io.harness.pms.contracts.execution.Status;
 import io.harness.pms.contracts.steps.StepCategory;
 import io.harness.pms.contracts.steps.StepType;
 import io.harness.pms.sdk.core.data.OptionalSweepingOutput;
-import io.harness.pms.sdk.core.plan.creation.yaml.StepOutcomeGroup;
 import io.harness.pms.sdk.core.resolver.RefObjectUtils;
 import io.harness.pms.sdk.core.resolver.outputs.ExecutionSweepingOutputService;
 import io.harness.pms.sdk.core.steps.executables.ChildChainExecutable;
@@ -101,7 +100,7 @@ public class RollbackOptionalChildChainStep implements ChildChainExecutable<Roll
         ambiance, RefObjectUtils.getSweepingOutputRefObject(YAMLFieldNameConstants.DEPLOYMENT_ROLLED_BACK));
     if (!optionalSweepingOutput.isFound()) {
       executionSweepingOutputService.consume(ambiance, YAMLFieldNameConstants.DEPLOYMENT_ROLLED_BACK,
-          RollbackTriggeredOutput.builder().rollbackTriggered(true).build(), StepOutcomeGroup.PIPELINE.name());
+          RollbackTriggeredOutput.builder().rollbackTriggered(true).build(), StepCategory.STAGE.name());
     }
     // If status is suspended, then we should mark the execution as success
     if (notifyData.getStatus() == Status.SUSPENDED) {

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
 build.number=74003
-build.patch=000
+build.patch=001
 delegate.version=22.02.11
 delegate.patch=000


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/30909)
<!-- Reviewable:end -->
