### PR TITLE
fix: [PL-23500]: added user group ldap sync with UserId

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
@@ -270,6 +270,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.mindrot.jbcrypt.BCrypt;
+import org.mongodb.morphia.FindAndModifyOptions;
 import org.mongodb.morphia.query.CriteriaContainer;
 import org.mongodb.morphia.query.FindOptions;
 import org.mongodb.morphia.query.Query;
@@ -1297,9 +1298,21 @@ public class UserServiceImpl implements UserService {
     }
   }
 
+  private void updateEmailOfUser(User user, String newEmail) {
+    if (user != null) {
+      UpdateOperations<User> updateOperations = wingsPersistence.createUpdateOperations(User.class);
+      setUnset(updateOperations, UserKeys.email, newEmail);
+      Query<User> query = wingsPersistence.createQuery(User.class).filter("_id", user.getUuid());
+      wingsPersistence.findAndModify(query, updateOperations, new FindAndModifyOptions());
+    }
+  }
+
   @Override
   public InviteOperationResponse inviteUser(
       UserInvite userInvite, boolean isInviteAcceptanceRequired, boolean markEmailVerified) {
+    log.info("Inviting user {} with isInviteAcceptanceRequired {} and markEmailVerified {}", userInvite.getEmail(),
+        isInviteAcceptanceRequired, markEmailVerified);
+
     signupService.checkIfEmailIsValid(userInvite.getEmail());
 
     String accountId = userInvite.getAccountId();
@@ -1317,7 +1330,17 @@ public class UserServiceImpl implements UserService {
       user = anUser().build();
     }
 
+    if (featureFlagService.isEnabled(FeatureName.LDAP_USER_ID_SYNC, accountId) && isNotEmpty(userInvite.getEmail())
+        && !userInvite.getEmail().equals(user.getEmail())) {
+      log.info("Updating email Id for user {} with current mail {} and new email {}", user.getUuid(), user.getEmail(),
+          userInvite.getEmail().trim().toLowerCase());
+      updateEmailOfUser(user, userInvite.getEmail().trim().toLowerCase());
+      user.setEmail(userInvite.getEmail().trim().toLowerCase());
+    }
+
     List<UserGroup> userGroups = userGroupService.getUserGroupsFromUserInvite(userInvite);
+    log.info("User {} is being part of groups {}", user.getUuid(), userGroups);
+
     if (isUserAssignedToAccount(user, accountId)) {
       updateUserGroupsOfUser(user.getUuid(), userGroups, accountId, true);
       return USER_ALREADY_ADDED;

--- a/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
@@ -1333,10 +1333,11 @@ public class UserServiceImpl implements UserService {
     String incomingEmail = userInvite.getEmail();
     if (featureFlagService.isEnabled(FeatureName.LDAP_USER_ID_SYNC, accountId) && isNotEmpty(incomingEmail)
         && isNotEmpty(user.getEmail()) && !incomingEmail.trim().toLowerCase().equals(user.getEmail())) {
+      String incomingEmailInLower = incomingEmail.trim().toLowerCase();
       log.info("Updating email Id for user {} with current mail {} and new email {}", user.getUuid(), user.getEmail(),
-          userInvite.getEmail().trim().toLowerCase());
-      updateEmailOfUser(user, userInvite.getEmail().trim().toLowerCase());
-      user.setEmail(userInvite.getEmail().trim().toLowerCase());
+          incomingEmailInLower);
+      updateEmailOfUser(user, incomingEmailInLower);
+      user.setEmail(incomingEmailInLower);
     }
 
     List<UserGroup> userGroups = userGroupService.getUserGroupsFromUserInvite(userInvite);

--- a/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
@@ -1299,7 +1299,7 @@ public class UserServiceImpl implements UserService {
   }
 
   private void updateEmailOfUser(User user, String newEmail) {
-    if (user != null) {
+    if (user != null && isNotEmpty(user.getUuid())) {
       UpdateOperations<User> updateOperations = wingsPersistence.createUpdateOperations(User.class);
       setUnset(updateOperations, UserKeys.email, newEmail);
       Query<User> query = wingsPersistence.createQuery(User.class).filter("_id", user.getUuid());
@@ -1330,8 +1330,9 @@ public class UserServiceImpl implements UserService {
       user = anUser().build();
     }
 
-    if (featureFlagService.isEnabled(FeatureName.LDAP_USER_ID_SYNC, accountId) && isNotEmpty(userInvite.getEmail())
-        && !userInvite.getEmail().equals(user.getEmail())) {
+    String incomingEmail = userInvite.getEmail();
+    if (featureFlagService.isEnabled(FeatureName.LDAP_USER_ID_SYNC, accountId) && isNotEmpty(incomingEmail)
+        && isNotEmpty(user.getEmail()) && !incomingEmail.trim().toLowerCase().equals(user.getEmail())) {
       log.info("Updating email Id for user {} with current mail {} and new email {}", user.getUuid(), user.getEmail(),
           userInvite.getEmail().trim().toLowerCase());
       updateEmailOfUser(user, userInvite.getEmail().trim().toLowerCase());

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
 build.number=74109
-build.patch=003
+build.patch=004
 delegate.version=22.02.12
 delegate.patch=000


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31258)
<!-- Reviewable:end -->
