### PR TITLE
fix: [PL-23563]: Deleting Referenced Secret, when SourceCodeManager is getting deleted.

### DIFF
--- a/120-ng-manager/src/test/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImplTest.java
+++ b/120-ng-manager/src/test/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImplTest.java
@@ -68,7 +68,12 @@ import io.harness.security.dto.Principal;
 import io.harness.security.dto.PrincipalType;
 
 import com.google.inject.Inject;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/120-ng-manager/src/test/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImplTest.java
+++ b/120-ng-manager/src/test/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImplTest.java
@@ -46,8 +46,7 @@ import io.harness.delegate.beans.connector.scm.gitlab.GitlabAuthenticationDTO;
 import io.harness.delegate.beans.connector.scm.gitlab.GitlabSshCredentialsDTO;
 import io.harness.encryption.SecretRefHelper;
 import io.harness.exception.InvalidRequestException;
-import io.harness.ng.core.api.NGSecretServiceV2;
-import io.harness.ng.core.api.impl.NGSecretServiceV2Impl;
+import io.harness.ng.core.api.impl.SecretCrudServiceImpl;
 import io.harness.ng.userprofile.commons.AwsCodeCommitSCMDTO;
 import io.harness.ng.userprofile.commons.AzureDevOpsSCMDTO;
 import io.harness.ng.userprofile.commons.BitbucketSCMDTO;
