### PR TITLE
fix: [DEL-3719]: Improvements in watcher while watching delegate process

### DIFF
--- a/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
+++ b/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
@@ -927,7 +927,9 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
     try {
       FibonacciBackOff.executeForEver(() -> {
         RequestBuilder requestBuilder = prepareRequestBuilder();
-        return socket.open(requestBuilder.build());
+        Socket skt = socket.open(requestBuilder.build());
+        log.info("Socket status: {}", socket.status().toString());
+        return skt;
       });
     } catch (IOException ex) {
       log.error("Unable to open socket", ex);
@@ -1755,7 +1757,7 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
         log.error("Error sending heartbeat", e);
       }
     } else {
-      log.warn("Socket is not open");
+      log.warn("Socket is not open, status: {}", socket.status().toString());
     }
   }
 
@@ -1778,7 +1780,7 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
         log.error("Error sending heartbeat", e);
       }
     } else {
-      log.warn("Socket is not open");
+      log.warn("Socket is not open, status: {}", socket.status().toString());
     }
   }
 

--- a/960-watcher/src/main/java/io/harness/watcher/service/WatcherServiceImpl.java
+++ b/960-watcher/src/main/java/io/harness/watcher/service/WatcherServiceImpl.java
@@ -972,6 +972,16 @@ public class WatcherServiceImpl implements WatcherService {
   }
 
   private boolean isPrimaryDelegate(String delegateVersion, List<String> expectedVersions) {
+    if (isEmpty(delegateVersion)) {
+      if (expectedVersions.size() == 1) {
+        // If we do not have valid delegateVersion and there is only one expected version,
+        // consider that to be primary.
+        log.info("Delegate version is not valid, assuming {} as primary", expectedVersions.get(0));
+        return true;
+      }
+      log.error("Invalid delegate version, expected version {}", expectedVersions.toString());
+      return false;
+    }
     return delegateVersion.equals(getPrimaryDelegate(expectedVersions));
   }
 

