### PR TITLE
fix: [PL-21822]: Creating new DTO for git sync error count. To update the api doc error count api.

### DIFF
--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/gitsyncerror/dtos/GitSyncErrorEntityInfoDTO.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/gitsyncerror/dtos/GitSyncErrorEntityInfoDTO.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.gitsync.gitsyncerror.dtos;
+
+import static io.harness.annotations.dev.HarnessTeam.PL;
+
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.gitsync.sdk.GitSyncApiConstants;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.ws.rs.QueryParam;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldNameConstants;
+
+@Getter
+@Builder
+@FieldNameConstants(innerTypeName = "GitSyncErrorEntityInfoDTO")
+@Schema(name = "GitSyncErrorEntityInfoDTO",
+    description = "Details to find Git Entity including: Git Sync Config Id and Branch Name")
+@OwnedBy(PL)
+@NoArgsConstructor
+@AllArgsConstructor
+public class GitSyncErrorEntityInfoDTO {
+  @Parameter(description = GitSyncApiConstants.BRANCH_PARAM_MESSAGE)
+  @QueryParam(GitSyncApiConstants.BRANCH_KEY)
+  String branch;
+  @Parameter(description = GitSyncApiConstants.REPOID_PARAM_MESSAGE
+          + "If empty, response will have the entities for default branch of all the existing repos")
+  @QueryParam(GitSyncApiConstants.REPO_IDENTIFIER_KEY)
+  String yamlGitConfigId;
+}

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/gitsyncerror/remote/GitSyncErrorResource.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/gitsyncerror/remote/GitSyncErrorResource.java
@@ -30,6 +30,7 @@ import io.harness.gitsync.gitsyncerror.beans.GitSyncError.GitSyncErrorKeys;
 import io.harness.gitsync.gitsyncerror.dtos.GitSyncErrorAggregateByCommitDTO;
 import io.harness.gitsync.gitsyncerror.dtos.GitSyncErrorCountDTO;
 import io.harness.gitsync.gitsyncerror.dtos.GitSyncErrorDTO;
+import io.harness.gitsync.gitsyncerror.dtos.GitSyncErrorEntityInfoDTO;
 import io.harness.gitsync.gitsyncerror.service.GitSyncErrorService;
 import io.harness.gitsync.interceptor.GitEntityFindInfoDTO;
 import io.harness.gitsync.sdk.GitSyncApiConstants;
@@ -229,7 +230,7 @@ public class GitSyncErrorResource {
       @Parameter(description = GitSyncApiConstants.SEARCH_TERM_PARAM_MESSAGE) @QueryParam(
           NGResourceFilterConstants.SEARCH_TERM_KEY) String searchTerm,
       @RequestBody(description = "Details to find Git Entity including: Git Sync Config Id and Branch Name")
-      @BeanParam GitEntityFindInfoDTO gitEntityBasicInfo) {
+      @BeanParam GitSyncErrorEntityInfoDTO gitEntityBasicInfo) {
     return ResponseDTO.newResponse(gitSyncErrorService.getErrorCount(accountIdentifier, orgIdentifier,
         projectIdentifier, searchTerm, gitEntityBasicInfo.getYamlGitConfigId(), gitEntityBasicInfo.getBranch()));
   }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31399)
<!-- Reviewable:end -->
