### PR TITLE
fix: [DEL-3789]: Print delegate configuration in delegate logs

### DIFF
--- a/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
+++ b/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
@@ -650,7 +650,7 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
         startUpgradeCheck(getVersion());
       }
 
-      log.info("Delegate started");
+      log.info("Delegate started with config {} ", getDelegateConfig());
       log.info("Manager Authority:{}, Manager Target:{}", delegateConfiguration.getManagerAuthority(),
           delegateConfiguration.getManagerTarget());
 
@@ -748,6 +748,12 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
     } catch (RuntimeException | IOException e) {
       log.error("Exception while starting/running delegate", e);
     }
+  }
+
+  private String getDelegateConfig() {
+    String delegateConfig = delegateConfiguration.getDelegateConfigAsString();
+    delegateConfig += ", Multiversion: " + String.valueOf(multiVersion);
+    return delegateConfig;
   }
 
   private void maybeUpdateTaskRejectionStatus() {

--- a/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
+++ b/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
@@ -752,7 +752,7 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
 
   private String getDelegateConfig() {
     String delegateConfig = delegateConfiguration.toString();
-    delegateConfig += ", Multiversion: " + String.valueOf(multiVersion);
+    delegateConfig += ", Multiversion: " + multiVersion;
     return delegateConfig;
   }
 

--- a/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
+++ b/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
@@ -751,7 +751,7 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
   }
 
   private String getDelegateConfig() {
-    String delegateConfig = delegateConfiguration.getDelegateConfigAsString();
+    String delegateConfig = delegateConfiguration.toString();
     delegateConfig += ", Multiversion: " + String.valueOf(multiVersion);
     return delegateConfig;
   }

--- a/960-api-services/src/main/java/io/harness/delegate/configuration/DelegateConfiguration.java
+++ b/960-api-services/src/main/java/io/harness/delegate/configuration/DelegateConfiguration.java
@@ -15,8 +15,10 @@ import io.harness.event.client.impl.EventPublisherConstants;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
+@Slf4j
 @Data
 @Builder
 @OwnedBy(DEL)
@@ -72,5 +74,27 @@ public class DelegateConfiguration {
 
   public String getQueueFilePath() {
     return Optional.ofNullable(queueFilePath).orElse(EventPublisherConstants.DEFAULT_QUEUE_FILE_PATH);
+  }
+
+  public String getDelegateConfigAsString() {
+    try {
+      String delegateConfig = this.toString();
+
+      // Remove accountSecret and delegateToken from this object.
+      int startIndex = delegateConfig.indexOf("accountSecret");
+      int endIndex = delegateConfig.indexOf(",", startIndex);
+      String toBeReplaced = delegateConfig.substring(startIndex, endIndex + 1);
+      delegateConfig = delegateConfig.replace(toBeReplaced, "");
+
+      startIndex = delegateConfig.indexOf("delegateToken");
+      endIndex = delegateConfig.indexOf(",", startIndex);
+      toBeReplaced = delegateConfig.substring(startIndex, endIndex + 1);
+      delegateConfig = delegateConfig.replace(toBeReplaced, "");
+
+      return delegateConfig;
+    } catch (Exception ex) {
+      log.error("Encountered error while serializing delegateConfiguration ", ex);
+      return "Config: NA";
+    }
   }
 }

--- a/960-api-services/src/main/java/io/harness/delegate/configuration/DelegateConfiguration.java
+++ b/960-api-services/src/main/java/io/harness/delegate/configuration/DelegateConfiguration.java
@@ -15,17 +15,17 @@ import io.harness.event.client.impl.EventPublisherConstants;
 import java.util.Optional;
 import lombok.Builder;
 import lombok.Data;
-import lombok.extern.slf4j.Slf4j;
+import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 
-@Slf4j
 @Data
 @Builder
+@ToString
 @OwnedBy(DEL)
 public class DelegateConfiguration {
   private String accountId;
-  private String accountSecret;
-  private String delegateToken;
+  @ToString.Exclude private String accountSecret;
+  @ToString.Exclude private String delegateToken;
   private String managerUrl;
   private String verificationServiceUrl;
   private String cvNextGenUrl;
@@ -74,27 +74,5 @@ public class DelegateConfiguration {
 
   public String getQueueFilePath() {
     return Optional.ofNullable(queueFilePath).orElse(EventPublisherConstants.DEFAULT_QUEUE_FILE_PATH);
-  }
-
-  public String getDelegateConfigAsString() {
-    try {
-      String delegateConfig = this.toString();
-
-      // Remove accountSecret and delegateToken from this object.
-      int startIndex = delegateConfig.indexOf("accountSecret");
-      int endIndex = delegateConfig.indexOf(",", startIndex);
-      String toBeReplaced = delegateConfig.substring(startIndex, endIndex + 1);
-      delegateConfig = delegateConfig.replace(toBeReplaced, "");
-
-      startIndex = delegateConfig.indexOf("delegateToken");
-      endIndex = delegateConfig.indexOf(",", startIndex);
-      toBeReplaced = delegateConfig.substring(startIndex, endIndex + 1);
-      delegateConfig = delegateConfig.replace(toBeReplaced, "");
-
-      return delegateConfig;
-    } catch (Exception ex) {
-      log.error("Encountered error while serializing delegateConfiguration ", ex);
-      return "Config: NA";
-    }
   }
 }


### PR DESCRIPTION
Changes to print delegateConfiguration (without secrets) in delegate logs.
This will be helpful in debugging issues in customer environment, where we don't have access to config-delegate.yml

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32236)
<!-- Reviewable:end -->
