### PR TITLE
fix: [DEL-3479]: Deprecate scope uuid in graphql api

### DIFF
--- a/400-rest/src/main/resources/graphql/public/delegateMutatation.graphql
+++ b/400-rest/src/main/resources/graphql/public/delegateMutatation.graphql
@@ -100,7 +100,7 @@ type AttachScopeToDelegatePayload {
 
 type DelegateScope {
   name: String
-  uuid: String
+  uuid: String @deprecated(reason: "Use scope name.")
   taskTypes: [TaskGroup]
   environmentTypes: [EnvironmentType]
   applications: [String]


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31337)
<!-- Reviewable:end -->