--- a/960-watcher/src/main/java/io/harness/watcher/service/WatcherServiceImpl.java
+++ b/960-watcher/src/main/java/io/harness/watcher/service/WatcherServiceImpl.java
@@ -518,6 +518,7 @@ public class WatcherServiceImpl implements WatcherService {
   }
 
   private void watchDelegate() {
+    Map<String, Object> delegateData = null;
     try {
       if (!multiVersion) {
         log.info("Watching delegate processes: {}", runningDelegates);
@@ -561,9 +562,10 @@ public class WatcherServiceImpl implements WatcherService {
       }
 
       List<String> expectedVersions = findExpectedDelegateVersions();
-      if (expectedVersions == null) {
+      if (isEmpty(expectedVersions)) {
         // Something went wrong with obtaining the list with expected delegates.
         // Postpone this for better times.
+        log.error("Unable to fetch expected version, skip watching delegate");
         return;
       }
       Multimap<String, String> runningVersions = LinkedHashMultimap.create();
@@ -573,7 +575,8 @@ public class WatcherServiceImpl implements WatcherService {
         if (!multiVersion) {
           if (working.compareAndSet(false, true)) {
             downloadRunScriptsBeforeRestartingDelegateAndWatcher();
-            startDelegateProcess(null, ".", emptyList(), "DelegateStartScript", getProcessId());
+            startDelegateProcess(
+                getPrimaryDelegate(expectedVersions), ".", emptyList(), "DelegateStartScript", getProcessId());
           }
         }
       } else {
@@ -598,7 +601,7 @@ public class WatcherServiceImpl implements WatcherService {
           notRunning.forEach(delegateVersionMatchedAt::remove);
 
           for (String delegateProcess : runningDelegates) {
-            Map<String, Object> delegateData = messageService.getAllData(DELEGATE_DASH + delegateProcess);
+            delegateData = messageService.getAllData(DELEGATE_DASH + delegateProcess);
             if (delegateData == null) {
               continue;
             }
@@ -654,6 +657,11 @@ public class WatcherServiceImpl implements WatcherService {
                   Optional.ofNullable((Long) delegateData.get(DELEGATE_UPGRADE_STARTED)).orElse(Long.MAX_VALUE);
               boolean upgradeTimedOut = now - upgradeStarted > DELEGATE_UPGRADE_TIMEOUT;
 
+              if (isEmpty(delegateVersion)) {
+                log.error("Unable to read Delegate version for process {}, setting {} as delegate version",
+                    delegateProcess, getPrimaryDelegate(expectedVersions));
+                delegateVersion = getPrimaryDelegate(expectedVersions);
+              }
               if (multiVersion) {
                 if (!expectedVersions.toString().contains(delegateVersion) && !shutdownPending) {
                   log.info("Delegate version {} ({}) is not a published version. Future requests will go to primary.",
@@ -744,7 +752,8 @@ public class WatcherServiceImpl implements WatcherService {
           } else if (drainingRestartNeededList.containsAll(runningDelegates) && working.compareAndSet(false, true)) {
             log.warn(
                 "Delegate processes {} need restart. Starting new process and draining old", drainingRestartNeededList);
-            startDelegateProcess(null, ".", drainingRestartNeededList, DELEGATE_RESTART_SCRIPT, getProcessId());
+            startDelegateProcess(getPrimaryDelegate(expectedVersions), ".", drainingRestartNeededList,
+                DELEGATE_RESTART_SCRIPT, getProcessId());
           }
         }
         if (!multiVersion && isNotEmpty(upgradeNeededList)) {
@@ -753,7 +762,8 @@ public class WatcherServiceImpl implements WatcherService {
             upgradeNeededList.forEach(
                 delegateProcess -> messageService.writeMessageToChannel(DELEGATE, delegateProcess, UPGRADING_DELEGATE));
             downloadRunScriptsBeforeRestartingDelegateAndWatcher();
-            startDelegateProcess(null, ".", upgradeNeededList, "DelegateUpgradeScript", getProcessId());
+            startDelegateProcess(
+                getPrimaryDelegate(expectedVersions), ".", upgradeNeededList, "DelegateUpgradeScript", getProcessId());
           }
         }
 
@@ -816,7 +826,9 @@ public class WatcherServiceImpl implements WatcherService {
         }
       }
     } catch (Exception e) {
-      log.error("Error processing delegate stream: {}", e.getMessage(), e);
+      final String delegateDataAsString = isNotEmpty(delegateData) ? delegateData.toString() : null;
+      log.error(
+          "Error processing delegate stream, message: {}, delegateData: {}", e.getMessage(), delegateDataAsString, e);
     }
   }
 
@@ -888,6 +900,7 @@ public class WatcherServiceImpl implements WatcherService {
   }
 
   private void restartDelegate() {
+    log.info("Received request to restart Delegate");
     if (multiVersion) {
       runningDelegates.forEach(this::drainDelegateProcess);
     } else if (working.compareAndSet(false, true)) {
@@ -958,13 +971,16 @@ public class WatcherServiceImpl implements WatcherService {
     }
   }
 
-  // Last element in expected version list is primary delegate version
   private boolean isPrimaryDelegate(String delegateVersion, List<String> expectedVersions) {
-    if (CollectionUtils.isEmpty(expectedVersions)) {
-      return false;
-    }
+    return delegateVersion.equals(getPrimaryDelegate(expectedVersions));
+  }
 
-    return delegateVersion.equals(expectedVersions.get(expectedVersions.size() - 1));
+  private String getPrimaryDelegate(List<String> expectedVersions) {
+    if (CollectionUtils.isEmpty(expectedVersions)) {
+      return null;
+    }
+    // Last element in expected version list is primary delegate version
+    return expectedVersions.get(expectedVersions.size() - 1);
   }
 
   @VisibleForTesting
@@ -1246,6 +1262,24 @@ public class WatcherServiceImpl implements WatcherService {
   }
 
   private void shutdownDelegate(String delegateProcess) {
+    boolean delegateRunning = true;
+    try {
+      delegateRunning = ProcessControl.isProcessRunning(delegateProcess);
+    } catch (Exception ex) {
+      log.error("Caught exception while getting process status ", ex);
+    }
+    if (!delegateRunning) {
+      log.info("Delegate with ID:{} not running, closing message channel", delegateProcess);
+      delegateProcessMap.remove(delegateProcess);
+      messageService.closeData(DELEGATE_DASH + delegateProcess);
+      messageService.closeChannel(DELEGATE, delegateProcess);
+      synchronized (runningDelegates) {
+        runningDelegates.remove(delegateProcess);
+        messageService.putData(WATCHER_DATA, RUNNING_DELEGATES, runningDelegates);
+      }
+      return;
+    }
+
     executorService.submit(() -> {
       messageService.writeMessageToChannel(DELEGATE, delegateProcess, DELEGATE_STOP_ACQUIRING);
       try {

--- a/980-commons/src/main/java/io/harness/utils/ProcessControl.java
+++ b/980-commons/src/main/java/io/harness/utils/ProcessControl.java
@@ -57,7 +57,7 @@ public class ProcessControl {
     }
   }
 
-  private static boolean isProcessRunning(final String pid) throws IOException, InterruptedException, TimeoutException {
+  public static boolean isProcessRunning(final String pid) throws IOException, InterruptedException, TimeoutException {
     final String isRunningCommand = "kill -0 " + pid;
     return new ProcessExecutor().command("/bin/bash", "-c", isRunningCommand).execute().getExitValue() == 0;
   }


### PR DESCRIPTION
This change-set contains following improvements:
1) Send primaryVersion while starting Delegate process (in case of on-prem)
2) Verbose logging if we get exception in watchDelegate()
3) Look for existence of delegate process before attempting to kill it.

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32265)
<!-- Reviewable:end -->
