### PR TITLE
fix: [CI-3895]: allow secret in user name env variables

### DIFF
--- a/320-ci-execution/src/main/java/io/harness/ci/plan/creator/filter/CIStageFilterJsonCreator.java
+++ b/320-ci-execution/src/main/java/io/harness/ci/plan/creator/filter/CIStageFilterJsonCreator.java
@@ -146,8 +146,7 @@ public class CIStageFilterJsonCreator extends GenericStageFilterJsonCreator {
           + YAMLFieldNameConstants.SPEC + PATH_CONNECTOR + ciCodeBase.getConnectorRef();
 
       result.add(convertToEntityDetailProtoDTO(accountIdentifier, orgIdentifier, projectIdentifier,
-          fullQualifiedDomainName,ciCodeBase.getConnectorRef(),
-          EntityTypeProtoEnum.CONNECTORS));
+          fullQualifiedDomainName, ciCodeBase.getConnectorRef(), EntityTypeProtoEnum.CONNECTORS));
     }
 
     IntegrationStageConfig integrationStage = (IntegrationStageConfig) stageElementConfig.getStageType();

--- a/320-ci-execution/src/main/java/io/harness/ci/plan/creator/filter/CIStageFilterJsonCreator.java
+++ b/320-ci-execution/src/main/java/io/harness/ci/plan/creator/filter/CIStageFilterJsonCreator.java
@@ -146,7 +146,7 @@ public class CIStageFilterJsonCreator extends GenericStageFilterJsonCreator {
           + YAMLFieldNameConstants.SPEC + PATH_CONNECTOR + ciCodeBase.getConnectorRef();
 
       result.add(convertToEntityDetailProtoDTO(accountIdentifier, orgIdentifier, projectIdentifier,
-          fullQualifiedDomainName, ParameterField.createValueField(ciCodeBase.getConnectorRef().getValue()),
+          fullQualifiedDomainName,ciCodeBase.getConnectorRef(),
           EntityTypeProtoEnum.CONNECTORS));
     }
 

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/citasks/cik8handler/helper/ConnectorEnvVariablesHelper.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/citasks/cik8handler/helper/ConnectorEnvVariablesHelper.java
@@ -66,10 +66,13 @@ public class ConnectorEnvVariablesHelper {
       String usernameEnvVarName = connectorDetails.getEnvToSecretsMap().get(EnvVariableEnum.ARTIFACTORY_USERNAME);
       String passwordEnvVarName = connectorDetails.getEnvToSecretsMap().get(EnvVariableEnum.ARTIFACTORY_PASSWORD);
       String endpointEnvVarName = connectorDetails.getEnvToSecretsMap().get(EnvVariableEnum.ARTIFACTORY_ENDPOINT);
+      String userName = FieldWithPlainTextOrSecretValueHelper.getSecretAsStringFromPlainTextOrSecretRef(
+              usernamePasswordAuthDTO.getUsername(), usernamePasswordAuthDTO.getUsernameRef());
+
       if (isNotBlank(usernameEnvVarName)) {
         secretData.put(usernameEnvVarName,
             getVariableSecret(usernameEnvVarName + connectorDetails.getIdentifier(),
-                encodeBase64(usernamePasswordAuthDTO.getUsername())));
+                encodeBase64(userName)));
       }
 
       if (usernamePasswordAuthDTO == null || usernamePasswordAuthDTO.getPasswordRef() == null
@@ -197,9 +200,11 @@ public class ConnectorEnvVariablesHelper {
       String usernameEnvVarName = connectorDetails.getEnvToSecretsMap().get(EnvVariableEnum.DOCKER_USERNAME);
       String passwordEnvVarName = connectorDetails.getEnvToSecretsMap().get(EnvVariableEnum.DOCKER_PASSWORD);
       if (isNotBlank(usernameEnvVarName)) {
+        String userName = FieldWithPlainTextOrSecretValueHelper.getSecretAsStringFromPlainTextOrSecretRef(
+                dockerUserNamePasswordDTO.getUsername(), dockerUserNamePasswordDTO.getUsernameRef());
         secretData.put(usernameEnvVarName,
             getVariableSecret(usernameEnvVarName + connectorDetails.getIdentifier(),
-                encodeBase64(dockerUserNamePasswordDTO.getUsername())));
+                encodeBase64(userName)));
       }
 
       if (dockerUserNamePasswordDTO == null || dockerUserNamePasswordDTO.getPasswordRef() == null

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/citasks/cik8handler/helper/ConnectorEnvVariablesHelper.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/citasks/cik8handler/helper/ConnectorEnvVariablesHelper.java
@@ -67,12 +67,11 @@ public class ConnectorEnvVariablesHelper {
       String passwordEnvVarName = connectorDetails.getEnvToSecretsMap().get(EnvVariableEnum.ARTIFACTORY_PASSWORD);
       String endpointEnvVarName = connectorDetails.getEnvToSecretsMap().get(EnvVariableEnum.ARTIFACTORY_ENDPOINT);
       String userName = FieldWithPlainTextOrSecretValueHelper.getSecretAsStringFromPlainTextOrSecretRef(
-              usernamePasswordAuthDTO.getUsername(), usernamePasswordAuthDTO.getUsernameRef());
+          usernamePasswordAuthDTO.getUsername(), usernamePasswordAuthDTO.getUsernameRef());
 
       if (isNotBlank(usernameEnvVarName)) {
         secretData.put(usernameEnvVarName,
-            getVariableSecret(usernameEnvVarName + connectorDetails.getIdentifier(),
-                encodeBase64(userName)));
+            getVariableSecret(usernameEnvVarName + connectorDetails.getIdentifier(), encodeBase64(userName)));
       }
 
       if (usernamePasswordAuthDTO == null || usernamePasswordAuthDTO.getPasswordRef() == null
@@ -201,10 +200,9 @@ public class ConnectorEnvVariablesHelper {
       String passwordEnvVarName = connectorDetails.getEnvToSecretsMap().get(EnvVariableEnum.DOCKER_PASSWORD);
       if (isNotBlank(usernameEnvVarName)) {
         String userName = FieldWithPlainTextOrSecretValueHelper.getSecretAsStringFromPlainTextOrSecretRef(
-                dockerUserNamePasswordDTO.getUsername(), dockerUserNamePasswordDTO.getUsernameRef());
+            dockerUserNamePasswordDTO.getUsername(), dockerUserNamePasswordDTO.getUsernameRef());
         secretData.put(usernameEnvVarName,
-            getVariableSecret(usernameEnvVarName + connectorDetails.getIdentifier(),
-                encodeBase64(userName)));
+            getVariableSecret(usernameEnvVarName + connectorDetails.getIdentifier(), encodeBase64(userName)));
       }
 
       if (dockerUserNamePasswordDTO == null || dockerUserNamePasswordDTO.getPasswordRef() == null

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/citasks/cik8handler/helper/ConnectorEnvVariablesHelperTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/citasks/cik8handler/helper/ConnectorEnvVariablesHelperTest.java
@@ -11,6 +11,7 @@ import static io.harness.data.encoding.EncodingUtils.encodeBase64;
 import static io.harness.delegate.beans.ci.pod.SecretParams.Type.TEXT;
 import static io.harness.rule.OwnerRule.ALEKSANDAR;
 
+import static io.harness.rule.OwnerRule.HARSH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -81,6 +82,56 @@ public class ConnectorEnvVariablesHelperTest extends CategoryTest {
           return (DecryptableEntity) args[0];
         });
   }
