### PR TITLE
[PL-23931]: query git file location repository on basis of complete git path with different possible formats

### DIFF
--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/impl/GitEntityServiceImpl.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/impl/GitEntityServiceImpl.java
@@ -280,7 +280,12 @@ public class GitEntityServiceImpl implements GitEntityService {
               entityReference.getFullyQualifiedName(), entityType.name(), entityReference.getAccountIdentifier(),
               branch, completeFilePath.substring(1));
     }
-    return gitFileLocation.map(this::buildGitSyncEntityDTO).orElse(null);
+    return gitFileLocation.map(this::buildGitSyncEntityDTO)
+        .orElseThrow(
+            ()
+                -> new InvalidRequestException(String.format(
+                    "No entity found for %s for entity type %s in branch [%s] with folderpath [%s] and filepath [%s]",
+                    entityReference.getFullyQualifiedName(), entityType, branch, folderPath, filePath)));
   }
 
   @Override

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/impl/GitEntityServiceImpl.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/impl/GitEntityServiceImpl.java
@@ -265,6 +265,25 @@ public class GitEntityServiceImpl implements GitEntityService {
   }
 
   @Override
+  public GitSyncEntityDTO get(
+      EntityReference entityReference, EntityType entityType, String branch, String folderPath, String filePath) {
+    Optional<GitFileLocation> gitFileLocation;
+    String completeFilePath = GitSyncFilePathUtils.createFilePath(folderPath, filePath);
+    gitFileLocation =
+        gitFileLocationRepository.findByEntityIdentifierFQNAndEntityTypeAndAccountIdAndBranchAndCompleteGitPath(
+            entityReference.getFullyQualifiedName(), entityType.name(), entityReference.getAccountIdentifier(), branch,
+            completeFilePath);
+    if (!gitFileLocation.isPresent()) {
+      // try with complete path without forward slash
+      gitFileLocation =
+          gitFileLocationRepository.findByEntityIdentifierFQNAndEntityTypeAndAccountIdAndBranchAndCompleteGitPath(
+              entityReference.getFullyQualifiedName(), entityType.name(), entityReference.getAccountIdentifier(),
+              branch, completeFilePath.substring(1));
+    }
+    return gitFileLocation.map(this::buildGitSyncEntityDTO).orElse(null);
+  }
+
+  @Override
   public boolean save(String accountId, EntityDetail entityDetail, YamlGitConfigDTO yamlGitConfig, String folderPath,
       String filePath, String commitId, String branchName) {
     final Optional<GitFileLocation> gitFileLocation =

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/impl/HarnessToGitHelperServiceImpl.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/impl/HarnessToGitHelperServiceImpl.java
@@ -365,8 +365,8 @@ public class HarnessToGitHelperServiceImpl implements HarnessToGitHelperService 
     if (isEmpty(lastCommitIdForFile) && request.getChangeType() != ChangeType.ADD) {
       // If its saveToNewBranch use-case, then we choose base branch for existing entity commit
       String branch = request.getIsNewBranch() ? request.getBaseBranch().getValue() : request.getBranch();
-      GitSyncEntityDTO gitSyncEntityDTO =
-          gitEntityService.get(entityDetailDTO.getEntityRef(), entityDetailDTO.getType(), branch);
+      GitSyncEntityDTO gitSyncEntityDTO = gitEntityService.get(entityDetailDTO.getEntityRef(),
+          entityDetailDTO.getType(), branch, request.getFolderPath(), request.getFilePath());
       lastCommitIdForFile = gitSyncEntityDTO.getLastCommitId();
     }
     return lastCommitIdForFile;

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/service/GitEntityService.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/service/GitEntityService.java
@@ -36,6 +36,9 @@ public interface GitEntityService {
 
   GitSyncEntityDTO get(EntityReference entityReference, EntityType entityType, String branch);
 
+  GitSyncEntityDTO get(
+      EntityReference entityReference, EntityType entityType, String branch, String folderPath, String filePath);
+
   boolean save(String accountId, EntityDetail entityDetail, YamlGitConfigDTO yamlGitConfig, String folderPath,
       String filePath, String commitId, String branchName);
 

--- a/136-git-sync-manager/src/main/java/io/harness/repositories/gitFileLocation/GitFileLocationRepository.java
+++ b/136-git-sync-manager/src/main/java/io/harness/repositories/gitFileLocation/GitFileLocationRepository.java
@@ -27,6 +27,9 @@ public interface GitFileLocationRepository
   Optional<GitFileLocation> findByEntityIdentifierFQNAndEntityTypeAndAccountIdAndBranch(
       String fqn, String entityType, String accountId, String branch);
 
+  Optional<GitFileLocation> findByEntityIdentifierFQNAndEntityTypeAndAccountIdAndBranchAndCompleteGitPath(
+      String fqn, String entityType, String accountId, String branch, String completeGitPath);
+
   Optional<GitFileLocation> findByEntityGitPathAndGitSyncConfigIdAndAccountIdAndBranch(
       String entityGitPath, String gitSyncConfigId, String accountId, String branch);
 

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/common/impl/HarnessToGitHelperServiceImplTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/common/impl/HarnessToGitHelperServiceImplTest.java
@@ -79,10 +79,10 @@ public class HarnessToGitHelperServiceImplTest extends GitSyncTestBase {
   @Category(UnitTests.class)
   public void testFetchLastCommitIdForFileUpdateCase() {
     ArgumentCaptor<String> branchArgumentCaptor = ArgumentCaptor.forClass(String.class);
-    when(gitEntityService.get(any(), any(), any())).thenReturn(getGitSyncEntityDTODefault());
+    when(gitEntityService.get(any(), any(), any(), any(), any())).thenReturn(getGitSyncEntityDTODefault());
     String lastCommitId = harnessToGitHelperService.fetchLastCommitIdForFile(
         getFileInfoDefault("", ChangeType.MODIFY), getEntityDetailDefault());
-    verify(gitEntityService, times(1)).get(any(), any(), branchArgumentCaptor.capture());
+    verify(gitEntityService, times(1)).get(any(), any(), branchArgumentCaptor.capture(), any(), any());
     assertThat(branchArgumentCaptor.getValue()).isEqualTo(branch);
     assertThat(lastCommitId).isEqualTo(commitId);
   }
@@ -92,10 +92,10 @@ public class HarnessToGitHelperServiceImplTest extends GitSyncTestBase {
   @Category(UnitTests.class)
   public void testFetchLastCommitIdForFileUpdateToNewBranchCase() {
     ArgumentCaptor<String> branchArgumentCaptor = ArgumentCaptor.forClass(String.class);
-    when(gitEntityService.get(any(), any(), any())).thenReturn(getGitSyncEntityDTODefault());
+    when(gitEntityService.get(any(), any(), any(), any(), any())).thenReturn(getGitSyncEntityDTODefault());
     String lastCommitId = harnessToGitHelperService.fetchLastCommitIdForFile(
         getFileInfoDefault("", ChangeType.MODIFY, true), getEntityDetailDefault());
-    verify(gitEntityService, times(1)).get(any(), any(), branchArgumentCaptor.capture());
+    verify(gitEntityService, times(1)).get(any(), any(), branchArgumentCaptor.capture(), any(), any());
     assertThat(branchArgumentCaptor.getValue()).isEqualTo(baseBranch);
     assertThat(lastCommitId).isEqualTo(commitId);
   }


### PR DESCRIPTION


You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31661)
<!-- Reviewable:end -->
