### PR TITLE
feat: [DEL-3455]: Convert delegateSelector to type TaskSelectorYaml

### DIFF
--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformApplyBaseStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformApplyBaseStepInfo.java
@@ -12,6 +12,7 @@ import static io.harness.yaml.schema.beans.SupportedPossibleFieldTypes.runtime;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.yaml.YamlSchemaTypes;
 
@@ -34,5 +35,5 @@ public class TerraformApplyBaseStepInfo {
   private ParameterField<String> provisionerIdentifier;
   @YamlSchemaTypes(value = {runtime})
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
-  private ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformApplyStep.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformApplyStep.java
@@ -163,7 +163,8 @@ public class TerraformApplyStep extends TaskExecutableWithRollbackAndRbac<Terraf
 
     return StepUtils.prepareCDTaskRequest(ambiance, taskData, kryoSerializer,
         Collections.singletonList(TerraformCommandUnit.Apply.name()), TaskType.TERRAFORM_TASK_NG.getDisplayName(),
-        StepUtils.getTaskSelectors(stepParameters.getDelegateSelectors()), stepHelper.getEnvironmentType(ambiance));
+        StepUtils.getTaskSelectorsFromYaml(stepParameters.getDelegateSelectors()),
+        stepHelper.getEnvironmentType(ambiance));
   }
 
   private TaskRequest obtainInheritedTask(
@@ -205,7 +206,8 @@ public class TerraformApplyStep extends TaskExecutableWithRollbackAndRbac<Terraf
 
     return StepUtils.prepareCDTaskRequest(ambiance, taskData, kryoSerializer,
         Collections.singletonList(TerraformCommandUnit.Apply.name()), TaskType.TERRAFORM_TASK_NG.getDisplayName(),
-        StepUtils.getTaskSelectors(stepParameters.getDelegateSelectors()), stepHelper.getEnvironmentType(ambiance));
+        StepUtils.getTaskSelectorsFromYaml(stepParameters.getDelegateSelectors()),
+        stepHelper.getEnvironmentType(ambiance));
   }
 
   @Override

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformApplyStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformApplyStepInfo.java
@@ -14,6 +14,7 @@ import io.harness.cdng.pipeline.CDStepInfo;
 import io.harness.data.structure.EmptyPredicate;
 import io.harness.executions.steps.StepSpecTypeConstants;
 import io.harness.filters.WithConnectorRef;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.contracts.steps.StepType;
 import io.harness.pms.execution.OrchestrationFacilitatorType;
@@ -50,7 +51,7 @@ public class TerraformApplyStepInfo
 
   @Builder(builderMethodName = "infoBuilder")
   public TerraformApplyStepInfo(ParameterField<String> provisionerIdentifier,
-      ParameterField<List<String>> delegateSelectors, TerraformStepConfiguration terraformStepConfiguration) {
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors, TerraformStepConfiguration terraformStepConfiguration) {
     super(provisionerIdentifier, delegateSelectors);
     this.terraformStepConfiguration = terraformStepConfiguration;
   }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformApplyStepParameters.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformApplyStepParameters.java
@@ -11,6 +11,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDP;
 
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.yaml.ParameterField;
 
@@ -33,7 +34,8 @@ public class TerraformApplyStepParameters extends TerraformApplyBaseStepInfo imp
 
   @Builder(builderMethodName = "infoBuilder")
   public TerraformApplyStepParameters(ParameterField<String> provisionerIdentifier,
-      ParameterField<List<String>> delegateSelectors, @NonNull TerraformStepConfigurationParameters configuration) {
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors,
+      @NonNull TerraformStepConfigurationParameters configuration) {
     super(provisionerIdentifier, delegateSelectors);
     this.configuration = configuration;
   }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformDestroyBaseStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformDestroyBaseStepInfo.java
@@ -12,6 +12,7 @@ import static io.harness.yaml.schema.beans.SupportedPossibleFieldTypes.runtime;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.yaml.YamlSchemaTypes;
 
