### PR TITLE
feat: [PL-24264]: Fetch commit id for file operations in azure

### DIFF
--- a/product/ci/scm/file/file_test.go
+++ b/product/ci/scm/file/file_test.go
@@ -532,3 +532,25 @@ func TestBatchFindFile(t *testing.T) {
 	assert.Contains(t, got.FileContents[0].Content, "test repo for source control operations")
 	assert.Equal(t, "", got.FileContents[1].Content, "missing file has no content")
 }
+
+func TestGetCommitIdByProvider(t *testing.T) {
+	if azureToken == "" {
+		t.Skip("Skipping, Acceptance test")
+	}
+	provider := &pb.Provider{
+		Hook: &pb.Provider_Azure{
+			Azure: &pb.AzureProvider{
+				PersonalAccessToken: azureToken,
+				Organization:        organization,
+				Project:             project,
+			},
+		},
+		Debug: true,
+	}
+
+	log, _ := logs.GetObservedLogger(zap.InfoLevel)
+	got, err := getCommitIdIfEmptyInRequest(context.Background(), "", repoID, "main", provider, log.Sugar())
+
+	assert.Nil(t, err, "no errors")
+	assert.NotNil(t, got, "There is a commit id")
+}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32287)
<!-- Reviewable:end -->
