### PR TITLE
[fix]: [SRM-9909]: Log trend analysis null pointer fix

### DIFF
--- a/300-cv-nextgen/src/main/java/io/harness/cvng/analysis/entities/LogAnalysisCluster.java
+++ b/300-cv-nextgen/src/main/java/io/harness/cvng/analysis/entities/LogAnalysisCluster.java
@@ -118,9 +118,15 @@ public final class LogAnalysisCluster implements PersistentEntity, UuidAware, Cr
     @Override
     public <TDocument> BsonDocument toBsonDocument(Class<TDocument> aClass, CodecRegistry codecRegistry) {
       BsonDocument bsonDocument = new BsonDocument();
-      bsonDocument.append(FrequencyKeys.count, new BsonInt64(count));
-      bsonDocument.append(FrequencyKeys.timestamp, new BsonInt64(timestamp));
-      bsonDocument.append(FrequencyKeys.riskScore, new BsonDouble(riskScore));
+      if (count != null) {
+        bsonDocument.append(FrequencyKeys.count, new BsonInt64(count));
+      }
+      if (timestamp != null) {
+        bsonDocument.append(FrequencyKeys.timestamp, new BsonInt64(timestamp));
+      }
+      if (riskScore != null) {
+        bsonDocument.append(FrequencyKeys.riskScore, new BsonDouble(riskScore));
+      }
       return bsonDocument;
     }
   }

--- a/300-cv-nextgen/src/test/java/io/harness/cvng/analysis/services/impl/TrendAnalysisServiceImplTest.java
+++ b/300-cv-nextgen/src/test/java/io/harness/cvng/analysis/services/impl/TrendAnalysisServiceImplTest.java
@@ -202,7 +202,7 @@ public class TrendAnalysisServiceImplTest extends CvNextGenTestBase {
         .getEnvironment(any(), any(), any(), any());
     Instant start = Instant.now().minus(10, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.MINUTES);
     Instant end = start.plus(5, ChronoUnit.MINUTES);
-    List<LogAnalysisCluster> logAnalysisClusters = createLogAnalysisClusters(start, end);
+    List<LogAnalysisCluster> logAnalysisClusters = createLogAnalysisClusters(start, end.plus(Duration.ofMinutes(5)));
     List<LogAnalysisResult> logAnalysisResults = createLogAnalysisResults(start, end);
     hPersistence.save(logAnalysisClusters);
     hPersistence.save(logAnalysisResults);
@@ -230,7 +230,9 @@ public class TrendAnalysisServiceImplTest extends CvNextGenTestBase {
     int index = 0;
     for (LogAnalysisCluster cluster : savedClusters) {
       for (Frequency frequency : cluster.getFrequencyTrend()) {
-        assertThat(frequency.getRiskScore()).isEqualTo((double) index);
+        if (frequency.getTimestamp() >= start.toEpochMilli() && frequency.getTimestamp() < end.toEpochMilli()) {
+          assertThat(frequency.getRiskScore()).isEqualTo((double) index);
+        }
       }
       index++;
     }
@@ -473,16 +475,10 @@ public class TrendAnalysisServiceImplTest extends CvNextGenTestBase {
                                      .build();
     Instant timestamp = startTime;
     while (timestamp.isBefore(endTime)) {
-      Frequency frequency1 = Frequency.builder()
-                                 .timestamp(TimeUnit.SECONDS.toMinutes(timestamp.getEpochSecond()))
-                                 .count(4)
-                                 .riskScore(0.5)
-                                 .build();
-      Frequency frequency2 = Frequency.builder()
-                                 .timestamp(TimeUnit.SECONDS.toMinutes(timestamp.getEpochSecond()))
-                                 .count(10)
-                                 .riskScore(0.1)
-                                 .build();
+      Frequency frequency1 =
+          Frequency.builder().timestamp(TimeUnit.SECONDS.toMinutes(timestamp.getEpochSecond())).count(4).build();
+      Frequency frequency2 =
+          Frequency.builder().timestamp(TimeUnit.SECONDS.toMinutes(timestamp.getEpochSecond())).count(10).build();
       record1.getFrequencyTrend().add(frequency1);
       record2.getFrequencyTrend().add(frequency2);
       timestamp = timestamp.plus(1, ChronoUnit.MINUTES);

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
 build.number=74513
-build.patch=000
+build.patch=001
 delegate.version=22.03.12
 delegate.patch=000


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/31995)
<!-- Reviewable:end -->
