### PR TITLE
[fix]: [CCM-7324]: Removed default CE permissions from user group creation

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/UserGroupServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/UserGroupServiceImpl.java
@@ -178,7 +178,7 @@ public class UserGroupServiceImpl implements UserGroupService {
     }
     AccountPermissions accountPermissions =
         Optional.ofNullable(userGroup.getAccountPermissions()).orElse(AccountPermissions.builder().build());
-    userGroup.setAccountPermissions(addDefaultCePermissions(accountPermissions));
+    userGroup.setAccountPermissions(accountPermissions);
     UserGroup savedUserGroup = wingsPersistence.saveAndGet(UserGroup.class, userGroup);
     Account account = accountService.get(userGroup.getAccountId());
     notNullCheck("account", account);
@@ -201,16 +201,6 @@ public class UserGroupServiceImpl implements UserGroupService {
     if (!matcher.matches()) {
       throw new InvalidRequestException("User group name is not valid.");
     }
-  }
-
-  private AccountPermissions addDefaultCePermissions(AccountPermissions accountPermissions) {
-    Set<PermissionType> accountPermissionsSet =
-        Optional.ofNullable(accountPermissions.getPermissions()).orElse(new HashSet<>());
-    accountPermissionsSet.add(PermissionType.CE_VIEWER);
-    if (accountPermissionsSet.contains(PermissionType.ACCOUNT_MANAGEMENT)) {
-      accountPermissionsSet.add(PermissionType.CE_ADMIN);
-    }
-    return AccountPermissions.builder().permissions(accountPermissionsSet).build();
   }
 
   private void checkForUserGroupWithSameName(UserGroup userGroup) {
@@ -565,7 +555,7 @@ public class UserGroupServiceImpl implements UserGroupService {
     UpdateOperations<UserGroup> operations = wingsPersistence.createUpdateOperations(UserGroup.class);
     setUnset(operations, UserGroupKeys.appPermissions, appPermissions);
     AccountPermissions accountPermissionsUpdate =
-        addDefaultCePermissions(Optional.ofNullable(accountPermissions).orElse(AccountPermissions.builder().build()));
+        Optional.ofNullable(accountPermissions).orElse(AccountPermissions.builder().build());
     setUnset(operations, UserGroupKeys.accountPermissions, accountPermissionsUpdate);
     UserGroup updatedUserGroup = update(userGroup, operations);
     evictUserPermissionInfoCacheForUserGroup(updatedUserGroup);
@@ -744,7 +734,6 @@ public class UserGroupServiceImpl implements UserGroupService {
     validateAppFilterForAppPermissions(userGroup.getAppPermissions(), userGroup.getAccountId());
     AccountPermissions accountPermissions =
         Optional.ofNullable(userGroup.getAccountPermissions()).orElse(AccountPermissions.builder().build());
-    accountPermissions = addDefaultCePermissions(accountPermissions);
     userGroup.setAccountPermissions(accountPermissions);
     UpdateOperations<UserGroup> operations = wingsPersistence.createUpdateOperations(UserGroup.class);
     setUnset(operations, UserGroupKeys.appPermissions, userGroup.getAppPermissions());

--- a/400-rest/src/main/java/software/wings/service/impl/UserGroupServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/UserGroupServiceImpl.java
@@ -178,7 +178,7 @@ public class UserGroupServiceImpl implements UserGroupService {
     }
     AccountPermissions accountPermissions =
         Optional.ofNullable(userGroup.getAccountPermissions()).orElse(AccountPermissions.builder().build());
-    userGroup.setAccountPermissions(accountPermissions);
+    userGroup.setAccountPermissions(addDefaultCePermissions(accountPermissions));
     UserGroup savedUserGroup = wingsPersistence.saveAndGet(UserGroup.class, userGroup);
     Account account = accountService.get(userGroup.getAccountId());
     notNullCheck("account", account);
@@ -201,6 +201,16 @@ public class UserGroupServiceImpl implements UserGroupService {
     if (!matcher.matches()) {
       throw new InvalidRequestException("User group name is not valid.");
     }
+  }
+
+  private AccountPermissions addDefaultCePermissions(AccountPermissions accountPermissions) {
+    Set<PermissionType> accountPermissionsSet =
+        Optional.ofNullable(accountPermissions.getPermissions()).orElse(new HashSet<>());
+    accountPermissionsSet.add(PermissionType.CE_VIEWER);
+    if (accountPermissionsSet.contains(PermissionType.ACCOUNT_MANAGEMENT)) {
+      accountPermissionsSet.add(PermissionType.CE_ADMIN);
+    }
+    return AccountPermissions.builder().permissions(accountPermissionsSet).build();
   }
 
   private void checkForUserGroupWithSameName(UserGroup userGroup) {


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32318)
<!-- Reviewable:end -->
