### PR TITLE
feat: [STO-3504]: propagate step output for failed steps

### DIFF
--- a/product/ci/addon/grpc/handler.go
+++ b/product/ci/addon/grpc/handler.go
@@ -90,6 +90,8 @@ func (h *handler) ExecuteStep(ctx context.Context, in *pb.ExecuteStepRequest) (*
 			Output:     stepOutput,
 			NumRetries: numRetries,
 		}
+
+		h.log.Infow("Plugin results", "output", stepOutput, "response", response)
 		err = close(rl.Writer, err)
 		return response, err
 	case nil:

--- a/product/ci/addon/grpc/handler.go
+++ b/product/ci/addon/grpc/handler.go
@@ -91,7 +91,7 @@ func (h *handler) ExecuteStep(ctx context.Context, in *pb.ExecuteStepRequest) (*
 			NumRetries: numRetries,
 		}
 
-		h.log.Infow("Plugin results", "output", stepOutput, "response", response)
+		h.log.Infow("Plugin results", "output:", stepOutput, "response:", response)
 		err = close(rl.Writer, err)
 		return response, err
 	case nil:

--- a/product/ci/addon/tasks/plugin.go
+++ b/product/ci/addon/tasks/plugin.go
@@ -130,10 +130,10 @@ func (t *pluginTask) Run(ctx context.Context) (map[string]string, *pb.Artifact, 
 		if errc != nil {
 			t.log.Errorw("error while collecting test reports", zap.Error(errc))
 		}
-		t.log.Infow("Step Succeeded", "output", so, "retries", t.numRetries)
+		t.log.Infow("Step Succeeded", "output:", so, "retries:", t.numRetries)
 		return so, nil, t.numRetries, err
 	}
-	t.log.Infow("Step Succeeded", "output", so, "retries", t.numRetries)
+	t.log.Infow("Step Succeeded", "output:", so, "retries:", t.numRetries)
 	return so, nil, t.numRetries, err
 }
 

--- a/product/ci/addon/tasks/plugin.go
+++ b/product/ci/addon/tasks/plugin.go
@@ -115,7 +115,7 @@ func (t *pluginTask) Run(ctx context.Context) (map[string]string, *pb.Artifact, 
 				// If there's an error in collecting reports, we won't retry but
 				// the step will be marked as an error
 				t.log.Errorw("unable to collect test reports", zap.Error(err))
-				return nil, nil, t.numRetries, err
+				return so, nil, t.numRetries, err
 			}
 			if len(t.reports) > 0 {
 				t.log.Infow(fmt.Sprintf("collected test reports in %s time", time.Since(st)))
@@ -130,9 +130,11 @@ func (t *pluginTask) Run(ctx context.Context) (map[string]string, *pb.Artifact, 
 		if errc != nil {
 			t.log.Errorw("error while collecting test reports", zap.Error(errc))
 		}
-		return nil, nil, t.numRetries, err
+		t.log.Infow("Step Succeeded", "output", so, "retries", t.numRetries)
+		return so, nil, t.numRetries, err
 	}
-	return nil, nil, t.numRetries, err
+	t.log.Infow("Step Succeeded", "output", so, "retries", t.numRetries)
+	return so, nil, t.numRetries, err
 }
 
 // resolveExprInEnv resolves JEXL expressions & env var present in plugin settings environment variables

