### PR TITLE
[fix]: [CCM-7064]: Add 2 days buffer time between job run time and event received 

### DIFF
--- a/280-batch-processing/src/main/java/io/harness/batch/processing/billing/writer/support/BillingDataGenerationValidator.java
+++ b/280-batch-processing/src/main/java/io/harness/batch/processing/billing/writer/support/BillingDataGenerationValidator.java
@@ -14,6 +14,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.inject.Inject;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -59,9 +60,10 @@ public class BillingDataGenerationValidator {
   private boolean fetchClusterBillingDataValidationInfo(String accountId, String clusterId, Instant startTime) {
     LastReceivedPublishedMessage lastReceivedPublishedMessage =
         lastReceivedPublishedMessageDao.get(accountId, clusterId);
+    Instant bufferedStartTime = startTime.minus(2, ChronoUnit.DAYS).truncatedTo(ChronoUnit.DAYS);
     boolean generateData = false;
     if (null != lastReceivedPublishedMessage
-        && Instant.ofEpochMilli(lastReceivedPublishedMessage.getLastReceivedAt()).isAfter(startTime)) {
+        && Instant.ofEpochMilli(lastReceivedPublishedMessage.getLastReceivedAt()).isAfter(bufferedStartTime)) {
       generateData = true;
     }
     if (!generateData) {

--- a/280-batch-processing/src/test/java/io/harness/batch/processing/billing/writer/support/BillingDataGenerationValidatorTest.java
+++ b/280-batch-processing/src/test/java/io/harness/batch/processing/billing/writer/support/BillingDataGenerationValidatorTest.java
@@ -58,7 +58,7 @@ public class BillingDataGenerationValidatorTest extends CategoryTest {
   @Category(UnitTests.class)
   public void shouldReturnFalseWhenClusterEventIsOld() {
     when(lastReceivedPublishedMessageDao.get(ACCOUNT_ID, CLUSTER_ID))
-        .thenReturn(lastReceivedPublishedMessage(START_TIME.minus(1, ChronoUnit.DAYS).toEpochMilli()));
+        .thenReturn(lastReceivedPublishedMessage(START_TIME.minus(3, ChronoUnit.DAYS).toEpochMilli()));
     boolean generateBillingData =
         billingDataGenerationValidator.shouldGenerateBillingData(ACCOUNT_ID, CLUSTER_ID, START_TIME);
     assertThat(generateBillingData).isFalse();


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31634)
<!-- Reviewable:end -->