+
+  @Test
+  @Owner(developers = HARSH)
+  @Category(UnitTests.class)
+  public void shouldGetArtifactorySecretVariablesWithUserName() {
+    ConnectorDetails connectorDetails =
+            ConnectorDetails.builder()
+                    .envToSecretEntry(EnvVariableEnum.ARTIFACTORY_USERNAME, USERNAME_ENV)
+                    .envToSecretEntry(EnvVariableEnum.ARTIFACTORY_PASSWORD, SECRET_ENV)
+                    .envToSecretEntry(EnvVariableEnum.ARTIFACTORY_ENDPOINT, ENDPOINT_ENV)
+                    .identifier(CONNECTOR_ID)
+                    .connectorType(ConnectorType.ARTIFACTORY)
+                    .connectorConfig(
+                            ArtifactoryConnectorDTO.builder()
+                                    .artifactoryServerUrl(SERVER_URL)
+                                    .auth(ArtifactoryAuthenticationDTO.builder()
+                                            .authType(ArtifactoryAuthType.USER_PASSWORD)
+                                            .credentials(
+                                                    ArtifactoryUsernamePasswordAuthDTO.builder()
+                                                            .usernameRef( SecretRefData.builder().decryptedValue(USERNAME_VALUE.toCharArray()).build())
+                                                            .passwordRef(
+                                                                    SecretRefData.builder().decryptedValue(SECRET_VALUE.toCharArray()).build())
+                                                            .build())
+                                            .build())
+                                    .build())
+                    .build();
+    Map<String, SecretParams> actualSecretVariables =
+            connectorEnvVariablesHelper.getArtifactorySecretVariables(connectorDetails);
+    Map<String, SecretParams> expectedSecretVariables = new HashMap<>();
+    expectedSecretVariables.put(ENDPOINT_ENV,
+            SecretParams.builder()
+                    .value(encodeBase64(SERVER_URL))
+                    .secretKey(ENDPOINT_ENV + CONNECTOR_ID)
+                    .type(TEXT)
+                    .build());
+    expectedSecretVariables.put(USERNAME_ENV,
+            SecretParams.builder()
+                    .value(encodeBase64(USERNAME_VALUE))
+                    .secretKey(USERNAME_ENV + CONNECTOR_ID)
+                    .type(TEXT)
+                    .build());
+    expectedSecretVariables.put(SECRET_ENV,
+            SecretParams.builder()
+                    .value(encodeBase64(SECRET_VALUE))
+                    .secretKey(SECRET_ENV + CONNECTOR_ID)
+                    .type(TEXT)
+                    .build());
+    assertThat(actualSecretVariables).isEqualTo(expectedSecretVariables);
+  }
+
 
   @Test
   @Owner(developers = ALEKSANDAR)
