### PR TITLE
fix: [PL-18325]: trim to remove the newline escape sequence from sign…

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/security/SecretManagementDelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/security/SecretManagementDelegateServiceImpl.java
@@ -107,7 +107,8 @@ public class SecretManagementDelegateServiceImpl implements SecretManagementDele
       if (response.isSuccessful() && response.body().getSignedSSHVaultResult() != null) {
         log.info(
             "[VaultSSH]: Signed public key is : {}", response.body().getSignedSSHVaultResult().getSignedPublicKey());
-        hostConnectionAttributes.setSignedPublicKey(response.body().getSignedSSHVaultResult().getSignedPublicKey());
+        hostConnectionAttributes.setSignedPublicKey(
+            response.body().getSignedSSHVaultResult().getSignedPublicKey().trim());
       } else {
         log.info("[VaultSSH]: Error signing public key for request:{}", signedSSHVaultRequest);
         logAndThrowVaultError(sshVaultConfig, response, "sign public key with SSH secret engine");


### PR DESCRIPTION
…ed public key causing errors in jsch

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