@@ -80,8 +79,7 @@ import org.junit.experimental.categories.Category;
 
 @OwnedBy(PL)
 public class SourceCodeManagerServiceImplTest extends NgManagerTestBase {
-  NGSecretServiceV2 ngSecretServiceV2;
-  NGSecretServiceV2Impl ngSecretServiceV2Impl;
+  SecretCrudServiceImpl secretCrudService;
   SourceCodeManagerService sourceCodeManagerService;
   @Inject private Map<SCMType, SourceCodeManagerMapper> scmMapBinder;
 
@@ -100,10 +98,9 @@ public class SourceCodeManagerServiceImplTest extends NgManagerTestBase {
     userIdentifier = generateUuid();
     accountIdentifier = randomAlphabetic(10);
     sourceCodeManagerRepository = mock(SourceCodeManagerRepository.class);
-    ngSecretServiceV2 = mock(NGSecretServiceV2.class);
-    ngSecretServiceV2Impl = mock(NGSecretServiceV2Impl.class);
+    secretCrudService = mock(SecretCrudServiceImpl.class);
     sourceCodeManagerService =
-        new SourceCodeManagerServiceImpl(ngSecretServiceV2, sourceCodeManagerRepository, scmMapBinder);
+        new SourceCodeManagerServiceImpl(secretCrudService, sourceCodeManagerRepository, scmMapBinder);
     Principal principal = mock(Principal.class);
     when(principal.getType()).thenReturn(PrincipalType.USER);
     when(principal.getName()).thenReturn(userIdentifier);
@@ -211,7 +208,7 @@ public class SourceCodeManagerServiceImplTest extends NgManagerTestBase {
         .thenReturn(sourceCodeManagerList);
     when(sourceCodeManagerRepository.deleteByUserIdentifierAndNameAndAccountIdentifier(any(), any(), any()))
         .thenReturn(1L);
-    when(ngSecretServiceV2.delete(any(), any(), any(), eq(secretKeyRef))).thenReturn(true);
+    when(secretCrudService.delete(any(), any(), any(), eq(secretKeyRef))).thenReturn(true);
     boolean result = sourceCodeManagerService.delete(gitHubScm.getName(), gitHubScm.getAccountIdentifier());
     assertThat(result).isTrue();
     delete(sourceCodeManagerList);
@@ -228,7 +225,7 @@ public class SourceCodeManagerServiceImplTest extends NgManagerTestBase {
         .thenReturn(sourceCodeManagerList);
     when(sourceCodeManagerRepository.deleteByUserIdentifierAndNameAndAccountIdentifier(any(), any(), any()))
         .thenReturn(1L);
-    when(ngSecretServiceV2.delete(any(), any(), any(), eq(secretKeyRef))).thenReturn(true);
+    when(secretCrudService.delete(any(), any(), any(), eq(secretKeyRef))).thenReturn(true);
     boolean result = sourceCodeManagerService.delete(gitHubScm.getName(), gitHubScm.getAccountIdentifier());
     assertThat(result).isTrue();
     delete(sourceCodeManagerList);
@@ -245,7 +242,7 @@ public class SourceCodeManagerServiceImplTest extends NgManagerTestBase {
         .thenReturn(sourceCodeManagerList);
     when(sourceCodeManagerRepository.deleteByUserIdentifierAndNameAndAccountIdentifier(any(), any(), any()))
         .thenReturn(1L);
-    when(ngSecretServiceV2.delete(any(), any(), any(), eq(secretKeyRef))).thenReturn(true);
+    when(secretCrudService.delete(any(), any(), any(), eq(secretKeyRef))).thenReturn(true);
     sourceCodeManagerService.delete(gitHubScm.getName(), gitHubScm.getAccountIdentifier());
   }
 

--- a/120-ng-manager/src/test/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImplTest.java
+++ b/120-ng-manager/src/test/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImplTest.java
@@ -25,7 +25,6 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.category.element.UnitTests;
 import io.harness.connector.entities.embedded.bitbucketconnector.BitbucketAuthentication;
 import io.harness.connector.entities.embedded.bitbucketconnector.BitbucketSshAuthentication;
-
 import io.harness.connector.entities.embedded.githubconnector.GithubAuthentication;
 import io.harness.connector.entities.embedded.githubconnector.GithubHttpAuthentication;
 import io.harness.connector.entities.embedded.githubconnector.GithubSshAuthentication;
@@ -40,7 +39,6 @@ import io.harness.delegate.beans.connector.scm.awscodecommit.AwsCodeCommitHttpsC
 import io.harness.delegate.beans.connector.scm.awscodecommit.AwsCodeCommitSecretKeyAccessKeyDTO;
 import io.harness.delegate.beans.connector.scm.bitbucket.BitbucketAuthenticationDTO;
 import io.harness.delegate.beans.connector.scm.bitbucket.BitbucketSshCredentialsDTO;
-
 import io.harness.delegate.beans.connector.scm.github.GithubAuthenticationDTO;
 import io.harness.delegate.beans.connector.scm.github.GithubSshCredentialsDTO;
 import io.harness.delegate.beans.connector.scm.gitlab.GitlabAuthenticationDTO;

--- a/120-ng-manager/src/test/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImplTest.java
+++ b/120-ng-manager/src/test/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImplTest.java
@@ -25,7 +25,11 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.category.element.UnitTests;
 import io.harness.connector.entities.embedded.bitbucketconnector.BitbucketAuthentication;
 import io.harness.connector.entities.embedded.bitbucketconnector.BitbucketSshAuthentication;
-import io.harness.connector.entities.embedded.githubconnector.*;
+
+import io.harness.connector.entities.embedded.githubconnector.GithubAuthentication;
+import io.harness.connector.entities.embedded.githubconnector.GithubHttpAuthentication;
+import io.harness.connector.entities.embedded.githubconnector.GithubSshAuthentication;
+import io.harness.connector.entities.embedded.githubconnector.GithubUsernameToken;
 import io.harness.connector.entities.embedded.gitlabconnector.GitlabAuthentication;
 import io.harness.connector.entities.embedded.gitlabconnector.GitlabSshAuthentication;
 import io.harness.delegate.beans.connector.scm.GitAuthType;
@@ -36,7 +40,9 @@ import io.harness.delegate.beans.connector.scm.awscodecommit.AwsCodeCommitHttpsC
 import io.harness.delegate.beans.connector.scm.awscodecommit.AwsCodeCommitSecretKeyAccessKeyDTO;
 import io.harness.delegate.beans.connector.scm.bitbucket.BitbucketAuthenticationDTO;
 import io.harness.delegate.beans.connector.scm.bitbucket.BitbucketSshCredentialsDTO;
-import io.harness.delegate.beans.connector.scm.github.*;
+
+import io.harness.delegate.beans.connector.scm.github.GithubAuthenticationDTO;
+import io.harness.delegate.beans.connector.scm.github.GithubSshCredentialsDTO;
 import io.harness.delegate.beans.connector.scm.gitlab.GitlabAuthenticationDTO;
 import io.harness.delegate.beans.connector.scm.gitlab.GitlabSshCredentialsDTO;
 import io.harness.encryption.SecretRefHelper;

--- a/123-ng-core-user/src/main/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImpl.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImpl.java
@@ -39,10 +39,11 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DuplicateKeyException;
 
-@Slf4j
+
 @OwnedBy(PL)
 @NoArgsConstructor
 @AllArgsConstructor
+@Slf4j
 public class SourceCodeManagerServiceImpl implements SourceCodeManagerService {
   @Inject private NGSecretServiceV2 ngSecretServiceV2;
   @Inject SourceCodeManagerRepository sourceCodeManagerRepository;

--- a/123-ng-core-user/src/main/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImpl.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImpl.java
@@ -14,7 +14,6 @@ import static java.lang.String.format;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.connector.entities.embedded.githubconnector.GithubHttpAuthentication;
 import io.harness.connector.entities.embedded.githubconnector.GithubUsernameToken;
-import io.harness.encryption.SecretRefData;
 import io.harness.encryption.SecretRefHelper;
 import io.harness.exception.DuplicateFieldException;
 import io.harness.exception.InvalidRequestException;

--- a/123-ng-core-user/src/main/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImpl.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImpl.java
@@ -17,7 +17,7 @@ import io.harness.connector.entities.embedded.githubconnector.GithubUsernameToke
 import io.harness.encryption.SecretRefHelper;
 import io.harness.exception.DuplicateFieldException;
 import io.harness.exception.InvalidRequestException;
-import io.harness.ng.core.api.NGSecretServiceV2;
+import io.harness.ng.core.api.SecretCrudService;
 import io.harness.ng.userprofile.commons.SCMType;
 import io.harness.ng.userprofile.commons.SourceCodeManagerDTO;
 import io.harness.ng.userprofile.entities.GithubSCM;
@@ -44,7 +44,7 @@ import org.springframework.dao.DuplicateKeyException;
 @AllArgsConstructor
 @Slf4j
 public class SourceCodeManagerServiceImpl implements SourceCodeManagerService {
-  @Inject private NGSecretServiceV2 ngSecretServiceV2;
+  @Inject private SecretCrudService ngSecretService;
   @Inject SourceCodeManagerRepository sourceCodeManagerRepository;
   @Inject private Map<SCMType, SourceCodeManagerMapper> scmMapBinder;
 
@@ -126,7 +126,7 @@ public class SourceCodeManagerServiceImpl implements SourceCodeManagerService {
                                       .getAuth())
                                      .getTokenRef())
                 .getIdentifier();
-        if (!ngSecretServiceV2.delete(accountIdentifier, null, null, secretId)) {
+        if (!ngSecretService.delete(accountIdentifier, null, null, secretId)) {
           log.error("Not able to delete Secret with id:{} associated with SCM {} in account {}", secretId, name,
               accountIdentifier);
           throw new InvalidRequestException("Secret cannot be deleted");

--- a/123-ng-core-user/src/main/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImpl.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImpl.java
@@ -114,8 +114,8 @@ public class SourceCodeManagerServiceImpl implements SourceCodeManagerService {
     List<SourceCodeManager> scmList = sourceCodeManagerRepository.findByUserIdentifierAndAccountIdentifier(
         getUserIdentifier().get(), accountIdentifier);
     if (!scmList.isEmpty()) {
-      if ((((GithubHttpAuthentication) ((GithubSCM) (scmList.get(0))).getAuthenticationDetails()).getAuth()
-                  instanceof GithubUsernameToken)) {
+      if (((GithubHttpAuthentication) ((GithubSCM) (scmList.get(0))).getAuthenticationDetails()).getAuth()
+              instanceof GithubUsernameToken) {
         String secretId = ((GithubUsernameToken) ((GithubHttpAuthentication) ((GithubSCM) (scmList.get(0)))
                                                       .getAuthenticationDetails())
                                .getAuth())

--- a/123-ng-core-user/src/main/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImpl.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImpl.java
@@ -39,7 +39,6 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DuplicateKeyException;
 
-
 @OwnedBy(PL)
 @NoArgsConstructor
 @AllArgsConstructor

--- a/123-ng-core-user/src/main/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImpl.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/userprofile/services/impl/SourceCodeManagerServiceImpl.java
@@ -116,11 +116,12 @@ public class SourceCodeManagerServiceImpl implements SourceCodeManagerService {
     if (!scmList.isEmpty()) {
       if (((GithubHttpAuthentication) ((GithubSCM) (scmList.get(0))).getAuthenticationDetails()).getAuth()
               instanceof GithubUsernameToken) {
-        String secretId = ((GithubUsernameToken) ((GithubHttpAuthentication) ((GithubSCM) (scmList.get(0)))
-                                                      .getAuthenticationDetails())
-                               .getAuth())
-                              .getTokenRef()
-                              .split("\\.")[1];
+        String[] tokenRef = ((GithubUsernameToken) ((GithubHttpAuthentication) ((GithubSCM) (scmList.get(0)))
+                                                        .getAuthenticationDetails())
+                                 .getAuth())
+                                .getTokenRef()
+                                .split("\\.");
+        String secretId = tokenRef.length > 0 ? tokenRef[1] : tokenRef[0];
         ngSecretServiceV2.delete(accountIdentifier, null, null, secretId);
       }
       sourceCodeManagerRepository.deleteByUserIdentifierAndNameAndAccountIdentifier(


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31645)
<!-- Reviewable:end -->