@@ -203,6 +254,55 @@ public class ConnectorEnvVariablesHelperTest extends CategoryTest {
             .secretKey(SECRET_KEY_ENV + CONNECTOR_ID)
             .type(TEXT)
             .build());
+    assertThat(actualSecretVariables).isEqualTo(expectedSecretVariables);
+  }
+
+  @Test
+  @Owner(developers = ALEKSANDAR)
+  @Category(UnitTests.class)
+  public void shouldGetDockerSecretVariablesWithSecretUserName() {
+    ConnectorDetails connectorDetails =
+            ConnectorDetails.builder()
+                    .identifier(CONNECTOR_ID)
+                    .envToSecretEntry(EnvVariableEnum.DOCKER_USERNAME, USERNAME_ENV)
+                    .envToSecretEntry(EnvVariableEnum.DOCKER_PASSWORD, SECRET_ENV)
+                    .envToSecretEntry(EnvVariableEnum.DOCKER_REGISTRY, REGISTRY_ENV)
+                    .connectorType(ConnectorType.DOCKER)
+                    .connectorConfig(
+                            DockerConnectorDTO.builder()
+                                    .dockerRegistryUrl(SERVER_URL)
+                                    .auth(DockerAuthenticationDTO.builder()
+                                            .authType(DockerAuthType.USER_PASSWORD)
+                                            .credentials(
+                                                    DockerUserNamePasswordDTO.builder()
+                                                            .usernameRef(SecretRefData.builder().decryptedValue(USERNAME_VALUE.toCharArray()).build())
+                                                            .passwordRef(
+                                                                    SecretRefData.builder().decryptedValue(SECRET_VALUE.toCharArray()).build())
+                                                            .build())
+                                            .build())
+                                    .build())
+                    .build();
+    Map<String, SecretParams> actualSecretVariables =
+            connectorEnvVariablesHelper.getDockerSecretVariables(connectorDetails);
+    Map<String, SecretParams> expectedSecretVariables = new HashMap<>();
+    expectedSecretVariables.put(USERNAME_ENV,
+            SecretParams.builder()
+                    .value(encodeBase64(USERNAME_VALUE))
+                    .secretKey(USERNAME_ENV + CONNECTOR_ID)
+                    .type(TEXT)
+                    .build());
+    expectedSecretVariables.put(SECRET_ENV,
+            SecretParams.builder()
+                    .value(encodeBase64(SECRET_VALUE))
+                    .secretKey(SECRET_ENV + CONNECTOR_ID)
+                    .type(TEXT)
+                    .build());
+    expectedSecretVariables.put(REGISTRY_ENV,
+            SecretParams.builder()
+                    .value(encodeBase64(SERVER_URL))
+                    .secretKey(REGISTRY_ENV + CONNECTOR_ID)
+                    .type(TEXT)
+                    .build());
     assertThat(actualSecretVariables).isEqualTo(expectedSecretVariables);
   }
 

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/citasks/cik8handler/helper/ConnectorEnvVariablesHelperTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/citasks/cik8handler/helper/ConnectorEnvVariablesHelperTest.java
@@ -10,8 +10,8 @@ package io.harness.delegate.task.citasks.cik8handler.helper;
 import static io.harness.data.encoding.EncodingUtils.encodeBase64;
 import static io.harness.delegate.beans.ci.pod.SecretParams.Type.TEXT;
 import static io.harness.rule.OwnerRule.ALEKSANDAR;
