### PR TITLE
[PL-23559]: The git to harness should work correctly if the file path / folder path contains harness as a substring

### DIFF
--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/impl/gittoharness/GitToHarnessProcessorServiceImpl.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/impl/gittoharness/GitToHarnessProcessorServiceImpl.java
@@ -541,10 +541,15 @@ public class GitToHarnessProcessorServiceImpl implements GitToHarnessProcessorSe
 
   private Set<String> getFilePathsWithoutError(List<GitToHarnessProcessingResponse> gitToHarnessProcessingResponses) {
     List<FileProcessingResponseDTO> fileResponses = new ArrayList<>();
-    gitToHarnessProcessingResponses.stream()
-        .map(GitToHarnessProcessingResponse::getProcessingResponse)
-        .map(GitToHarnessProcessingResponseDTO::getFileResponses)
-        .forEach(fileProcessingResponseDTO -> fileResponses.addAll(fileProcessingResponseDTO));
+    for (GitToHarnessProcessingResponse gitToHarnessProcessingResponse : emptyIfNull(gitToHarnessProcessingResponses)) {
+      GitToHarnessProcessingResponseDTO processingResponse = gitToHarnessProcessingResponse.getProcessingResponse();
+      if (processingResponse != null) {
+        if (processingResponse.getFileResponses() != null) {
+          List<FileProcessingResponseDTO> fileResponseList = emptyIfNull(processingResponse.getFileResponses());
+          fileResponses.addAll(fileResponseList);
+        }
+      }
+    }
     return fileResponses.stream()
         .filter(fileResponse -> fileResponse.getFileProcessingStatus() == FileProcessingStatus.SUCCESS)
         .map(FileProcessingResponseDTO::getFilePath)

--- a/900-git-sync-sdk/src/main/java/io/harness/gitsync/gittoharness/GitToHarnessSdkProcessorImpl.java
+++ b/900-git-sync-sdk/src/main/java/io/harness/gitsync/gittoharness/GitToHarnessSdkProcessorImpl.java
@@ -43,6 +43,7 @@ import io.harness.manage.GlobalContextManager;
 import io.harness.manage.GlobalContextManager.GlobalContextGuard;
 import io.harness.ng.core.ValidationError;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
@@ -53,6 +54,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -199,9 +202,10 @@ public class GitToHarnessSdkProcessorImpl implements GitToHarnessSdkProcessor {
     return false;
   }
 
-  private GitSyncBranchContext createGitEntityInfo(
+  @VisibleForTesting
+  protected GitSyncBranchContext createGitEntityInfo(
       String branch, String filePath, String yamlGitConfigId, String lastObjectId, String commitId) {
-    String[] pathSplited = emptyIfNull(filePath).split(GitSyncConstants.FOLDER_PATH);
+    String[] pathSplited = Pattern.compile("([.])(harness/)").split(filePath);
     if (pathSplited.length != 2) {
       throw new InvalidRequestException(String.format(
           "The path %s doesn't contain the .harness folder, thus this file won't be processed", filePath));

--- a/900-git-sync-sdk/src/main/java/io/harness/gitsync/utils/GitSyncSdkUtils.java
+++ b/900-git-sync-sdk/src/main/java/io/harness/gitsync/utils/GitSyncSdkUtils.java
@@ -16,13 +16,14 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.exception.InvalidRequestException;
 import io.harness.gitsync.interceptor.GitSyncConstants;
 
+import java.util.regex.Pattern;
 import lombok.experimental.UtilityClass;
 
 @OwnedBy(HarnessTeam.PL)
 @UtilityClass
 public class GitSyncSdkUtils {
   public GitEntityFilePath getRootFolderAndFilePath(String completeFilePath) {
-    String[] pathSplited = emptyIfNull(completeFilePath).split(GitSyncConstants.FOLDER_PATH);
+    String[] pathSplited = Pattern.compile("([.])(harness/)").split(completeFilePath);
     if (pathSplited.length != 2) {
       throw new InvalidRequestException(String.format(
           "The path %s doesn't contain the .harness folder, thus this file won't be processed", completeFilePath));

--- a/900-git-sync-sdk/src/main/java/io/harness/gitsync/utils/GitSyncSdkUtils.java
+++ b/900-git-sync-sdk/src/main/java/io/harness/gitsync/utils/GitSyncSdkUtils.java
@@ -7,8 +7,6 @@
 
 package io.harness.gitsync.utils;
 
-import static io.harness.data.structure.HarnessStringUtils.emptyIfNull;
-
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import io.harness.annotations.dev.HarnessTeam;

--- a/900-git-sync-sdk/src/test/java/io/harness/gitsync/gittoharness/GitToHarnessSdkProcessorImplTest.java
+++ b/900-git-sync-sdk/src/test/java/io/harness/gitsync/gittoharness/GitToHarnessSdkProcessorImplTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.gitsync.gittoharness;
+
+import static io.harness.rule.OwnerRule.DEEPAK;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import io.harness.CategoryTest;
+import io.harness.category.element.UnitTests;
+import io.harness.exception.InvalidRequestException;
+import io.harness.gitsync.interceptor.GitEntityInfo;
+import io.harness.gitsync.interceptor.GitSyncBranchContext;
+import io.harness.rule.Owner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InjectMocks;
+
+public class GitToHarnessSdkProcessorImplTest extends CategoryTest {
+  @InjectMocks GitToHarnessSdkProcessorImpl gitToHarnessSdkProcessor;
+
+  @Before
+  public void setup() {
+    initMocks(this);
+  }
+
+  @Test
+  @Owner(developers = DEEPAK)
+  @Category(UnitTests.class)
+  public void createGitEntityInfo() {
+    String branch = "branch";
+    String filePath = "filePath";
+    String yamlGitConfigId = "yamlGitConfigId";
+    String lastObjectId = "lastObjectId";
+    String commitId = "commitId";
+    String folderPath = "/folderPath/.harness/";
+    GitSyncBranchContext gitEntityInfo = gitToHarnessSdkProcessor.createGitEntityInfo(
+        branch, "/folderPath/.harness/filePath", yamlGitConfigId, lastObjectId, commitId);
+
+    final GitEntityInfo gitBranchInfo = gitEntityInfo.getGitBranchInfo();
+    assertThat(gitBranchInfo.getBranch()).isEqualTo(branch);
+    assertThat(gitBranchInfo.getFilePath()).isEqualTo(filePath);
+    assertThat(gitBranchInfo.getFolderPath()).isEqualTo(folderPath);
+    assertThat(gitBranchInfo.getYamlGitConfigId()).isEqualTo(yamlGitConfigId);
+    assertThat(gitBranchInfo.getLastObjectId()).isEqualTo(lastObjectId);
+    assertThat(gitBranchInfo.isSyncFromGit()).isEqualTo(true);
+    assertThat(gitBranchInfo.getCommitId()).isEqualTo(commitId);
+  }
+
+  @Test(expected = InvalidRequestException.class)
+  @Owner(developers = DEEPAK)
+  @Category(UnitTests.class)
+  public void test_createGitEntityInfoWhenFilePathDoesNotContainsHarness() {
+    String branch = "branch";
+    String yamlGitConfigId = "yamlGitConfigId";
+    String lastObjectId = "lastObjectId";
+    String commitId = "commitId";
+    GitSyncBranchContext gitEntityInfo = gitToHarnessSdkProcessor.createGitEntityInfo(
+        branch, "folderPath/filePath", yamlGitConfigId, lastObjectId, commitId);
+  }
+
+  @Test
+  @Owner(developers = DEEPAK)
+  @Category(UnitTests.class)
+  public void test_createGitEntityInfoWhenFolderPathContainsHarness() {
+    String branch = "branch";
+    String yamlGitConfigId = "yamlGitConfigId";
+    String lastObjectId = "lastObjectId";
+    String commitId = "commitId";
+    GitSyncBranchContext gitEntityInfo = gitToHarnessSdkProcessor.createGitEntityInfo(
+        branch, "testharness/.harness/filePath", yamlGitConfigId, lastObjectId, commitId);
+    final GitEntityInfo gitBranchInfo = gitEntityInfo.getGitBranchInfo();
+    assertThat(gitBranchInfo).isNotNull();
+  }
+
+  @Test
+  @Owner(developers = DEEPAK)
+  @Category(UnitTests.class)
+  public void test_createGitEntityInfoWhenFilePathContainsHarness() {
+    String branch = "branch";
+    String yamlGitConfigId = "yamlGitConfigId";
+    String lastObjectId = "lastObjectId";
+    String commitId = "commitId";
+    GitSyncBranchContext gitEntityInfo = gitToHarnessSdkProcessor.createGitEntityInfo(
+        branch, "folderPath/.harness/harness.yaml", yamlGitConfigId, lastObjectId, commitId);
+    final GitEntityInfo gitBranchInfo = gitEntityInfo.getGitBranchInfo();
+    assertThat(gitBranchInfo).isNotNull();
+  }
+
+  @Test
+  @Owner(developers = DEEPAK)
+  @Category(UnitTests.class)
+  public void test_createGitEntityInfo_WithComplexPath() {
+    String branch = "branch";
+    String yamlGitConfigId = "yamlGitConfigId";
+    String lastObjectId = "lastObjectId";
+    String commitId = "commitId";
+    GitSyncBranchContext gitEntityInfo = gitToHarnessSdkProcessor.createGitEntityInfo(
+        branch, "testharness/pipelines/.harness/ci/cd/filePath", yamlGitConfigId, lastObjectId, commitId);
+    final GitEntityInfo gitBranchInfo = gitEntityInfo.getGitBranchInfo();
+    assertThat(gitBranchInfo).isNotNull();
+    assertThat(gitBranchInfo.getFilePath()).isEqualTo("ci/cd/filePath");
+    assertThat(gitBranchInfo.getFolderPath()).isEqualTo("testharness/pipelines/.harness/");
+  }
+}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