@@ -32,5 +33,5 @@ public class TerraformDestroyBaseStepInfo {
   @NotNull @ApiModelProperty(dataType = SwaggerConstants.STRING_CLASSPATH) ParameterField<String> provisionerIdentifier;
   @YamlSchemaTypes(value = {runtime})
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformDestroyStep.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformDestroyStep.java
@@ -164,7 +164,7 @@ public class TerraformDestroyStep extends TaskExecutableWithRollbackAndRbac<Terr
 
     return StepUtils.prepareCDTaskRequest(ambiance, taskData, kryoSerializer,
         Collections.singletonList(TerraformCommandUnit.Destroy.name()), TaskType.TERRAFORM_TASK_NG.getDisplayName(),
-        StepUtils.getTaskSelectors(parameters.getDelegateSelectors()), stepHelper.getEnvironmentType(ambiance));
+        StepUtils.getTaskSelectorsFromYaml(parameters.getDelegateSelectors()), stepHelper.getEnvironmentType(ambiance));
   }
 
   private TaskRequest obtainInheritedTask(
@@ -206,7 +206,7 @@ public class TerraformDestroyStep extends TaskExecutableWithRollbackAndRbac<Terr
 
     return StepUtils.prepareCDTaskRequest(ambiance, taskData, kryoSerializer,
         Collections.singletonList(TerraformCommandUnit.Destroy.name()), TaskType.TERRAFORM_TASK_NG.getDisplayName(),
-        StepUtils.getTaskSelectors(parameters.getDelegateSelectors()), stepHelper.getEnvironmentType(ambiance));
+        StepUtils.getTaskSelectorsFromYaml(parameters.getDelegateSelectors()), stepHelper.getEnvironmentType(ambiance));
   }
 
   private TaskRequest obtainLastApplyTask(
@@ -249,7 +249,7 @@ public class TerraformDestroyStep extends TaskExecutableWithRollbackAndRbac<Terr
 
     return StepUtils.prepareCDTaskRequest(ambiance, taskData, kryoSerializer,
         Collections.singletonList(TerraformCommandUnit.Destroy.name()), TaskType.TERRAFORM_TASK_NG.getDisplayName(),
-        StepUtils.getTaskSelectors(parameters.getDelegateSelectors()), stepHelper.getEnvironmentType(ambiance));
+        StepUtils.getTaskSelectorsFromYaml(parameters.getDelegateSelectors()), stepHelper.getEnvironmentType(ambiance));
   }
 
   @Override

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformDestroyStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformDestroyStepInfo.java
@@ -14,6 +14,7 @@ import io.harness.cdng.pipeline.CDStepInfo;
 import io.harness.data.structure.EmptyPredicate;
 import io.harness.executions.steps.StepSpecTypeConstants;
 import io.harness.filters.WithConnectorRef;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.contracts.steps.StepType;
 import io.harness.pms.execution.OrchestrationFacilitatorType;
@@ -50,7 +51,7 @@ public class TerraformDestroyStepInfo
 
   @Builder(builderMethodName = "infoBuilder")
   public TerraformDestroyStepInfo(ParameterField<String> provisionerIdentifier,
-      ParameterField<List<String>> delegateSelectors, TerraformStepConfiguration terraformStepConfiguration) {
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors, TerraformStepConfiguration terraformStepConfiguration) {
     super(provisionerIdentifier, delegateSelectors);
     this.terraformStepConfiguration = terraformStepConfiguration;
   }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformDestroyStepParameters.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformDestroyStepParameters.java
@@ -10,6 +10,7 @@ package io.harness.cdng.provision.terraform;
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.yaml.ParameterField;
 
@@ -32,7 +33,8 @@ public class TerraformDestroyStepParameters extends TerraformDestroyBaseStepInfo
 
   @Builder(builderMethodName = "infoBuilder")
   public TerraformDestroyStepParameters(ParameterField<String> provisionerIdentifier,
-      ParameterField<List<String>> delegateSelectors, @NonNull TerraformStepConfigurationParameters configuration) {
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors,
+      @NonNull TerraformStepConfigurationParameters configuration) {
     super(provisionerIdentifier, delegateSelectors);
     this.configuration = configuration;
   }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformPlanBaseStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformPlanBaseStepInfo.java
@@ -12,6 +12,7 @@ import static io.harness.yaml.schema.beans.SupportedPossibleFieldTypes.runtime;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.yaml.YamlSchemaTypes;
 
