### PR TITLE
fix: [DEL-3563]: filter active account for rebroadcast iterator

### DIFF
--- a/360-cg-manager/config.yml
+++ b/360-cg-manager/config.yml
@@ -687,7 +687,7 @@ iteratorsConfig:
   delegateTaskRebroadcastIteratorConfig:
     threadPoolSize: ${DELEGATE_TASK_REBROADCAST_ITERATOR_THREAD_COUNT:-5}
   failDelegateTaskIteratorConfig:
-      threadPoolSize: ${FAIL_DELEGATE_TASK_ITERATOR_THREAD_COUNT:-5}
+      threadPoolSize: ${FAIL_DELEGATE_TASK_ITERATOR_THREAD_COUNT:-2}
 
 disableDelegateMgmtInManager: false
 

--- a/400-rest/src/main/java/io/harness/iterator/DelegateTaskRebroadcastIterator.java
+++ b/400-rest/src/main/java/io/harness/iterator/DelegateTaskRebroadcastIterator.java
@@ -30,10 +30,11 @@ import io.harness.mongo.iterator.provider.MorphiaPersistenceProvider;
 import io.harness.persistence.HIterator;
 import io.harness.persistence.HPersistence;
 import io.harness.service.intfc.DelegateTaskService;
-import io.harness.workers.background.AccountLevelEntityProcessController;
 
 import software.wings.beans.Account;
 import software.wings.beans.Account.AccountKeys;
+import software.wings.beans.AccountStatus;
+import software.wings.beans.LicenseInfo.LicenseInfoKeys;
 import software.wings.beans.TaskType;
 import software.wings.core.managerConfiguration.ConfigurationController;
 import software.wings.service.impl.DelegateTaskBroadcastHelper;
@@ -95,7 +96,10 @@ public class DelegateTaskRebroadcastIterator implements MongoPersistenceIterator
             .targetInterval(Duration.ofSeconds(DELEGATE_TASK_REBROADCAST_TIMEOUT))
             .acceptableNoAlertDelay(Duration.ofSeconds(15))
             .acceptableExecutionTime(Duration.ofSeconds(30))
-            .entityProcessController(new AccountLevelEntityProcessController(accountService))
+            .filterExpander(query
+                -> query.or(query.criteria(AccountKeys.licenseInfo).doesNotExist(),
+                    query.criteria(AccountKeys.licenseInfo + "." + LicenseInfoKeys.accountStatus)
+                        .equal(AccountStatus.ACTIVE)))
             .handler(this)
             .schedulingType(MongoPersistenceIterator.SchedulingType.REGULAR)
             .persistenceProvider(persistenceProvider)

--- a/400-rest/src/main/java/io/harness/iterator/FailDelegateTaskIterator.java
+++ b/400-rest/src/main/java/io/harness/iterator/FailDelegateTaskIterator.java
@@ -51,10 +51,11 @@ import io.harness.persistence.HIterator;
 import io.harness.persistence.HPersistence;
 import io.harness.service.intfc.DelegateCache;
 import io.harness.service.intfc.DelegateTaskService;
-import io.harness.workers.background.AccountLevelEntityProcessController;
 
 import software.wings.beans.Account;
 import software.wings.beans.Account.AccountKeys;
+import software.wings.beans.AccountStatus;
+import software.wings.beans.LicenseInfo.LicenseInfoKeys;
 import software.wings.beans.TaskType;
 import software.wings.core.managerConfiguration.ConfigurationController;
 import software.wings.service.intfc.AccountService;
@@ -116,7 +117,10 @@ public class FailDelegateTaskIterator implements MongoPersistenceIterator.Handle
             .targetInterval(Duration.ofSeconds(DELEGATE_TASK_FAIL_TIMEOUT))
             .acceptableNoAlertDelay(Duration.ofSeconds(45))
             .acceptableExecutionTime(Duration.ofSeconds(30))
-            .entityProcessController(new AccountLevelEntityProcessController(accountService))
+            .filterExpander(query
+                -> query.or(query.criteria(AccountKeys.licenseInfo).doesNotExist(),
+                    query.criteria(AccountKeys.licenseInfo + "." + LicenseInfoKeys.accountStatus)
+                        .equal(AccountStatus.ACTIVE)))
             .handler(this)
             .schedulingType(MongoPersistenceIterator.SchedulingType.REGULAR)
             .persistenceProvider(persistenceProvider)

--- a/build.properties
+++ b/build.properties
@@ -3,4 +3,4 @@ build.minorVersion=0
 build.number=74214
 build.patch=003
 delegate.version=22.02.13
-delegate.patch=000
+delegate.patch=001

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
 build.number=74214
-build.patch=003
+build.patch=004
 delegate.version=22.02.13
-delegate.patch=001
+delegate.patch=00


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31577)
<!-- Reviewable:end -->