--- a/product/ci/engine/legacy/executor/parallel_executor.go
+++ b/product/ci/engine/legacy/executor/parallel_executor.go
@@ -86,6 +86,7 @@ func (e *parallelExecutor) Run(ctx context.Context, ps *pb.ParallelStep, so outp
 	for i := 0; i < numSteps; i++ {
 		result := <-results
 		stepStatusByID[result.stepID] = completed
+		stepOutputByID[result.stepID] = result.stepOutput
 		if result.err != nil {
 			e.log.Errorw(
 				"failed to execute parallel step",
@@ -94,10 +95,8 @@ func (e *parallelExecutor) Run(ctx context.Context, ps *pb.ParallelStep, so outp
 				zap.Error(result.err),
 			)
 			e.sendAbortToPendingSteps(ctx, stepStatusByID, ps.GetSteps(), start, accountID)
-			return nil, result.err
+			return stepOutputByID, result.err
 		}
-
-		stepOutputByID[result.stepID] = result.stepOutput
 	}
 
 	e.log.Infow(

--- a/product/ci/engine/legacy/executor/stage_executor.go
+++ b/product/ci/engine/legacy/executor/stage_executor.go
@@ -115,17 +115,18 @@ func (e *stageExecutor) executeStep(ctx context.Context, step *pb.Step, accountI
 	switch x := step.GetStep().(type) {
 	case *pb.Step_Unit:
 		stepOutput, err := e.unitExecutor.Run(ctx, step.GetUnit(), e.stageOutput, accountID)
+		e.stageOutput[step.GetUnit().GetId()] = stepOutput
+
 		if err != nil {
 			return err
 		}
-		e.stageOutput[step.GetUnit().GetId()] = stepOutput
 	case *pb.Step_Parallel:
 		stepOutputByID, err := e.parallelExecutor.Run(ctx, step.GetParallel(), e.stageOutput, accountID)
-		if err != nil {
-			return err
-		}
 		for stepID, stepOutput := range stepOutputByID {
 			e.stageOutput[stepID] = stepOutput
+		}
+		if err != nil {
+			return err
 		}
 	default:
 		return fmt.Errorf("Step has unexpected type %T", x)

--- a/product/ci/engine/legacy/executor/unit_executor.go
+++ b/product/ci/engine/legacy/executor/unit_executor.go
@@ -112,7 +112,7 @@ func (e *unitExecutor) Run(ctx context.Context, step *pb.UnitStep, so output.Sta
 	}
 	statusErr := e.updateStepStatus(ctx, step, stepStatus, errMsg, numRetries, stepOutput, accountID, time.Since(start))
 	if statusErr != nil {
-		return nil, statusErr
+		return stepOutput, statusErr
 	}
 	return stepOutput, err
 }
@@ -188,7 +188,7 @@ func (e *unitExecutor) execute(ctx context.Context, step *pb.UnitStep,
 		e.log.Infow("Plugin step info", "step", x.Plugin.String(), "step_id", step.GetId())
 		stepOutput, numRetries, err = pluginStep(step, e.tmpFilePath, so, e.log).Run(ctx)
 		if err != nil {
-			return nil, numRetries, err
+			return stepOutput, numRetries, err
 		}
 	case *pb.UnitStep_SaveCache:
 		rl, err = newRemoteLogger(step.GetLogKey())

--- a/product/ci/engine/legacy/steps/plugin.go
+++ b/product/ci/engine/legacy/steps/plugin.go
@@ -84,13 +84,13 @@ func (e *pluginStep) execute(ctx context.Context) (*output.StepOutput, int32, er
 	c := addonClient.Client()
 	arg := e.getExecuteStepArg()
 	ret, err := c.ExecuteStep(ctx, arg, grpc_retry.WithMax(maxAddonRetries))
-	if err != nil {
-		e.log.Errorw("Plugin step RPC failed", "step_id", e.id, "elapsed_time_ms", utils.TimeSince(st), zap.Error(err))
-		return nil, int32(1), err
-	}
-	e.log.Infow("Successfully executed step", "step_id", e.id, "elapsed_time_ms", utils.TimeSince(st))
 	stepOutput := &output.StepOutput{}
 	stepOutput.Output.Variables = ret.GetOutput()
+	if err != nil {
+		e.log.Errorw("Plugin step RPC failed", "step_id", e.id, "elapsed_time_ms", utils.TimeSince(st), zap.Error(err))
+		return stepOutput, int32(1), err
+	}
+	e.log.Infow("Successfully executed step", "step_id", e.id, "elapsed_time_ms", utils.TimeSince(st))
 	return stepOutput, ret.GetNumRetries(), nil
 }
 

--- a/product/ci/engine/new/executor/addon_executor.go
+++ b/product/ci/engine/new/executor/addon_executor.go
@@ -56,16 +56,17 @@ func ExecuteStepOnAddon(ctx context.Context, step *pb.UnitStep, tmpFilePath stri
 		TmpFilePath: tmpFilePath,
 	}
 	ret, err := c.ExecuteStep(ctx, arg, grpc_retry.WithMax(maxAddonRetries))
+	stepOutput := &output.StepOutput{}
+	stepOutput.Output.Variables = ret.GetOutput()
+
 	if err != nil {
 		log.Errorw("Execute step RPC failed", "step_id", stepID,
-			"elapsed_time_ms", utils.TimeSince(st), zap.Error(err))
-		return nil, nil, err
+			"elapsed_time_ms", utils.TimeSince(st), "step output", ret, zap.Error(err))
+		return stepOutput, nil, err
 	}
 
 	log.Infow("Successfully executed step", "step_id", stepID,
 		"elapsed_time_ms", utils.TimeSince(st))
-	stepOutput := &output.StepOutput{}
-	stepOutput.Output.Variables = ret.GetOutput()
 	artifact := ret.GetArtifact()
 	return stepOutput, artifact, nil
 }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31486)
<!-- Reviewable:end -->