@@ -30,5 +31,5 @@ public class TerraformPlanBaseStepInfo {
   @NotNull @ApiModelProperty(dataType = SwaggerConstants.STRING_CLASSPATH) ParameterField<String> provisionerIdentifier;
   @YamlSchemaTypes(value = {runtime})
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformPlanStep.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformPlanStep.java
@@ -149,7 +149,8 @@ public class TerraformPlanStep extends TaskExecutableWithRollbackAndRbac<Terrafo
 
     return StepUtils.prepareCDTaskRequest(ambiance, taskData, kryoSerializer,
         Collections.singletonList(TerraformCommandUnit.Plan.name()), TaskType.TERRAFORM_TASK_NG.getDisplayName(),
-        StepUtils.getTaskSelectors(planStepParameters.getDelegateSelectors()), stepHelper.getEnvironmentType(ambiance));
+        StepUtils.getTaskSelectorsFromYaml(planStepParameters.getDelegateSelectors()),
+        stepHelper.getEnvironmentType(ambiance));
   }
 
   @Override

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformPlanStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformPlanStepInfo.java
@@ -14,6 +14,7 @@ import io.harness.cdng.pipeline.CDStepInfo;
 import io.harness.data.structure.EmptyPredicate;
 import io.harness.executions.steps.StepSpecTypeConstants;
 import io.harness.filters.WithConnectorRef;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.contracts.steps.StepType;
 import io.harness.pms.execution.OrchestrationFacilitatorType;
@@ -46,7 +47,7 @@ public class TerraformPlanStepInfo extends TerraformPlanBaseStepInfo implements 
 
   @Builder(builderMethodName = "infoBuilder")
   public TerraformPlanStepInfo(ParameterField<String> provisionerIdentifier,
-      ParameterField<List<String>> delegateSelectors, TerraformPlanExecutionData terraformPlanExecutionData) {
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors, TerraformPlanExecutionData terraformPlanExecutionData) {
     super(provisionerIdentifier, delegateSelectors);
     this.terraformPlanExecutionData = terraformPlanExecutionData;
   }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformPlanStepParameters.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformPlanStepParameters.java
@@ -10,6 +10,7 @@ package io.harness.cdng.provision.terraform;
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.yaml.ParameterField;
 
@@ -31,7 +32,7 @@ public class TerraformPlanStepParameters extends TerraformPlanBaseStepInfo imple
 
   @Builder(builderMethodName = "infoBuilder")
   public TerraformPlanStepParameters(ParameterField<String> provisionerIdentifier,
-      ParameterField<List<String>> delegateSelectors, TerraformPlanExecutionDataParameters configuration) {
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors, TerraformPlanExecutionDataParameters configuration) {
     super(provisionerIdentifier, delegateSelectors);
     this.configuration = configuration;
   }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/steps/rolllback/TerraformRollbackStep.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/steps/rolllback/TerraformRollbackStep.java
@@ -30,6 +30,7 @@ import io.harness.expression.ExpressionEvaluatorUtils;
 import io.harness.logging.CommandExecutionStatus;
 import io.harness.logging.UnitProgress;
 import io.harness.persistence.HIterator;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.StepElementParameters;
 import io.harness.plancreator.steps.common.rollback.TaskExecutableWithRollbackAndRbac;
 import io.harness.pms.contracts.ambiance.Ambiance;
@@ -164,9 +165,9 @@ public class TerraformRollbackStep extends TaskExecutableWithRollbackAndRbac<Ter
               .parameters(new Object[] {builder.build()})
               .build();
 
-      ParameterField<List<String>> delegateSelectors = stepParametersSpec.getDelegateSelectors();
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors = stepParametersSpec.getDelegateSelectors();
 
