### PR TITLE
fix: [CDS-25357]: Ensure metadata is of instance HashMap

### DIFF
--- a/400-rest/src/main/java/software/wings/beans/artifact/ArtifactStreamAttributes.java
+++ b/400-rest/src/main/java/software/wings/beans/artifact/ArtifactStreamAttributes.java
@@ -12,6 +12,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDC;
 import io.harness.annotations.dev.HarnessModule;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.annotations.dev.TargetModule;
+import io.harness.data.structure.EmptyPredicate;
 import io.harness.delegate.beans.artifact.ArtifactFileMetadata;
 import io.harness.delegate.beans.executioncapability.ExecutionCapability;
 import io.harness.delegate.beans.executioncapability.ExecutionCapabilityDemander;
@@ -115,5 +116,16 @@ public class ArtifactStreamAttributes implements ExecutionCapabilityDemander {
       return String.format("https://%s/v2/%s/tags/list", registryHostName, imageName);
     }
     return "https://" + registryHostName + (registryHostName.endsWith("/") ? "" : "/");
+  }
+
+  public void setMetadata(Map<String, String> metadata) {
+    if (EmptyPredicate.isEmpty(metadata)) {
+      this.metadata = metadata;
+      return;
+    }
+    // Doing this so as to avoid ArtifactMetadataEvaluator & Kryo exception using that
+    Map<String, String> recreated = new HashMap<>();
+    metadata.keySet().forEach(key -> recreated.put(key, metadata.get(key)));
+    this.metadata = recreated;
   }
 }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32329)
<!-- Reviewable:end -->
