### PR TITLE
fix: [CDS-35561]: Handling variable creator for deployment stage

### DIFF
--- a/125-cd-nextgen/src/main/java/io/harness/cdng/creator/plan/stage/DeploymentStageNode.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/creator/plan/stage/DeploymentStageNode.java
@@ -16,6 +16,7 @@ import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.plancreator.stages.stage.StageInfoConfig;
 import io.harness.steps.StepSpecTypeConstants;
+import io.harness.yaml.core.VariableExpression;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -35,7 +36,7 @@ import org.springframework.data.annotation.TypeAlias;
 @OwnedBy(CDC)
 @RecasterAlias("io.harness.cdng.creator.plan.stage.DeploymentStageNode")
 public class DeploymentStageNode extends DeploymentAbstractStageNode {
-  @JsonProperty("type") @NotNull StepType type = StepType.Deployment;
+  @JsonProperty("type") @NotNull @VariableExpression(replaceWithUUid = false) StepType type = StepType.Deployment;
 
   @JsonProperty("spec")
   @JsonTypeInfo(use = NAME, property = "type", include = EXTERNAL_PROPERTY, visible = true)

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/creator/plan/stage/DeploymentStageNode.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/creator/plan/stage/DeploymentStageNode.java
@@ -40,6 +40,7 @@ public class DeploymentStageNode extends DeploymentAbstractStageNode {
 
   @JsonProperty("spec")
   @JsonTypeInfo(use = NAME, property = "type", include = EXTERNAL_PROPERTY, visible = true)
+  @VariableExpression
   DeploymentStageConfig deploymentStageConfig;
   @Override
   public String getType() {

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/creator/variables/DeploymentStageVariableCreator.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/creator/variables/DeploymentStageVariableCreator.java
@@ -7,6 +7,7 @@
 
 package io.harness.cdng.creator.variables;
 
+import io.harness.cdng.creator.plan.stage.DeploymentStageNode;
 import io.harness.cdng.visitor.YamlTypes;
 import io.harness.pms.sdk.core.variables.AbstractStageVariableCreator;
 import io.harness.pms.sdk.core.variables.VariableCreatorHelper;
@@ -22,7 +23,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
-public class DeploymentStageVariableCreator extends AbstractStageVariableCreator {
+public class DeploymentStageVariableCreator extends AbstractStageVariableCreator<DeploymentStageNode> {
   @Override
   public LinkedHashMap<String, VariableCreationResponse> createVariablesForChildrenNodes(
       VariableCreationContext ctx, YamlField config) {
@@ -58,5 +59,16 @@ public class DeploymentStageVariableCreator extends AbstractStageVariableCreator
   @Override
   public Map<String, Set<String>> getSupportedTypes() {
     return Collections.singletonMap(YAMLFieldNameConstants.STAGE, Collections.singleton("Deployment"));
+  }
+
+  @Override
+  public LinkedHashMap<String, VariableCreationResponse> createVariablesForChildrenNodesV2(
+      VariableCreationContext ctx, DeploymentStageNode config) {
+    return createVariablesForChildrenNodes(ctx, ctx.getCurrentField());
+  }
+
+  @Override
+  public Class<DeploymentStageNode> getFieldClass() {
+    return DeploymentStageNode.class;
   }
 }

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/creator/variables/DeploymentStageVariableCreatorTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/creator/variables/DeploymentStageVariableCreatorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.cdng.creator.variables;
+
+import static io.harness.rule.OwnerRule.NAMAN_TALAYCHA;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.harness.CategoryTest;
+import io.harness.category.element.UnitTests;
+import io.harness.cdng.creator.plan.stage.DeploymentStageNode;
+import io.harness.pms.contracts.plan.YamlProperties;
+import io.harness.pms.sdk.core.variables.beans.VariableCreationContext;
+import io.harness.pms.sdk.core.variables.beans.VariableCreationResponse;
+import io.harness.pms.yaml.YAMLFieldNameConstants;
+import io.harness.pms.yaml.YamlField;
+import io.harness.pms.yaml.YamlNode;
+import io.harness.pms.yaml.YamlUtils;
+import io.harness.rule.Owner;
+import io.harness.serializer.JsonUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class DeploymentStageVariableCreatorTest extends CategoryTest {
+  DeploymentStageVariableCreator deploymentStageVariableCreator = new DeploymentStageVariableCreator();
+  private static final String STAGE_ID = "NnmWEe_TRXCba1-R2EsDrw";
+  @Test
+  @Owner(developers = NAMAN_TALAYCHA)
+  @Category(UnitTests.class)
+  public void createVariablesForChildrenNodes() throws IOException {
+    ClassLoader classLoader = this.getClass().getClassLoader();
+    final URL testFile = classLoader.getResource("deployment_stage.json");
+    String json = Resources.toString(testFile, Charsets.UTF_8);
+    JsonNode jsonNode = JsonUtils.asObject(json, JsonNode.class);
+    YamlNode deploymentYamlNode = new YamlNode("stage", jsonNode);
+    YamlField yamlField = new YamlField(deploymentYamlNode);
+    LinkedHashMap<String, VariableCreationResponse> variablesMap =
+        deploymentStageVariableCreator.createVariablesForChildrenNodes(null, yamlField);
+    assertThat(variablesMap.get(STAGE_ID)).isNotNull();
+    String yamlPath = variablesMap.get(STAGE_ID).getDependencies().getDependenciesMap().get(STAGE_ID);
+    YamlField fullYamlField = YamlUtils.readTree(json);
+    assertThat(fullYamlField).isNotNull();
+    YamlField specYaml = fullYamlField.fromYamlPath(yamlPath);
+    assertThat(yamlField.getNode().getFieldName()).isNotEmpty();
+    assertThat(specYaml.getName()).isEqualTo("execution");
+    assertThat(specYaml.getNode().fetchKeys()).containsExactlyInAnyOrder("steps", "rollbackSteps", "__uuid");
+  }
+  @Test
+  @Owner(developers = NAMAN_TALAYCHA)
+  @Category(UnitTests.class)
+  public void getSupportedTypes() {
+    assertThat(deploymentStageVariableCreator.getSupportedTypes())
+        .containsEntry(YAMLFieldNameConstants.STAGE, Collections.singleton("Deployment"));
+  }
+
+  @Test
+  @Owner(developers = NAMAN_TALAYCHA)
+  @Category(UnitTests.class)
+  public void getClassType() {
+    assertThat(deploymentStageVariableCreator.getFieldClass()).isEqualTo(DeploymentStageNode.class);
+  }
+
+  @Test
+  @Owner(developers = NAMAN_TALAYCHA)
+  @Category(UnitTests.class)
+  public void createVariablesForParentNodes() throws IOException {
+    ClassLoader classLoader = this.getClass().getClassLoader();
+    final URL testFile = classLoader.getResource("pipelineVariableCreatorUuidJson.yaml");
+    String pipelineJson = Resources.toString(testFile, Charsets.UTF_8);
+    YamlField fullYamlField = YamlUtils.readTree(pipelineJson);
+
+    // Pipeline Node
+    YamlField stageField = fullYamlField.getNode()
+                               .getField("pipeline")
+                               .getNode()
+                               .getField("stages")
+                               .getNode()
+                               .asArray()
+                               .get(0)
+                               .getField("stage");
+    // yaml input expressions
+    VariableCreationResponse variablesForParentNodeV2 = deploymentStageVariableCreator.createVariablesForParentNodeV2(
+        VariableCreationContext.builder().currentField(stageField).build(),
+        YamlUtils.read(stageField.getNode().toString(), DeploymentStageNode.class));
+    List<String> fqnPropertiesList = variablesForParentNodeV2.getYamlProperties()
+                                         .values()
+                                         .stream()
+                                         .map(YamlProperties::getFqn)
+                                         .collect(Collectors.toList());
+    assertThat(fqnPropertiesList)
+        .containsAll(Arrays.asList("pipeline.stages.qaStage.description", "pipeline.stages.qaStage.name"));
+
+    // yaml extra properties
+    List<String> fqnExtraPropertiesList = variablesForParentNodeV2.getYamlExtraProperties()
+                                              .get("tGufMZnYTNCcFFLz74wtpA") // pipeline uuid
+                                              .getPropertiesList()
+                                              .stream()
+                                              .map(YamlProperties::getFqn)
+                                              .collect(Collectors.toList());
+    assertThat(fqnExtraPropertiesList)
+        .containsAll(Arrays.asList("pipeline.stages.qaStage.variables", "pipeline.stages.qaStage.identifier",
+            "pipeline.stages.qaStage.startTs", "pipeline.stages.qaStage.endTs", "pipeline.stages.qaStage.tags",
+            "pipeline.stages.qaStage.type"));
+  }
+}

--- a/125-cd-nextgen/src/test/resources/deployment_stage.json
+++ b/125-cd-nextgen/src/test/resources/deployment_stage.json
@@ -99,7 +99,17 @@
                 }
               ],
               "rollbackSteps":[
-
+                {
+                  "step": {
+                    "name": "Rollback Rollout Deployment",
+                    "identifier": "rollbackRolloutDeployment",
+                    "type": "K8sRollingRollback",
+                    "timeout": "10m",
+                    "spec": {},
+                    "__uuid": "NnmWEe_TRXCba1-R2EsDdf"
+                  },
+                  "__uuid": "NnmWEe_TRXCba1-R2Esssw"
+                }
               ],
               "__uuid": "NnmWEe_TRXCba1-R2EsDrw"
             },

--- a/125-cd-nextgen/src/test/resources/deployment_stage.json
+++ b/125-cd-nextgen/src/test/resources/deployment_stage.json
@@ -1,0 +1,109 @@
+{
+          "identifier": "qaStage",
+          "name": "6FIJyvOXQc6KwJQyHvqoqg",
+          "description": "48OagCMoShuZNmFHdt4z3Q",
+          "type": "Deployment",
+          "spec": {
+            "serviceConfig": {
+              "service": {
+                "identifier": "manager",
+                "name": "manager",
+                "__uuid": "vDSvcNoEd8-v2i4PsR_EPg"
+              },
+              "serviceDefinition": {
+                "type": "Kubernetes",
+                "spec": {
+                  "artifacts": {
+                    "primary": {
+                      "type": "DockerRegistry",
+                      "spec": {
+                        "connectorRef": "account.docker",
+                        "imagePath": "library/nginx",
+                        "tag": "1.19",
+                        "__uuid": "OPDEDpT2S_2PFqeWVVhEsc"
+                      },
+                      "__uuid": "OPDdgpT2S_2PFqeWVVhEwA"
+                    },
+                    "__uuid": "OPjhDpT2S_2PFqeWVVhEwA"
+                  },
+                  "manifests": [
+                    {
+                      "manifest": {
+                        "identifier": "baseValues",
+                        "type": "K8sManifest",
+                        "spec": {
+                          "store": {
+                            "type": "Git",
+                            "spec": {
+                              "connectorRef": "my_git_connector",
+                              "gitFetchType": "Branch",
+                              "branch": "master",
+                              "paths": [
+                                "test/spec"
+                              ],
+                              "__uuid": "7Oszx9TqQWbbkz3_emc5ng"
+                            },
+                            "__uuid": "7Oszx9Tqkm2Nkz3_emc5ng"
+                          },
+                          "__uuid": "7Oszx9TqQweNkz3_emc5ng"
+                        },
+                        "__uuid": "7Oszx9TjjW2Nkz3_emc5ng"
+                      },
+                      "__uuid": "7Oszx9TgtW2Nkz3_emc5ng"
+                    }
+                  ],
+                  "__uuid": "7Oszx9TqQsdNkz3_emc5ng"
+                },
+                "__uuid": "7Oszx9TqQW2hhz3_emc5ng"
+              },
+              "__uuid": "7Oszx9TqQddNkz3_emc5ng"
+            },
+            "infrastructure": {
+              "environment": {
+                "identifier": "stagingInfra",
+                "type": "PreProduction",
+                "tags": {
+                  "cloud": "GCP",
+                  "team": "cdp",
+                  "__uuid": "VgWSDz31S3eZdAtFvTHHoA"
+                },
+                "__uuid": "qOnpI7A_SX6-K6JSr7TKKA"
+              },
+              "infrastructureDefinition": {
+                "type": "KubernetesDirect",
+                "spec": {
+                  "connectorRef": "account.argocd-account",
+                  "namespace": "harness",
+                  "releaseName": "testingqa",
+                  "__uuid": "cX5YIAPUQqOlyuSFyKOVGA"
+                },
+                "__uuid": "d2f8dAryRXeX4nY4dssJxQ"
+              },
+              "__uuid": "KmxClH1bSKiNstn52Cf6BA"
+            },
+            "execution": {
+              "steps": [
+                {
+                  "step": {
+                    "name": "Rollout Deployment",
+                    "identifier": "rolloutDeployment",
+                    "type": "K8sRollingDeploy",
+                    "spec": {
+                      "timeout": 120000,
+                      "skipDryRun": false,
+                      "__uuid": "OPDEDpT2S_2PFqeWVVhEwA"
+                    },
+                    "__uuid": "r8Uq7gxzS42XfE54jfaGTw"
+                  },
+                  "__uuid": "QI3_RIg8TQeB9QQOEAiM8w"
+                }
+              ],
+              "rollbackSteps":[
+
+              ],
+              "__uuid": "NnmWEe_TRXCba1-R2EsDrw"
+            },
+            "__uuid": "CcTvyLUVSoS18MrrFX4pFQ"
+          },
+          "__uuid": "tGufMZnYTNCcFFLz74wtpA"
+        }

--- a/125-cd-nextgen/src/test/resources/pipelineVariableCreatorUuidJson.yaml
+++ b/125-cd-nextgen/src/test/resources/pipelineVariableCreatorUuidJson.yaml
@@ -1,0 +1,124 @@
+{
+  "pipeline": {
+    "name": "Manager Service Deployment",
+    "identifier": "k8s",
+    "projectIdentifier": "ArchitProject",
+    "orgIdentifier": "default",
+    "tags": {
+      "__uuid": "vDSvcNoES8-v2i4PsR_EPg"
+    },
+    "stages": [
+      {
+        "stage": {
+          "identifier": "qaStage",
+          "name": "qa stage",
+          "description": "",
+          "type": "Deployment",
+          "spec": {
+            "serviceConfig": {
+              "service": {
+                "identifier": "manager",
+                "name": "manager",
+                "__uuid": "vDSvcNoEd8-v2i4PsR_EPg"
+              },
+              "serviceDefinition": {
+                "type": "Kubernetes",
+                "spec": {
+                  "artifacts": {
+                    "primary": {
+                      "type": "DockerRegistry",
+                      "spec": {
+                        "connectorRef": "account.docker",
+                        "imagePath": "library/nginx",
+                        "tag": "1.19",
+                        "__uuid": "OPDEDpT2S_2PFqeWVVhEsc"
+                      },
+                      "__uuid": "OPDdgpT2S_2PFqeWVVhEwA"
+                    },
+                    "__uuid": "OPjhDpT2S_2PFqeWVVhEwA"
+                  },
+                  "manifests": [
+                    {
+                      "manifest": {
+                        "identifier": "baseValues",
+                        "type": "K8sManifest",
+                        "spec": {
+                          "store": {
+                            "type": "Git",
+                            "spec": {
+                              "connectorRef": "my_git_connector",
+                              "gitFetchType": "Branch",
+                              "branch": "master",
+                              "paths": [
+                                "test/spec"
+                              ],
+                              "__uuid": "7Oszx9TqQWbbkz3_emc5ng"
+                            },
+                            "__uuid": "7Oszx9Tqkm2Nkz3_emc5ng"
+                          },
+                          "__uuid": "7Oszx9TqQweNkz3_emc5ng"
+                        },
+                        "__uuid": "7Oszx9TjjW2Nkz3_emc5ng"
+                      },
+                      "__uuid": "7Oszx9TgtW2Nkz3_emc5ng"
+                    }
+                  ],
+                  "__uuid": "7Oszx9TqQsdNkz3_emc5ng"
+                },
+                "__uuid": "7Oszx9TqQW2hhz3_emc5ng"
+              },
+              "__uuid": "7Oszx9TqQddNkz3_emc5ng"
+            },
+            "infrastructure": {
+              "environment": {
+                "identifier": "stagingInfra",
+                "type": "PreProduction",
+                "tags": {
+                  "cloud": "GCP",
+                  "team": "cdp",
+                  "__uuid": "VgWSDz31S3eZdAtFvTHHoA"
+                },
+                "__uuid": "qOnpI7A_SX6-K6JSr7TKKA"
+              },
+              "infrastructureDefinition": {
+                "type": "KubernetesDirect",
+                "spec": {
+                  "connectorRef": "account.argocd-account",
+                  "namespace": "harness",
+                  "releaseName": "testingqa",
+                  "__uuid": "cX5YIAPUQqOlyuSFyKOVGA"
+                },
+                "__uuid": "d2f8dAryRXeX4nY4dssJxQ"
+              },
+              "__uuid": "KmxClH1bSKiNstn52Cf6BA"
+            },
+            "execution": {
+              "steps": [
+                {
+                  "step": {
+                    "name": "Rollout Deployment",
+                    "identifier": "rolloutDeployment",
+                    "type": "K8sRollingDeploy",
+                    "spec": {
+                      "timeout": 120000,
+                      "skipDryRun": false,
+                      "__uuid": "OPDEDpT2S_2PFqeWVVhEwA"
+                    },
+                    "__uuid": "r8Uq7gxzS42XfE54jfaGTw"
+                  },
+                  "__uuid": "QI3_RIg8TQeB9QQOEAiM8w"
+                }
+              ],
+              "__uuid": "CcTvyLUVSoS18MrrFX4pFQ"
+            },
+            "__uuid": "NnmWEe_TRXCba1-R2EsDrw"
+          },
+          "__uuid": "tGufMZnYTNCcFFLz74wtpA"
+        },
+        "__uuid": "tA9GOy9nR3-spMTx2kpKaw"
+      }
+    ],
+    "__uuid": "CRPECVboRjGi9bHpIqbRyw"
+  },
+  "__uuid": "LYeF7J0hQMuoFf3yBt7HBA"
+}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32068)
<!-- Reviewable:end -->
