### PR TITLE
[fix]: [CDS-36417]: add null check

### DIFF
--- a/400-rest/src/main/java/software/wings/sm/states/collaboration/JiraCreateUpdate.java
+++ b/400-rest/src/main/java/software/wings/sm/states/collaboration/JiraCreateUpdate.java
@@ -13,15 +13,12 @@ import static io.harness.beans.ExecutionStatus.FAILED;
 import static io.harness.beans.OrchestrationWorkflowType.BUILD;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
-import static io.harness.delegate.beans.TaskData.DEFAULT_ASYNC_CALL_TIMEOUT;
-import static io.harness.delegate.beans.TaskData.DEFAULT_SYNC_CALL_TIMEOUT;
 import static io.harness.exception.WingsException.USER;
 import static io.harness.validation.Validator.notNullCheck;
 
 import static software.wings.beans.CGConstants.GLOBAL_ENV_ID;
 import static software.wings.beans.TaskType.JIRA;
 
-import static java.lang.String.valueOf;
 import static java.util.stream.Collectors.toMap;
 
 import io.harness.annotations.dev.HarnessModule;

--- a/400-rest/src/main/java/software/wings/sm/states/collaboration/JiraCreateUpdate.java
+++ b/400-rest/src/main/java/software/wings/sm/states/collaboration/JiraCreateUpdate.java
@@ -13,9 +13,12 @@ import static io.harness.beans.ExecutionStatus.FAILED;
 import static io.harness.beans.OrchestrationWorkflowType.BUILD;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
+import static io.harness.delegate.beans.TaskData.DEFAULT_ASYNC_CALL_TIMEOUT;
+import static io.harness.delegate.beans.TaskData.DEFAULT_SYNC_CALL_TIMEOUT;
 import static io.harness.exception.WingsException.USER;
 import static io.harness.validation.Validator.notNullCheck;
 
+import static java.lang.String.valueOf;
 import static software.wings.beans.CGConstants.GLOBAL_ENV_ID;
 import static software.wings.beans.TaskType.JIRA;
 
@@ -189,7 +192,7 @@ public class JiraCreateUpdate extends State implements SweepingOutputStateMixin 
 
     if (areRequiredFieldsTemplatized) {
       createMeta = jiraHelperService.getCreateMetadata(
-          jiraConnectorId, null, project, accountId, context.getAppId(), getTimeoutMillis());
+          jiraConnectorId, null, project, accountId, context.getAppId(), getTimeoutMillis() != null ? getTimeoutMillis() : DEFAULT_SYNC_CALL_TIMEOUT);
       try {
         validateRequiredFields(createMeta, context);
       } catch (HarnessJiraException e) {
@@ -200,7 +203,7 @@ public class JiraCreateUpdate extends State implements SweepingOutputStateMixin 
 
     if (EmptyPredicate.isNotEmpty(customFields)) {
       JiraCreateMetaResponse createMetadata = createMeta == null ? jiraHelperService.getCreateMetadata(jiraConnectorId,
-                                                  null, project, accountId, context.getAppId(), getTimeoutMillis())
+                                                  null, project, accountId, context.getAppId(), getTimeoutMillis() != null ? getTimeoutMillis() : DEFAULT_SYNC_CALL_TIMEOUT)
                                                                  : createMeta;
 
       Map<String, String> customFieldsIdToNameMap = mapCustomFieldsIdsToNames(createMetadata);
@@ -276,7 +279,7 @@ public class JiraCreateUpdate extends State implements SweepingOutputStateMixin 
                       .async(true)
                       .taskType(JIRA.name())
                       .parameters(new Object[] {parameters})
-                      .timeout(getTimeoutMillis())
+                      .timeout(getTimeoutMillis() != null ? getTimeoutMillis() : DEFAULT_ASYNC_CALL_TIMEOUT)
                       .build())
             .tags(jiraConfig.getDelegateSelectors())
             .workflowExecutionId(context.getWorkflowExecutionId())

--- a/400-rest/src/main/java/software/wings/sm/states/collaboration/JiraCreateUpdate.java
+++ b/400-rest/src/main/java/software/wings/sm/states/collaboration/JiraCreateUpdate.java
@@ -18,10 +18,10 @@ import static io.harness.delegate.beans.TaskData.DEFAULT_SYNC_CALL_TIMEOUT;
 import static io.harness.exception.WingsException.USER;
 import static io.harness.validation.Validator.notNullCheck;
 
-import static java.lang.String.valueOf;
 import static software.wings.beans.CGConstants.GLOBAL_ENV_ID;
 import static software.wings.beans.TaskType.JIRA;
 
+import static java.lang.String.valueOf;
 import static java.util.stream.Collectors.toMap;
 
 import io.harness.annotations.dev.HarnessModule;
@@ -191,8 +191,8 @@ public class JiraCreateUpdate extends State implements SweepingOutputStateMixin 
     renderExpressions(context);
 
     if (areRequiredFieldsTemplatized) {
-      createMeta = jiraHelperService.getCreateMetadata(
-          jiraConnectorId, null, project, accountId, context.getAppId(), getTimeoutMillis() != null ? getTimeoutMillis() : DEFAULT_SYNC_CALL_TIMEOUT);
+      createMeta = jiraHelperService.getCreateMetadata(jiraConnectorId, null, project, accountId, context.getAppId(),
+          getTimeoutMillis() != null ? getTimeoutMillis() : JIRA_TASK_TIMEOUT_MILLIS);
       try {
         validateRequiredFields(createMeta, context);
       } catch (HarnessJiraException e) {
@@ -202,9 +202,10 @@ public class JiraCreateUpdate extends State implements SweepingOutputStateMixin 
     }
 
     if (EmptyPredicate.isNotEmpty(customFields)) {
-      JiraCreateMetaResponse createMetadata = createMeta == null ? jiraHelperService.getCreateMetadata(jiraConnectorId,
-                                                  null, project, accountId, context.getAppId(), getTimeoutMillis() != null ? getTimeoutMillis() : DEFAULT_SYNC_CALL_TIMEOUT)
-                                                                 : createMeta;
+      JiraCreateMetaResponse createMetadata = createMeta == null
+          ? jiraHelperService.getCreateMetadata(jiraConnectorId, null, project, accountId, context.getAppId(),
+              getTimeoutMillis() != null ? getTimeoutMillis() : JIRA_TASK_TIMEOUT_MILLIS)
+          : createMeta;
 
       Map<String, String> customFieldsIdToNameMap = mapCustomFieldsIdsToNames(createMetadata);
       Map<String, Map<Object, Object>> customFieldsValueToIdMap =
@@ -279,7 +280,7 @@ public class JiraCreateUpdate extends State implements SweepingOutputStateMixin 
                       .async(true)
                       .taskType(JIRA.name())
                       .parameters(new Object[] {parameters})
-                      .timeout(getTimeoutMillis() != null ? getTimeoutMillis() : DEFAULT_ASYNC_CALL_TIMEOUT)
+                      .timeout(getTimeoutMillis() != null ? getTimeoutMillis() : JIRA_TASK_TIMEOUT_MILLIS)
                       .build())
             .tags(jiraConfig.getDelegateSelectors())
             .workflowExecutionId(context.getWorkflowExecutionId())


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32311)
<!-- Reviewable:end -->
