### PR TITLE
feat: [PL-23377]: SCM, Azure createhook for multiple events

### DIFF
--- a/product/ci/scm/proto/scm.proto
+++ b/product/ci/scm/proto/scm.proto
@@ -602,8 +602,7 @@ message BitbucketServerWebhookEvents {
 }
 
 message AzureWebhookEvents {
-  // Azure only allows one event type per hook
-  AzureWebhookEvent events = 1;
+  repeated AzureWebhookEvent events = 1;
 }
 
 message NativeEvents {

--- a/product/ci/scm/repo/azure_test.go
+++ b/product/ci/scm/repo/azure_test.go
@@ -34,7 +34,7 @@ func TestCreateListAndDeleteWebhookAzure(t *testing.T) {
 		NativeEvents: &pb.NativeEvents{
 			NativeEvents: &pb.NativeEvents_Azure{
 				Azure: &pb.AzureWebhookEvents{
-					Events: pb.AzureWebhookEvent_AZURE_PULLREQUEST_CREATED,
+					Events: []pb.AzureWebhookEvent{pb.AzureWebhookEvent_AZURE_PULLREQUEST_CREATED},
 				},
 			},
 		},
@@ -55,7 +55,7 @@ func TestCreateListAndDeleteWebhookAzure(t *testing.T) {
 
 	assert.Nil(t, err, "no errors")
 	assert.Equal(t, int32(200), got.Status, "Correct http response")
-	assert.Equal(t, pb.AzureWebhookEvent_AZURE_PULLREQUEST_CREATED, got.GetWebhook().GetNativeEvents().GetAzure().GetEvents(), "created a webhook 'asdas' event")
+	assert.Equal(t, 1, len(got.GetWebhook().GetNativeEvents().GetAzure().GetEvents()), "created a webhook 'pull request created' event")
 
 	list := &pb.ListWebhooksRequest{
 		Slug: repoID,


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32016)
<!-- Reviewable:end -->
