### PR TITLE
fix: [PL-18485]: Raise alert when a more general issue happens during git integration

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/yaml/YamlGitServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/yaml/YamlGitServiceImpl.java
@@ -1090,7 +1090,8 @@ public class YamlGitServiceImpl implements YamlGitService {
     // We get some exception in delegate while processing git commands, out of those
     // exceptions, we show the git connection error in UI and create alert so that
     // the user is directed to the git connectivity issue page
-    if (ErrorCode.GIT_CONNECTION_ERROR == gitSyncFailureAlertDetails.getErrorCode()) {
+    if (ErrorCode.GIT_CONNECTION_ERROR == gitSyncFailureAlertDetails.getErrorCode()
+        || (ErrorCode.GENERAL_YAML_ERROR == gitSyncFailureAlertDetails.getErrorCode())) {
       alertService.openAlert(accountId, appId, AlertType.GitConnectionError,
           getGitConnectionErrorAlert(accountId, gitSyncFailureAlertDetails));
     } else {

--- a/400-rest/src/main/java/software/wings/service/impl/yaml/YamlGitServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/yaml/YamlGitServiceImpl.java
@@ -1118,7 +1118,7 @@ public class YamlGitServiceImpl implements YamlGitService {
   private GitConnectionErrorAlert getGitConnectionErrorAlert(
       String accountId, GitSyncFailureAlertDetails gitFailureDetails) {
     if (gitFailureDetails == null) {
-      throw new UnexpectedException("The git error detials supplied for the connection error is empty");
+      throw new UnexpectedException("The git error details supplied for the connection error is empty");
     }
     return GitConnectionErrorAlert.builder()
         .accountId(accountId)

--- a/930-delegate-tasks/src/main/java/software/wings/delegatetasks/GitCommandTask.java
+++ b/930-delegate-tasks/src/main/java/software/wings/delegatetasks/GitCommandTask.java
@@ -8,6 +8,7 @@
 package software.wings.delegatetasks;
 
 import static io.harness.data.structure.UUIDGenerator.generateUuid;
+import static io.harness.eraro.ErrorCode.GENERAL_YAML_ERROR;
 import static io.harness.eraro.ErrorCode.GIT_CONNECTION_ERROR;
 import static io.harness.eraro.ErrorCode.GIT_DIFF_COMMIT_NOT_IN_ORDER;
 import static io.harness.eraro.ErrorCode.GIT_UNSEEN_REMOTE_HEAD_COMMIT;
@@ -200,6 +201,8 @@ public class GitCommandTask extends AbstractDelegateRunnableTask {
         return GIT_DIFF_COMMIT_NOT_IN_ORDER;
       } else if (GIT_UNSEEN_REMOTE_HEAD_COMMIT == we.getCode()) {
         return GIT_UNSEEN_REMOTE_HEAD_COMMIT;
+      } else if (GENERAL_YAML_ERROR == we.getCode()) {
+        return GENERAL_YAML_ERROR;
       }
     }
     return null;

--- a/990-commons-test/src/main/java/io/harness/rule/OwnerRule.java
+++ b/990-commons-test/src/main/java/io/harness/rule/OwnerRule.java
@@ -253,6 +253,7 @@ public class OwnerRule implements TestRule {
   public static final String DEV_MITTAL = "devki.mittal";
   public static final String HEN = "hen.amar";
   public static final String LUCAS_SALES = "lucas.sales";
+  public static final String FERNANDOD = "fernando.dourado";
   @Deprecated public static final String UNKNOWN = "unknown";
 
   private static UserInfoBuilder defaultUserInfo(String user) {
@@ -436,6 +437,7 @@ public class OwnerRule implements TestRule {
           .put(DEV_MITTAL, defaultUserInfo(DEV_MITTAL).slack("U032JRFUZT2").team(CI).build())
           .put(HEN, defaultUserInfo(HEN).slack("U02MD3UMWUA").team(CI).build())
           .put(LUCAS_SALES, defaultUserInfo(LUCAS_SALES).slack("U038PURJS69").team(SPG).build())
+          .put(FERNANDOD, defaultUserInfo(FERNANDOD).slack("U039ESJUMFA").team(SPG).build())
           .build();
 
   private static String prDeveloperId = findDeveloperId(System.getenv(GHPRB_PULL_AUTHOR_EMAIL));
@@ -453,6 +455,7 @@ public class OwnerRule implements TestRule {
           .put(PL, TeamInfo.builder().team(PL).leader(ANKIT).leader(VIKAS).build())
           .put(SWAT, TeamInfo.builder().team(SWAT).leader(BRETT).build())
           .put(GTM, TeamInfo.builder().team(GTM).leader(RAMA).build())
+          .put(SPG, TeamInfo.builder().team(SPG).leader(SRINIVAS).build())
           .build();
 
   @Override


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32342)
<!-- Reviewable:end -->
