### PR TITLE
fix: [CDS-35229]: get resolved templates pipeline yaml for validating on new manifest and artifact triggers

### DIFF
--- a/810-ng-triggers/src/main/java/io/harness/ngtriggers/buildtriggers/helpers/BuildTriggerHelper.java
+++ b/810-ng-triggers/src/main/java/io/harness/ngtriggers/buildtriggers/helpers/BuildTriggerHelper.java
@@ -12,7 +12,9 @@ import static io.harness.annotations.dev.HarnessTeam.PIPELINE;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.exception.InvalidArgumentsException;
@@ -61,9 +63,21 @@ public class BuildTriggerHelper {
   public Optional<String> fetchPipelineForTrigger(NGTriggerEntity ngTriggerEntity) {
     PMSPipelineResponseDTO response = NGRestUtils.getResponse(pipelineServiceClient.getPipelineByIdentifier(
         ngTriggerEntity.getTargetIdentifier(), ngTriggerEntity.getAccountId(), ngTriggerEntity.getOrgIdentifier(),
-        ngTriggerEntity.getProjectIdentifier(), null, null, false));
+        ngTriggerEntity.getProjectIdentifier(), null, null, false, false));
 
     return response != null ? Optional.of(response.getYamlPipeline()) : Optional.empty();
+  }
+
+  public Optional<String> fetchTemplatesResolvedPipelineYamlForTrigger(NGTriggerEntity ngTriggerEntity) {
+    PMSPipelineResponseDTO response = NGRestUtils.getResponse(pipelineServiceClient.getPipelineByIdentifier(
+        ngTriggerEntity.getTargetIdentifier(), ngTriggerEntity.getAccountId(), ngTriggerEntity.getOrgIdentifier(),
+        ngTriggerEntity.getProjectIdentifier(), null, null, false, true));
+
+    if (response != null && isNotEmpty(response.getYamlPipeline())
+        && isEmpty(response.getResolvedTemplatesPipelineYaml())) {
+      throw new InvalidRequestException("Template Inputs are not correctly set in pipeline.");
+    }
+    return response != null ? Optional.of(response.getResolvedTemplatesPipelineYaml()) : Optional.empty();
   }
 
   public Map<String, JsonNode> fetchTriggerBuildSpecMap(NGTriggerEntity ngTriggerEntity) throws IOException {

--- a/810-ng-triggers/src/main/java/io/harness/ngtriggers/utils/PollingSubscriptionHelper.java
+++ b/810-ng-triggers/src/main/java/io/harness/ngtriggers/utils/PollingSubscriptionHelper.java
@@ -45,7 +45,7 @@ public class PollingSubscriptionHelper {
     }
 
     try {
-      Optional<String> pipelineYml = buildTriggerHelper.fetchPipelineForTrigger(ngTriggerEntity);
+      Optional<String> pipelineYml = buildTriggerHelper.fetchTemplatesResolvedPipelineYamlForTrigger(ngTriggerEntity);
       if (!pipelineYml.isPresent()) {
         throw new InvalidRequestException("Failed to retrieve pipeline");
       }

--- a/810-ng-triggers/src/main/java/io/harness/ngtriggers/validations/impl/ArtifactTriggerValidator.java
+++ b/810-ng-triggers/src/main/java/io/harness/ngtriggers/validations/impl/ArtifactTriggerValidator.java
@@ -53,7 +53,7 @@ public class ArtifactTriggerValidator implements TriggerValidator {
     ValidationResultBuilder builder = ValidationResult.builder().success(true);
     try {
       Optional<String> pipelineYmlOptional =
-          validationHelper.fetchPipelineForTrigger(triggerDetails.getNgTriggerEntity());
+          validationHelper.fetchTemplatesResolvedPipelineYamlForTrigger(triggerDetails.getNgTriggerEntity());
 
       if (!pipelineYmlOptional.isPresent()) {
         return builder.success(false).message("Pipeline doesn't exists").build();

--- a/810-ng-triggers/src/main/java/io/harness/ngtriggers/validations/impl/ManifestTriggerValidator.java
+++ b/810-ng-triggers/src/main/java/io/harness/ngtriggers/validations/impl/ManifestTriggerValidator.java
@@ -47,7 +47,7 @@ public class ManifestTriggerValidator implements TriggerValidator {
 
     try {
       Optional<String> pipelineYmlOptional =
-          validationHelper.fetchPipelineForTrigger(triggerDetails.getNgTriggerEntity());
+          validationHelper.fetchTemplatesResolvedPipelineYamlForTrigger(triggerDetails.getNgTriggerEntity());
 
       if (!pipelineYmlOptional.isPresent()) {
         return builder.success(false).message("Pipeline doesn't exists").build();

--- a/888-pms-client/src/main/java/io/harness/pipeline/remote/PipelineServiceClient.java
+++ b/888-pms-client/src/main/java/io/harness/pipeline/remote/PipelineServiceClient.java
@@ -64,5 +64,6 @@ public interface PipelineServiceClient {
       @Query(value = NGCommonEntityConstants.PROJECT_KEY) String projectIdentifier,
       @Query(GitSyncApiConstants.BRANCH_KEY) String branch,
       @Query(GitSyncApiConstants.REPO_IDENTIFIER_KEY) String yamlGitConfigId,
-      @Query(GitSyncApiConstants.DEFAULT_FROM_OTHER_REPO) Boolean defaultFromOtherRepo);
+      @Query(GitSyncApiConstants.DEFAULT_FROM_OTHER_REPO) Boolean defaultFromOtherRepo,
+      @Query("getTemplatesResolvedPipeline") boolean getTemplatesResolvedPipeline);
 }


### PR DESCRIPTION
Since triggers don't understand templates, they need templates resolved pipeline yaml to do validations for on new artifacts and manifests trigger

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31959)
<!-- Reviewable:end -->
