### PR TITLE
fix: [CI-3987]: disable auth between lite engine and delegate service

### DIFF
--- a/420-delegate-agent/src/main/java/io/harness/delegate/app/DelegateGrpcServiceModule.java
+++ b/420-delegate-agent/src/main/java/io/harness/delegate/app/DelegateGrpcServiceModule.java
@@ -26,6 +26,7 @@ import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
 import io.grpc.BindableService;
 import io.grpc.ServerInterceptor;
 import java.util.List;
@@ -50,11 +51,13 @@ public class DelegateGrpcServiceModule extends AbstractModule {
     bindableServiceMultibinder.addBinding().to(TaskServiceImpl.class);
     bindableServiceMultibinder.addBinding().to(ExpressionServiceImpl.class);
 
+    Multibinder<String> nonAuthServices =
+        Multibinder.newSetBinder(binder(), String.class, Names.named("excludedGrpcAuthValidationServices"));
+    nonAuthServices.addBinding().toInstance(TaskServiceGrpc.SERVICE_NAME);
+
     MapBinder<String, ServiceInfo> stringServiceInfoMapBinder =
         MapBinder.newMapBinder(binder(), String.class, ServiceInfo.class);
     stringServiceInfoMapBinder.addBinding(ExpressionEvaulatorServiceGrpc.SERVICE_NAME)
-        .toInstance(ServiceInfo.builder().id(SERVICE_ID).secret(serviceSecret).build());
-    stringServiceInfoMapBinder.addBinding(TaskServiceGrpc.SERVICE_NAME)
         .toInstance(ServiceInfo.builder().id(SERVICE_ID).secret(serviceSecret).build());
 
     install(new GrpcServerModule(getConnectors(), getProvider(Key.get(new TypeLiteral<Set<BindableService>>() {})),

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=74513
+build.number=74514
 build.patch=000
 delegate.version=22.03.12
 delegate.patch=000


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31970)
<!-- Reviewable:end -->
