### PR TITLE
[PL-23661]: Fixing ldap CITI requirement of null email ids

### DIFF
--- a/400-rest/src/main/java/software/wings/scheduler/LdapGroupSyncJobHelper.java
+++ b/400-rest/src/main/java/software/wings/scheduler/LdapGroupSyncJobHelper.java
@@ -234,45 +234,53 @@ public class LdapGroupSyncJobHelper {
     return wingsPersistence.findAndModify(query, updateOperations, new FindAndModifyOptions());
   }
 
-  private void syncUserGroupMembers(String accountId, Map<UserGroup, Set<User>> removedGroupMembers,
+  @VisibleForTesting
+  public void syncUserGroupMembers(String accountId, Map<UserGroup, Set<User>> removedGroupMembers,
       Map<LdapUserResponse, Set<UserGroup>> addedGroupMembers) {
-    removedGroupMembers.forEach((userGroup, users) -> userGroupService.removeMembers(userGroup, users, false, true));
+    if (isNotEmpty(removedGroupMembers)) {
+      log.info("LDAPIterator: users to be removed {}", removedGroupMembers);
+      removedGroupMembers.forEach((userGroup, users) -> userGroupService.removeMembers(userGroup, users, false, true));
+    }
+    if (isNotEmpty(addedGroupMembers)) {
+      for (Map.Entry<LdapUserResponse, Set<UserGroup>> entry : addedGroupMembers.entrySet()) {
+        LdapUserResponse ldapUserResponse = entry.getKey();
+        Set<UserGroup> userGroups = entry.getValue();
 
-    for (Map.Entry<LdapUserResponse, Set<UserGroup>> entry : addedGroupMembers.entrySet()) {
-      LdapUserResponse ldapUserResponse = entry.getKey();
-      Set<UserGroup> userGroups = entry.getValue();
+        try {
+          User user = userService.getUserByEmail(ldapUserResponse.getEmail());
+          log.info("LDAPIterator: user found from by email Id {} is {}", ldapUserResponse.getEmail(), user);
 
-      try {
-        User user = userService.getUserByEmail(ldapUserResponse.getEmail());
-        if (featureFlagService.isEnabled(FeatureName.LDAP_SYNC_WITH_USERID, accountId)) {
-          user = userService.getUserByUserId(ldapUserResponse.getUserId());
-          log.info("LDAPIterator: Fetching user with user Id {}", ldapUserResponse.getUserId());
-        }
-        log.info("LDAPIterator: user found from system is {}", user);
-        if (user != null && userService.isUserAssignedToAccount(user, accountId)) {
-          log.info("LDAPIterator: user {} already assigned to account {}", user.getEmail(), accountId);
-          userService.addUserToUserGroups(accountId, user, Lists.newArrayList(userGroups), true, true);
-          log.info("LDAPIterator: adding user {} to groups {}  in accountId {}", user.getUuid(),
-              Lists.newArrayList(userGroups), accountId);
-        } else {
-          UserInvite userInvite = anUserInvite()
-                                      .withAccountId(accountId)
-                                      .withEmail(ldapUserResponse.getEmail())
-                                      .withName(ldapUserResponse.getName())
-                                      .withUserGroups(Lists.newArrayList(userGroups))
-                                      .withUserId(ldapUserResponse.getUserId())
-                                      .build();
-          log.info(
-              "LDAPIterator: creating user invite for account {} and user Invite {} and user Groups {} and externalUserId {}",
-              accountId, userInvite.getEmail(), Lists.newArrayList(userGroups), ldapUserResponse.getUserId());
-          userService.inviteUser(userInvite, false, true);
-        }
-      } catch (Exception e) {
-        if (ldapUserResponse != null && isNotEmpty(ldapUserResponse.getEmail())) {
-          log.error("LDAPIterator: could not sync user {} of account {} with error", ldapUserResponse.getEmail(),
-              accountId, e);
-        } else {
-          log.error("LDAPIterator: could not sync for account {} as email was not found ", accountId, e);
+          if (featureFlagService.isEnabled(FeatureName.LDAP_SYNC_WITH_USERID, accountId)) {
+            user = userService.getUserByUserId(ldapUserResponse.getUserId());
+            log.info("LDAPIterator: Fetching user with user Id {}", ldapUserResponse.getUserId());
+          }
+          log.info("LDAPIterator: user found from system is {}", user);
+
+          if (user != null && userService.isUserAssignedToAccount(user, accountId)) {
+            log.info("LDAPIterator: user {} already assigned to account {}", user.getEmail(), accountId);
+            userService.addUserToUserGroups(accountId, user, Lists.newArrayList(userGroups), true, true);
+            log.info("LDAPIterator: adding user {} to groups {}  in accountId {}", user.getUuid(),
+                Lists.newArrayList(userGroups), accountId);
+          } else {
+            UserInvite userInvite = anUserInvite()
+                                        .withAccountId(accountId)
+                                        .withEmail(ldapUserResponse.getEmail())
+                                        .withName(ldapUserResponse.getName())
+                                        .withUserGroups(Lists.newArrayList(userGroups))
+                                        .withUserId(ldapUserResponse.getUserId())
+                                        .build();
+            log.info(
+                "LDAPIterator: creating user invite for account {} and user Invite {} and user Groups {} and externalUserId {}",
+                accountId, userInvite.getEmail(), Lists.newArrayList(userGroups), ldapUserResponse.getUserId());
+            userService.inviteUser(userInvite, false, true);
+          }
+        } catch (Exception e) {
+          if (ldapUserResponse != null && isNotEmpty(ldapUserResponse.getEmail())) {
+            log.error("LDAPIterator: could not sync user {} of account {} with error", ldapUserResponse.getEmail(),
+                accountId, e);
+          } else {
+            log.error("LDAPIterator: could not sync for account {} as email was not found ", accountId, e);
+          }
         }
       }
     }

--- a/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
@@ -270,6 +270,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.mindrot.jbcrypt.BCrypt;
+import org.mongodb.morphia.FindAndModifyOptions;
 import org.mongodb.morphia.query.CriteriaContainer;
 import org.mongodb.morphia.query.FindOptions;
 import org.mongodb.morphia.query.Query;
@@ -1297,9 +1298,21 @@ public class UserServiceImpl implements UserService {
     }
   }
 
+  private void updateEmailOfUser(User user, String newEmail) {
+    if (user != null && isNotEmpty(user.getUuid())) {
+      UpdateOperations<User> updateOperations = wingsPersistence.createUpdateOperations(User.class);
+      setUnset(updateOperations, UserKeys.email, newEmail);
+      Query<User> query = wingsPersistence.createQuery(User.class).filter("_id", user.getUuid());
+      wingsPersistence.findAndModify(query, updateOperations, new FindAndModifyOptions());
+    }
+  }
+
   @Override
   public InviteOperationResponse inviteUser(
       UserInvite userInvite, boolean isInviteAcceptanceRequired, boolean markEmailVerified) {
+    log.info("Inviting user {} with isInviteAcceptanceRequired {} and markEmailVerified {}", userInvite.getEmail(),
+        isInviteAcceptanceRequired, markEmailVerified);
+
     signupService.checkIfEmailIsValid(userInvite.getEmail());
 
     String accountId = userInvite.getAccountId();
@@ -1315,6 +1328,16 @@ public class UserServiceImpl implements UserService {
     boolean createNewUser = user == null;
     if (createNewUser) {
       user = anUser().build();
+    }
+
+    String incomingEmail = userInvite.getEmail();
+    if (featureFlagService.isEnabled(FeatureName.LDAP_USER_ID_SYNC, accountId) && isNotEmpty(incomingEmail)
+        && isNotEmpty(user.getEmail()) && !incomingEmail.trim().toLowerCase().equals(user.getEmail())) {
+      String incomingEmailInLower = incomingEmail.trim().toLowerCase();
+      log.info("Updating email Id for user {} with current mail {} and new email {}", user.getUuid(), user.getEmail(),
+          incomingEmailInLower);
+      updateEmailOfUser(user, incomingEmailInLower);
+      user.setEmail(incomingEmailInLower);
     }
 
     List<UserGroup> userGroups = userGroupService.getUserGroupsFromUserInvite(userInvite);

--- a/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
@@ -1315,6 +1315,7 @@ public class UserServiceImpl implements UserService {
 
     signupService.checkIfEmailIsValid(userInvite.getEmail());
 
+    log.info("LDAPIterator: email {} of account {} is valid", userInvite.getEmail(), userInvite.getAccountId());
     String accountId = userInvite.getAccountId();
     limitCheck(accountId, userInvite.getEmail());
 

--- a/400-rest/src/main/java/software/wings/signup/SignupServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/signup/SignupServiceImpl.java
@@ -202,12 +202,14 @@ public class SignupServiceImpl implements SignupService {
       clonedEmail = replaceTopLevelDomain(topLevelDomain, clonedEmail);
     }
     if (isBlank(clonedEmail)) {
+      log.error("Blank user email found");
       throw new WingsException(INVALID_EMAIL, USER).addParam(EMAIL, email);
     }
 
     final String clonedEmailAddress = clonedEmail.trim();
     final String emailAddress = email.trim();
     if (!EmailValidator.getInstance().isValid(clonedEmailAddress)) {
+      log.error("Invalid user email with id {}", email);
       throw new WingsException(INVALID_EMAIL, USER).addParam(EMAIL, emailAddress);
     }
   }

--- a/400-rest/src/test/java/software/wings/scheduler/LdapGroupSyncJobHelperTest.java
+++ b/400-rest/src/test/java/software/wings/scheduler/LdapGroupSyncJobHelperTest.java
@@ -89,6 +89,30 @@ public class LdapGroupSyncJobHelperTest extends CategoryTest {
   @Test
   @Owner(developers = UJJAWAL)
   @Category(UnitTests.class)
+  public void shouldSyncUserGroupWithNullInputs() {
+    UserGroup userGroup = mock(UserGroup.class);
+    Account account = new Account();
+    account.setUuid(UUIDGenerator.generateUuid());
+    when(userGroup.getName()).thenReturn("userGroupName");
+    when(userGroup.getAccountId()).thenReturn(UUIDGenerator.generateUuid());
+    userGroup.setAccountId(UUIDGenerator.generateUuid());
+    doReturn(LdapGroupResponse.builder().selectable(true).build())
+        .when(ldapGroupSyncJobHelper)
+        .fetchGroupDetails(any(), any(), any());
+    doReturn(userGroup).when(ldapGroupSyncJobHelper).syncUserGroupMetadata(any(), any());
+    doReturn(true).when(ldapGroupSyncJobHelper).validateUserGroupStates(any());
+    boolean exceptionThrown = false;
+    try {
+      ldapGroupSyncJobHelper.syncUserGroupMembers(account.getUuid(), null, null);
+    } catch (Exception e) {
+      exceptionThrown = true;
+    }
+    assertThat(exceptionThrown).isEqualTo(false);
+  }
+
+  @Test
+  @Owner(developers = UJJAWAL)
+  @Category(UnitTests.class)
   public void testLdapSyncTimeout() {
     long NEGATIVE_TIME = -10000;
     long HALF_MINUTE = 30 * 1000;


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31349)
<!-- Reviewable:end -->
