### PR TITLE
fix: [DEL-3500]: Wrong log printed for non shell delegates

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
@@ -2934,16 +2934,18 @@ public class DelegateServiceImpl implements DelegateService {
         UUID currentUUID = convertFromBase64(heartbeat.getDelegateConnectionId());
         UUID existingUUID = convertFromBase64(existingConnection.getUuid());
         if (existingUUID.timestamp() > currentUUID.timestamp()) {
-          boolean notSameLocationForShellScriptDelegate = DelegateType.SHELL_SCRIPT.equals(delegate.getDelegateType())
-              && (isNotEmpty(heartbeat.getLocation()) && isNotEmpty(existingConnection.getLocation())
-                  && !heartbeat.getLocation().equals(existingConnection.getLocation()));
-          if (notSameLocationForShellScriptDelegate) {
-            log.error(
-                "Newer delegate connection found for the delegate id! Will initiate self destruct sequence for the current delegate.");
-            destroyTheCurrentDelegate(accountId, delegateId, heartbeat.getDelegateConnectionId(), connectionMode);
-            delegateConnectionDao.replaceWithNewerConnection(heartbeat.getDelegateConnectionId(), existingConnection);
-          } else {
-            log.error("Two delegates with the same identity");
+          if (DelegateType.SHELL_SCRIPT.equals(delegate.getDelegateType())) {
+            boolean notSameLocationForShellScriptDelegate = isNotEmpty(heartbeat.getLocation())
+                && isNotEmpty(existingConnection.getLocation())
+                && !heartbeat.getLocation().equals(existingConnection.getLocation());
+            if (notSameLocationForShellScriptDelegate) {
+              log.error(
+                  "Newer delegate connection found for the delegate id! Will initiate self destruct sequence for the current delegate.");
+              destroyTheCurrentDelegate(accountId, delegateId, heartbeat.getDelegateConnectionId(), connectionMode);
+              delegateConnectionDao.replaceWithNewerConnection(heartbeat.getDelegateConnectionId(), existingConnection);
+            } else {
+              log.error("Two delegates with the same identity");
+            }
           }
         } else {
           delegateMetricsService.recordDelegateMetrics(delegate, DELEGATE_RESTARTED);


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31325)
<!-- Reviewable:end -->
