### PR TITLE
[fix]: [CI-3416]: Add parameterized field for pool name

### DIFF
--- a/320-ci-execution/src/main/java/io/harness/stateutils/buildstate/VmInitializeTaskUtils.java
+++ b/320-ci-execution/src/main/java/io/harness/stateutils/buildstate/VmInitializeTaskUtils.java
@@ -94,7 +94,7 @@ public class VmInitializeTaskUtils {
     }
     VmBuildJobInfo vmBuildJobInfo = (VmBuildJobInfo) initializeStepInfo.getBuildJobEnvInfo();
     VmPoolYaml vmPoolYaml = (VmPoolYaml) vmInfraYaml.getSpec();
-    String poolId = vmPoolYaml.getSpec().getIdentifier();
+    String poolId = vmPoolYaml.getSpec().getName().getValue();
     consumeSweepingOutput(ambiance,
         VmStageInfraDetails.builder()
             .poolId(poolId)

--- a/320-ci-execution/src/test/java/io/harness/integrationstage/VmBuildJobTestHelper.java
+++ b/320-ci-execution/src/test/java/io/harness/integrationstage/VmBuildJobTestHelper.java
@@ -24,7 +24,7 @@ public class VmBuildJobTestHelper {
   public StageElementConfig getVmStage(String poolId) {
     VmInfraYaml awsVmInfraYaml =
         VmInfraYaml.builder()
-            .spec(VmPoolYaml.builder().spec(VmPoolYamlSpec.builder().identifier(poolId).build()).build())
+            .spec(VmPoolYaml.builder().spec(VmPoolYamlSpec.builder().name(poolId).build()).build())
             .build();
     StageElementConfig stageElementConfig =
         StageElementConfig.builder()

--- a/320-ci-execution/src/test/java/io/harness/stateutils/buildstate/VmInitializeTaskUtilsTest.java
+++ b/320-ci-execution/src/test/java/io/harness/stateutils/buildstate/VmInitializeTaskUtilsTest.java
@@ -68,7 +68,7 @@ public class VmInitializeTaskUtilsTest extends CIExecutionTestBase {
   @Category(UnitTests.class)
   public void getInitializeTaskParams() {
     String poolId = "test";
-    VmPoolYaml vmPoolYaml = VmPoolYaml.builder().spec(VmPoolYamlSpec.builder().identifier(poolId).build()).build();
+    VmPoolYaml vmPoolYaml = VmPoolYaml.builder().spec(VmPoolYamlSpec.builder().name(poolId).build()).build();
 
     String stageRuntimeId = "test";
     InitializeStepInfo initializeStepInfo = InitializeStepInfo.builder()

--- a/330-ci-beans/src/main/java/io/harness/beans/yaml/extended/infrastrucutre/VmPoolYaml.java
+++ b/330-ci-beans/src/main/java/io/harness/beans/yaml/extended/infrastrucutre/VmPoolYaml.java
@@ -8,11 +8,15 @@
 package io.harness.beans.yaml.extended.infrastrucutre;
 
 import static io.harness.annotations.dev.HarnessTeam.CI;
+import static io.harness.beans.SwaggerConstants.STRING_CLASSPATH;
 
 import io.harness.annotations.dev.OwnedBy;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import javax.validation.constraints.NotNull;
+
+import io.harness.pms.yaml.ParameterField;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -35,6 +39,6 @@ public class VmPoolYaml implements VmInfraSpec {
   @NoArgsConstructor
   @AllArgsConstructor
   public static class VmPoolYamlSpec {
-    @NotNull private String identifier;
+    @NotNull @ApiModelProperty(dataType = STRING_CLASSPATH) private ParameterField<String> name;
   }
 }

--- a/330-ci-beans/src/test/resources/schema/IntegrationStage/all.json
+++ b/330-ci-beans/src/test/resources/schema/IntegrationStage/all.json
@@ -5539,10 +5539,10 @@
     "VmPoolYamlSpec": {
       "type": "object",
       "required": [
-        "identifier"
+        "name"
       ],
       "properties": {
-        "identifier": {
+        "name": {
           "type": "string"
         }
       },


### PR DESCRIPTION
This is backward incompatible change and requires migration of yaml from the customers. 

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31401)
<!-- Reviewable:end -->
