### PR TITLE
[fix]: [CI-0]: Use API instead of Api

### DIFF
--- a/120-ng-manager/src/main/java/io/harness/ng/NextGenConfiguration.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/NextGenConfiguration.java
@@ -293,7 +293,7 @@ public class NextGenConfiguration extends Configuration {
         new Info()
             .title("Harness NextGen Software Delivery Platform API Reference")
             .description(
-                "This is the Open Api Spec 3 for the NextGen Manager. This is under active development. Beware of the breaking change with respect to the generated code stub")
+                "This is the Open API Spec 3 for the NextGen Manager. This is under active development. Beware of any breaking changes with respect to the generated code stub")
             .termsOfService("https://harness.io/terms-of-use/")
             .version("3.0")
             .contact(new Contact().email("contact@harness.io"));


### PR DESCRIPTION
Use API instead of Api in the public-facing API documentation front page.

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31252)
<!-- Reviewable:end -->
