### PR TITLE
feat: [DEL-3079]: show error in UI if grpc is not enabled

### DIFF
--- a/400-rest/src/main/java/software/wings/beans/DelegateStatus.java
+++ b/400-rest/src/main/java/software/wings/beans/DelegateStatus.java
@@ -60,6 +60,7 @@ public class DelegateStatus {
     private long profileExecutedAt;
     private boolean profileError;
     private boolean sampleDelegate;
+    private boolean isGrpcActive;
     List<DelegateConnectionDetails> connections;
   }
 }

--- a/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
@@ -332,6 +332,8 @@ public class DelegateServiceImpl implements DelegateService {
   private static final String SAMPLE_DELEGATE_NAME = "harness-sample-k8s-delegate";
   private static final String deployVersion = System.getenv(DEPLOY_VERSION);
 
+  private static final long MAX_GRPC_HB_TIMEOUT = TimeUnit.MINUTES.toMillis(15);
+
   static {
     templateConfiguration.setTemplateLoader(new ClassTemplateLoader(DelegateServiceImpl.class, "/delegatetemplates"));
   }
@@ -810,6 +812,8 @@ public class DelegateServiceImpl implements DelegateService {
               .tags(delegate.getTags())
               .profileExecutedAt(delegate.getProfileExecutedAt())
               .profileError(delegate.isProfileError())
+              .isGrpcActive(connections.stream().allMatch(
+                  connection -> connection.getLastGrpcHeartbeat() > System.currentTimeMillis() - MAX_GRPC_HB_TIMEOUT))
               .implicitSelectors(delegateSetupService.retrieveDelegateImplicitSelectors(delegate))
               .sampleDelegate(delegate.isSampleDelegate())
               .connections(connections)

--- a/420-delegate-service/src/main/java/software/wings/service/impl/DelegateConnectionDao.java
+++ b/420-delegate-service/src/main/java/software/wings/service/impl/DelegateConnectionDao.java
@@ -85,6 +85,7 @@ public class DelegateConnectionDao {
                                                        .project(DelegateConnectionKeys.delegateId, true)
                                                        .project(DelegateConnectionKeys.version, true)
                                                        .project(DelegateConnectionKeys.lastHeartbeat, true)
+                                                       .project(DelegateConnectionKeys.lastGrpcHeartbeat, true)
                                                        .asList();
 
     return delegateConnections.stream().collect(Collectors.groupingBy(delegateConnection
@@ -94,6 +95,7 @@ public class DelegateConnectionDao {
                    .uuid(delegateConnection.getUuid())
                    .lastHeartbeat(delegateConnection.getLastHeartbeat())
                    .version(delegateConnection.getVersion())
+                   .lastGrpcHeartbeat(delegateConnection.getLastGrpcHeartbeat())
                    .build(),
             toList())));
   }

--- a/920-delegate-service-beans/src/main/java/io/harness/delegate/beans/DelegateConnectionDetails.java
+++ b/920-delegate-service-beans/src/main/java/io/harness/delegate/beans/DelegateConnectionDetails.java
@@ -25,4 +25,5 @@ public class DelegateConnectionDetails {
   private String uuid;
   private String version;
   private long lastHeartbeat;
+  private long lastGrpcHeartbeat;
 }

--- a/920-delegate-service-beans/src/main/java/io/harness/delegate/beans/DelegateGroupDetails.java
+++ b/920-delegate-service-beans/src/main/java/io/harness/delegate/beans/DelegateGroupDetails.java
@@ -38,5 +38,6 @@ public class DelegateGroupDetails {
   private long lastHeartBeat;
   private String connectivityStatus;
   private boolean activelyConnected;
+  private boolean isGrpcActive;
   private List<DelegateGroupListing.DelegateInner> delegateInstanceDetails;
 }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
