### PR TITLE
fix: [CDS-34753]: setting attribute should return right total

### DIFF
--- a/400-rest/src/main/java/software/wings/graphql/datafetcher/outcome/OutcomeConnectionDataFetcher.java
+++ b/400-rest/src/main/java/software/wings/graphql/datafetcher/outcome/OutcomeConnectionDataFetcher.java
@@ -10,6 +10,7 @@ package software.wings.graphql.datafetcher.outcome;
 import static io.harness.annotations.dev.HarnessTeam.CDC;
 import static io.harness.beans.PageRequest.PageRequestBuilder.aPageRequest;
 import static io.harness.beans.SearchFilter.Operator.IN;
+import static io.harness.data.structure.CollectionUtils.emptyIfNull;
 import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
 
 import io.harness.annotations.dev.HarnessModule;
@@ -98,7 +99,7 @@ public class OutcomeConnectionDataFetcher
 
   private void getOutcomeWithInfraDef(
       QLOutcomesQueryParameters qlQuery, WorkflowExecution execution, QLOutcomeConnectionBuilder connectionBuilder) {
-    final List<String> infraMappingIds = execution.getInfraMappingIds();
+    final List<String> infraMappingIds = emptyIfNull(execution.getInfraMappingIds());
     final PageRequest pageRequest =
         aPageRequest().addFilter(InfrastructureMapping.ID, IN, infraMappingIds.toArray()).build();
     final PageResponse<InfrastructureMapping> infraMappings = infrastructureMappingService.list(pageRequest);

--- a/400-rest/src/main/java/software/wings/service/impl/SettingsServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/SettingsServiceImpl.java
@@ -282,10 +282,7 @@ public class SettingsServiceImpl implements SettingsService {
       List<SettingAttribute> filteredSettingAttributes = getFilteredSettingAttributes(
           pageResponse.getResponse(), appIdFromRequest, envIdFromRequest, forUsageInNewApp);
       log.info("Total time taken in filtering setting records:  {}.", System.currentTimeMillis() - timestamp);
-      return aPageResponse()
-          .withResponse(filteredSettingAttributes)
-          .withTotal(filteredSettingAttributes.size())
-          .build();
+      return aPageResponse().withResponse(filteredSettingAttributes).withTotal(pageResponse.getTotal()).build();
     } catch (Exception e) {
       throw new InvalidRequestException(ExceptionUtils.getMessage(e), e);
     }

--- a/400-rest/src/main/java/software/wings/service/impl/SettingsServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/SettingsServiceImpl.java
@@ -356,7 +356,7 @@ public class SettingsServiceImpl implements SettingsService {
 
       return aPageResponse()
           .withResponse(resp)
-          .withTotal(filteredSettingAttributes.size())
+          .withTotal(pageResponse.getTotal())
           .withOffset(req.getOffset())
           .withLimit(req.getLimit())
           .build();


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31278)
<!-- Reviewable:end -->