-
 import static io.harness.rule.OwnerRule.HARSH;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -88,50 +88,50 @@ public class ConnectorEnvVariablesHelperTest extends CategoryTest {
   @Category(UnitTests.class)
   public void shouldGetArtifactorySecretVariablesWithUserName() {
     ConnectorDetails connectorDetails =
-            ConnectorDetails.builder()
-                    .envToSecretEntry(EnvVariableEnum.ARTIFACTORY_USERNAME, USERNAME_ENV)
-                    .envToSecretEntry(EnvVariableEnum.ARTIFACTORY_PASSWORD, SECRET_ENV)
-                    .envToSecretEntry(EnvVariableEnum.ARTIFACTORY_ENDPOINT, ENDPOINT_ENV)
-                    .identifier(CONNECTOR_ID)
-                    .connectorType(ConnectorType.ARTIFACTORY)
-                    .connectorConfig(
-                            ArtifactoryConnectorDTO.builder()
-                                    .artifactoryServerUrl(SERVER_URL)
-                                    .auth(ArtifactoryAuthenticationDTO.builder()
-                                            .authType(ArtifactoryAuthType.USER_PASSWORD)
-                                            .credentials(
-                                                    ArtifactoryUsernamePasswordAuthDTO.builder()
-                                                            .usernameRef( SecretRefData.builder().decryptedValue(USERNAME_VALUE.toCharArray()).build())
-                                                            .passwordRef(
-                                                                    SecretRefData.builder().decryptedValue(SECRET_VALUE.toCharArray()).build())
-                                                            .build())
-                                            .build())
-                                    .build())
-                    .build();
+        ConnectorDetails.builder()
+            .envToSecretEntry(EnvVariableEnum.ARTIFACTORY_USERNAME, USERNAME_ENV)
+            .envToSecretEntry(EnvVariableEnum.ARTIFACTORY_PASSWORD, SECRET_ENV)
+            .envToSecretEntry(EnvVariableEnum.ARTIFACTORY_ENDPOINT, ENDPOINT_ENV)
+            .identifier(CONNECTOR_ID)
+            .connectorType(ConnectorType.ARTIFACTORY)
+            .connectorConfig(
+                ArtifactoryConnectorDTO.builder()
+                    .artifactoryServerUrl(SERVER_URL)
+                    .auth(ArtifactoryAuthenticationDTO.builder()
+                              .authType(ArtifactoryAuthType.USER_PASSWORD)
+                              .credentials(
+                                  ArtifactoryUsernamePasswordAuthDTO.builder()
+                                      .usernameRef(
+                                          SecretRefData.builder().decryptedValue(USERNAME_VALUE.toCharArray()).build())
+                                      .passwordRef(
+                                          SecretRefData.builder().decryptedValue(SECRET_VALUE.toCharArray()).build())
+                                      .build())
+                              .build())
+                    .build())
+            .build();
     Map<String, SecretParams> actualSecretVariables =
-            connectorEnvVariablesHelper.getArtifactorySecretVariables(connectorDetails);
+        connectorEnvVariablesHelper.getArtifactorySecretVariables(connectorDetails);
     Map<String, SecretParams> expectedSecretVariables = new HashMap<>();
     expectedSecretVariables.put(ENDPOINT_ENV,
-            SecretParams.builder()
-                    .value(encodeBase64(SERVER_URL))
-                    .secretKey(ENDPOINT_ENV + CONNECTOR_ID)
-                    .type(TEXT)
-                    .build());
+        SecretParams.builder()
+            .value(encodeBase64(SERVER_URL))
+            .secretKey(ENDPOINT_ENV + CONNECTOR_ID)
+            .type(TEXT)
+            .build());
     expectedSecretVariables.put(USERNAME_ENV,
-            SecretParams.builder()
-                    .value(encodeBase64(USERNAME_VALUE))
-                    .secretKey(USERNAME_ENV + CONNECTOR_ID)
-                    .type(TEXT)
-                    .build());
+        SecretParams.builder()
+            .value(encodeBase64(USERNAME_VALUE))
+            .secretKey(USERNAME_ENV + CONNECTOR_ID)
+            .type(TEXT)
+            .build());
     expectedSecretVariables.put(SECRET_ENV,
-            SecretParams.builder()
-                    .value(encodeBase64(SECRET_VALUE))
-                    .secretKey(SECRET_ENV + CONNECTOR_ID)
-                    .type(TEXT)
-                    .build());
+        SecretParams.builder()
+            .value(encodeBase64(SECRET_VALUE))
+            .secretKey(SECRET_ENV + CONNECTOR_ID)
+            .type(TEXT)
+            .build());
     assertThat(actualSecretVariables).isEqualTo(expectedSecretVariables);
   }