-      List<TaskSelector> taskSelectors = StepUtils.getTaskSelectors(delegateSelectors);
+      List<TaskSelector> taskSelectors = StepUtils.getTaskSelectorsFromYaml(delegateSelectors);
 
       return StepUtils.prepareCDTaskRequest(ambiance, taskData, kryoSerializer,
           Collections.singletonList(TerraformCommandUnit.Rollback.name()), TaskType.TERRAFORM_TASK_NG.getDisplayName(),

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/steps/rolllback/TerraformRollbackStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/steps/rolllback/TerraformRollbackStepInfo.java
@@ -15,6 +15,7 @@ import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
 import io.harness.cdng.pipeline.CDStepInfo;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.contracts.steps.StepType;
 import io.harness.pms.execution.OrchestrationFacilitatorType;
@@ -40,7 +41,7 @@ public class TerraformRollbackStepInfo implements CDStepInfo {
   @NotNull String provisionerIdentifier;
   @YamlSchemaTypes(value = {runtime})
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 
   @Override
   public StepType getStepType() {

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/steps/rolllback/TerraformRollbackStepParameters.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/steps/rolllback/TerraformRollbackStepParameters.java
@@ -11,6 +11,7 @@ import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.yaml.ParameterField;
 
@@ -34,5 +35,6 @@ import org.springframework.data.annotation.TypeAlias;
 @RecasterAlias("io.harness.cdng.provision.terraform.steps.rolllback.TerraformRollbackStepParameters")
 public class TerraformRollbackStepParameters implements SpecParameters {
   @NotNull String provisionerIdentifier;
-  @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH) ParameterField<List<String>> delegateSelectors;
+  @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 }

--- a/800-pipeline-service/src/main/java/io/harness/pms/approval/jira/JiraApprovalHelperServiceImpl.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/approval/jira/JiraApprovalHelperServiceImpl.java
@@ -35,6 +35,7 @@ import io.harness.logstreaming.LogStreamingStepClientFactory;
 import io.harness.logstreaming.NGLogCallback;
 import io.harness.ng.core.BaseNGAccess;
 import io.harness.ng.core.NGAccessWithEncryptionConsumer;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.pms.contracts.ambiance.Ambiance;
 import io.harness.pms.contracts.execution.tasks.TaskRequest;
 import io.harness.pms.execution.utils.AmbianceUtils;
@@ -147,7 +148,8 @@ public class JiraApprovalHelperServiceImpl implements JiraApprovalHelperService 
   }
 
   private JiraTaskNGParameters prepareJiraTaskParameters(String accountIdentifier, String orgIdentifier,
-      String projectIdentifier, String issueId, String connectorRef, ParameterField<List<String>> delegateSelectors) {
+      String projectIdentifier, String issueId, String connectorRef,
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors) {
     JiraConnectorDTO jiraConnectorDTO =
         getJiraConnector(accountIdentifier, orgIdentifier, projectIdentifier, connectorRef);
     BaseNGAccess baseNGAccess = BaseNGAccess.builder()
@@ -166,7 +168,7 @@ public class JiraApprovalHelperServiceImpl implements JiraApprovalHelperService 
         .encryptionDetails(encryptionDataDetails)
         .jiraConnectorDTO(jiraConnectorDTO)
         .issueKey(issueId)
-        .delegateSelectors(StepUtils.getDelegateSelectorList(delegateSelectors))
+        .delegateSelectors(StepUtils.getDelegateSelectorListFromTaskSelectorYaml(delegateSelectors))
         .build();
   }
 

--- a/800-pipeline-service/src/main/java/io/harness/pms/approval/servicenow/ServiceNowApprovalHelperServiceImpl.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/approval/servicenow/ServiceNowApprovalHelperServiceImpl.java
@@ -38,6 +38,7 @@ import io.harness.logstreaming.LogStreamingStepClientFactory;
 import io.harness.logstreaming.NGLogCallback;
 import io.harness.ng.core.BaseNGAccess;
 import io.harness.ng.core.NGAccessWithEncryptionConsumer;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.pms.contracts.ambiance.Ambiance;
 import io.harness.pms.contracts.execution.tasks.TaskRequest;
 import io.harness.pms.execution.utils.AmbianceUtils;
@@ -182,7 +183,7 @@ public class ServiceNowApprovalHelperServiceImpl implements ServiceNowApprovalHe
 
   private ServiceNowTaskNGParameters prepareServiceNowTaskParameters(String accountIdentifier, String orgIdentifier,
       String projectIdentifier, String ticketNumber, String connectorRef,
-      ParameterField<List<String>> delegateSelectors, String ticketType) {
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors, String ticketType) {
     ServiceNowConnectorDTO serviceNowConnector =
         getServiceNowConnector(accountIdentifier, orgIdentifier, projectIdentifier, connectorRef);
     BaseNGAccess baseNGAccess = BaseNGAccess.builder()
@@ -202,7 +203,7 @@ public class ServiceNowApprovalHelperServiceImpl implements ServiceNowApprovalHe
         .serviceNowConnectorDTO(serviceNowConnector)
         .ticketNumber(ticketNumber)
         .ticketType(ticketType)
-        .delegateSelectors(StepUtils.getDelegateSelectorList(delegateSelectors))
+        .delegateSelectors(StepUtils.getDelegateSelectorListFromTaskSelectorYaml(delegateSelectors))
         .build();
   }
 

--- a/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/jira/JiraApprovalSpecParameters.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/jira/JiraApprovalSpecParameters.java
@@ -11,6 +11,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDC;
 
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.steps.approval.step.beans.CriteriaSpecWrapper;
@@ -34,5 +35,5 @@ public class JiraApprovalSpecParameters implements SpecParameters {
   @NotNull ParameterField<String> issueKey;
   @NotNull CriteriaSpecWrapper approvalCriteria;
   CriteriaSpecWrapper rejectionCriteria;
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/jira/JiraApprovalStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/jira/JiraApprovalStepInfo.java
@@ -14,6 +14,7 @@ import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
 import io.harness.filters.WithConnectorRef;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.plancreator.steps.internal.PMSStepInfo;
 import io.harness.pms.contracts.steps.StepType;
@@ -51,7 +52,7 @@ public class JiraApprovalStepInfo implements PMSStepInfo, WithConnectorRef {
 
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
   @YamlSchemaTypes(value = {runtime})
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 
   @Override
   public StepType getStepType() {

--- a/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/jira/entities/JiraApprovalInstance.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/jira/entities/JiraApprovalInstance.java
@@ -13,6 +13,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.exception.InvalidRequestException;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.StepElementParameters;
 import io.harness.pms.contracts.ambiance.Ambiance;
 import io.harness.pms.yaml.ParameterField;
@@ -45,7 +46,7 @@ public class JiraApprovalInstance extends ApprovalInstance {
   @NotEmpty String issueKey;
   @NotNull CriteriaSpecWrapperDTO approvalCriteria;
   CriteriaSpecWrapperDTO rejectionCriteria;
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 
   public static JiraApprovalInstance fromStepParameters(Ambiance ambiance, StepElementParameters stepParameters) {
     if (stepParameters == null) {

--- a/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/servicenow/ServiceNowApprovalSpecParameters.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/servicenow/ServiceNowApprovalSpecParameters.java
@@ -11,6 +11,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDC;
 
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.steps.approval.step.beans.CriteriaSpecWrapper;
@@ -35,5 +36,5 @@ public class ServiceNowApprovalSpecParameters implements SpecParameters {
   @NotNull ParameterField<String> ticketType;
   @NotNull CriteriaSpecWrapper approvalCriteria;
   CriteriaSpecWrapper rejectionCriteria;
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/servicenow/ServiceNowApprovalStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/servicenow/ServiceNowApprovalStepInfo.java
@@ -14,6 +14,7 @@ import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
 import io.harness.filters.WithConnectorRef;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.plancreator.steps.internal.PMSStepInfo;
 import io.harness.pms.contracts.steps.StepType;
@@ -52,7 +53,7 @@ public class ServiceNowApprovalStepInfo implements PMSStepInfo, WithConnectorRef
 
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
   @YamlSchemaTypes(value = {runtime})
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 
   @Override
   public StepType getStepType() {

--- a/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/servicenow/entities/ServiceNowApprovalInstance.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/servicenow/entities/ServiceNowApprovalInstance.java
@@ -13,6 +13,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.exception.InvalidRequestException;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.StepElementParameters;
 import io.harness.pms.contracts.ambiance.Ambiance;
 import io.harness.pms.yaml.ParameterField;
@@ -46,7 +47,7 @@ public class ServiceNowApprovalInstance extends ApprovalInstance {
   @NotEmpty String ticketType;
   @NotNull CriteriaSpecWrapperDTO approvalCriteria;
   CriteriaSpecWrapperDTO rejectionCriteria;
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 
   public static ServiceNowApprovalInstance fromStepParameters(Ambiance ambiance, StepElementParameters stepParameters) {
     if (stepParameters == null) {

--- a/860-orchestration-steps/src/main/java/io/harness/steps/jira/create/JiraCreateSpecParameters.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/jira/create/JiraCreateSpecParameters.java
@@ -11,6 +11,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDC;
 
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.yaml.ParameterField;
 
@@ -35,5 +36,5 @@ public class JiraCreateSpecParameters implements SpecParameters {
   @NotEmpty ParameterField<String> issueType;
 
   Map<String, ParameterField<String>> fields;
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/jira/create/JiraCreateStep.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/jira/create/JiraCreateStep.java
@@ -70,7 +70,8 @@ public class JiraCreateStep extends TaskExecutableWithRollbackAndRbac<JiraTaskNG
             .action(JiraActionNG.CREATE_ISSUE)
             .projectKey(specParameters.getProjectKey().getValue())
             .issueType(specParameters.getIssueType().getValue())
-            .delegateSelectors(StepUtils.getDelegateSelectorList(specParameters.getDelegateSelectors()))
+            .delegateSelectors(
+                StepUtils.getDelegateSelectorListFromTaskSelectorYaml(specParameters.getDelegateSelectors()))
             .fields(JiraStepUtils.processJiraFieldsInParameters(specParameters.getFields()));
     return jiraStepHelperService.prepareTaskRequest(paramsBuilder, ambiance,
         specParameters.getConnectorRef().getValue(), stepParameters.getTimeout().getValue(), "Jira Task: Create Issue");

--- a/860-orchestration-steps/src/main/java/io/harness/steps/jira/create/JiraCreateStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/jira/create/JiraCreateStepInfo.java
@@ -14,6 +14,7 @@ import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
 import io.harness.filters.WithConnectorRef;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.plancreator.steps.internal.PMSStepInfo;
 import io.harness.pms.contracts.steps.StepType;
@@ -53,7 +54,7 @@ public class JiraCreateStepInfo implements PMSStepInfo, WithConnectorRef {
 
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
   @YamlSchemaTypes(value = {runtime})
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 
   @Override
   public StepType getStepType() {

--- a/860-orchestration-steps/src/main/java/io/harness/steps/jira/update/JiraUpdateSpecParameters.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/jira/update/JiraUpdateSpecParameters.java
@@ -11,6 +11,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDC;
 
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.steps.jira.update.beans.TransitionTo;
@@ -36,5 +37,5 @@ public class JiraUpdateSpecParameters implements SpecParameters {
 
   TransitionTo transitionTo;
   Map<String, ParameterField<String>> fields;
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/jira/update/JiraUpdateStep.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/jira/update/JiraUpdateStep.java
@@ -76,7 +76,8 @@ public class JiraUpdateStep extends TaskExecutableWithRollbackAndRbac<JiraTaskNG
                     ? null
                     : (String) specParameters.getTransitionTo().getTransitionName().fetchFinalValue())
             .fields(JiraStepUtils.processJiraFieldsInParameters(specParameters.getFields()))
-            .delegateSelectors(StepUtils.getDelegateSelectorList(specParameters.getDelegateSelectors()));
+            .delegateSelectors(
+                StepUtils.getDelegateSelectorListFromTaskSelectorYaml(specParameters.getDelegateSelectors()));
     return jiraStepHelperService.prepareTaskRequest(paramsBuilder, ambiance,
         specParameters.getConnectorRef().getValue(), stepParameters.getTimeout().getValue(), "Jira Task: Update Issue");
   }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/jira/update/JiraUpdateStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/jira/update/JiraUpdateStepInfo.java
@@ -14,6 +14,7 @@ import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
 import io.harness.filters.WithConnectorRef;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.plancreator.steps.internal.PMSStepInfo;
 import io.harness.pms.contracts.steps.StepType;
@@ -54,7 +55,7 @@ public class JiraUpdateStepInfo implements PMSStepInfo, WithConnectorRef {
 
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
   @YamlSchemaTypes(value = {runtime})
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 
   @Override
   public StepType getStepType() {

--- a/860-orchestration-steps/src/main/java/io/harness/steps/servicenow/create/ServiceNowCreateSpecParameters.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/servicenow/create/ServiceNowCreateSpecParameters.java
@@ -11,6 +11,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDC;
 
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.yaml.ParameterField;
 
@@ -35,5 +36,5 @@ public class ServiceNowCreateSpecParameters implements SpecParameters {
 
   Map<String, ParameterField<String>> fields;
 
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/servicenow/create/ServiceNowCreateStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/servicenow/create/ServiceNowCreateStepInfo.java
@@ -14,6 +14,7 @@ import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
 import io.harness.filters.WithConnectorRef;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.plancreator.steps.internal.PMSStepInfo;
 import io.harness.pms.contracts.steps.StepType;
@@ -52,7 +53,7 @@ public class ServiceNowCreateStepInfo implements PMSStepInfo, WithConnectorRef {
 
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
   @YamlSchemaTypes(value = {runtime})
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 
   @Override
   public StepType getStepType() {

--- a/860-orchestration-steps/src/main/java/io/harness/steps/servicenow/update/ServiceNowUpdateSpecParameters.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/servicenow/update/ServiceNowUpdateSpecParameters.java
@@ -11,6 +11,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDC;
 
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.pms.yaml.ParameterField;
 
@@ -34,5 +35,5 @@ public class ServiceNowUpdateSpecParameters implements SpecParameters {
   @NotNull ParameterField<String> ticketType;
   @NotNull ParameterField<String> ticketNumber;
   Map<String, ParameterField<String>> fields;
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/servicenow/update/ServiceNowUpdateStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/servicenow/update/ServiceNowUpdateStepInfo.java
@@ -14,6 +14,7 @@ import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
 import io.harness.filters.WithConnectorRef;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.plancreator.steps.common.SpecParameters;
 import io.harness.plancreator.steps.internal.PMSStepInfo;
 import io.harness.pms.contracts.steps.StepType;
@@ -54,7 +55,7 @@ public class ServiceNowUpdateStepInfo implements PMSStepInfo, WithConnectorRef {
 
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
   @YamlSchemaTypes(value = {runtime})
-  ParameterField<List<String>> delegateSelectors;
+  ParameterField<List<TaskSelectorYaml>> delegateSelectors;
 
   @Override
   public StepType getStepType() {

--- a/878-ng-common-utilities/src/main/java/io/harness/steps/StepUtils.java
+++ b/878-ng-common-utilities/src/main/java/io/harness/steps/StepUtils.java
@@ -39,6 +39,7 @@ import io.harness.exception.InvalidRequestException;
 import io.harness.exception.WingsException;
 import io.harness.logging.CommandExecutionStatus;
 import io.harness.logstreaming.LogStreamingHelper;
+import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.pms.contracts.ambiance.Ambiance;
 import io.harness.pms.contracts.ambiance.Level;
 import io.harness.pms.contracts.execution.Status;
@@ -66,6 +67,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.apache.commons.collections4.ListUtils;
 
@@ -364,6 +366,24 @@ public class StepUtils {
       return new ArrayList<>();
     }
     return delegateSelectors.getValue();
+  }
+
+  public static List<String> getDelegateSelectorListFromTaskSelectorYaml(
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors) {
+    if (ParameterField.isNull(delegateSelectors) || delegateSelectors.getValue() == null) {
+      return new ArrayList<>();
+    }
+    return delegateSelectors.getValue()
+        .stream()
+        .map(TaskSelectorYaml::getDelegateSelectors)
+        .collect(Collectors.toList());
+  }
+
+  public static List<TaskSelector> getTaskSelectorsFromYaml(ParameterField<List<TaskSelectorYaml>> delegateSelectors) {
+    return getDelegateSelectorListFromTaskSelectorYaml(delegateSelectors)
+        .stream()
+        .map(delegateSelector -> TaskSelector.newBuilder().setSelector(delegateSelector).build())
+        .collect(toList());
   }
 
   public static Status getStepStatus(CommandExecutionStatus commandExecutionStatus) {


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