-
 
   @Test
   @Owner(developers = ALEKSANDAR)
@@ -262,47 +262,48 @@ public class ConnectorEnvVariablesHelperTest extends CategoryTest {
   @Category(UnitTests.class)
   public void shouldGetDockerSecretVariablesWithSecretUserName() {
     ConnectorDetails connectorDetails =
-            ConnectorDetails.builder()
-                    .identifier(CONNECTOR_ID)
-                    .envToSecretEntry(EnvVariableEnum.DOCKER_USERNAME, USERNAME_ENV)
-                    .envToSecretEntry(EnvVariableEnum.DOCKER_PASSWORD, SECRET_ENV)
-                    .envToSecretEntry(EnvVariableEnum.DOCKER_REGISTRY, REGISTRY_ENV)
-                    .connectorType(ConnectorType.DOCKER)
-                    .connectorConfig(
-                            DockerConnectorDTO.builder()
-                                    .dockerRegistryUrl(SERVER_URL)
-                                    .auth(DockerAuthenticationDTO.builder()
-                                            .authType(DockerAuthType.USER_PASSWORD)
-                                            .credentials(
-                                                    DockerUserNamePasswordDTO.builder()
-                                                            .usernameRef(SecretRefData.builder().decryptedValue(USERNAME_VALUE.toCharArray()).build())
-                                                            .passwordRef(
-                                                                    SecretRefData.builder().decryptedValue(SECRET_VALUE.toCharArray()).build())
-                                                            .build())
-                                            .build())
-                                    .build())
-                    .build();
+        ConnectorDetails.builder()
+            .identifier(CONNECTOR_ID)
+            .envToSecretEntry(EnvVariableEnum.DOCKER_USERNAME, USERNAME_ENV)
+            .envToSecretEntry(EnvVariableEnum.DOCKER_PASSWORD, SECRET_ENV)
+            .envToSecretEntry(EnvVariableEnum.DOCKER_REGISTRY, REGISTRY_ENV)
+            .connectorType(ConnectorType.DOCKER)
+            .connectorConfig(
+                DockerConnectorDTO.builder()
+                    .dockerRegistryUrl(SERVER_URL)
+                    .auth(DockerAuthenticationDTO.builder()
+                              .authType(DockerAuthType.USER_PASSWORD)
+                              .credentials(
+                                  DockerUserNamePasswordDTO.builder()
+                                      .usernameRef(
+                                          SecretRefData.builder().decryptedValue(USERNAME_VALUE.toCharArray()).build())
+                                      .passwordRef(
+                                          SecretRefData.builder().decryptedValue(SECRET_VALUE.toCharArray()).build())
+                                      .build())
+                              .build())
+                    .build())
+            .build();
     Map<String, SecretParams> actualSecretVariables =
-            connectorEnvVariablesHelper.getDockerSecretVariables(connectorDetails);
+        connectorEnvVariablesHelper.getDockerSecretVariables(connectorDetails);
     Map<String, SecretParams> expectedSecretVariables = new HashMap<>();
     expectedSecretVariables.put(USERNAME_ENV,
-            SecretParams.builder()
-                    .value(encodeBase64(USERNAME_VALUE))
-                    .secretKey(USERNAME_ENV + CONNECTOR_ID)
-                    .type(TEXT)
-                    .build());
+        SecretParams.builder()
+            .value(encodeBase64(USERNAME_VALUE))
+            .secretKey(USERNAME_ENV + CONNECTOR_ID)
+            .type(TEXT)
+            .build());
     expectedSecretVariables.put(SECRET_ENV,
-            SecretParams.builder()
-                    .value(encodeBase64(SECRET_VALUE))
-                    .secretKey(SECRET_ENV + CONNECTOR_ID)
-                    .type(TEXT)
-                    .build());
+        SecretParams.builder()
+            .value(encodeBase64(SECRET_VALUE))
+            .secretKey(SECRET_ENV + CONNECTOR_ID)
+            .type(TEXT)
+            .build());
     expectedSecretVariables.put(REGISTRY_ENV,
-            SecretParams.builder()
-                    .value(encodeBase64(SERVER_URL))
-                    .secretKey(REGISTRY_ENV + CONNECTOR_ID)
-                    .type(TEXT)
-                    .build());
+        SecretParams.builder()
+            .value(encodeBase64(SERVER_URL))
+            .secretKey(REGISTRY_ENV + CONNECTOR_ID)
+            .type(TEXT)
+            .build());
     assertThat(actualSecretVariables).isEqualTo(expectedSecretVariables);
   }
 


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31855)
<!-- Reviewable:end -->
