### PR TITLE
[Fix]: [CCM-7400]: Disabling batch stackdriver metrics

### DIFF
--- a/280-batch-processing/src/main/java/io/harness/batch/processing/svcmetrics/BatchJobExecutionListener.java
+++ b/280-batch-processing/src/main/java/io/harness/batch/processing/svcmetrics/BatchJobExecutionListener.java
@@ -43,8 +43,9 @@ public class BatchJobExecutionListener implements JobExecutionListener {
     long durationInSeconds = durationInMillis / 1000;
 
     log.info("Job execution completed in {} sec: accountId={} jobType={}", durationInSeconds, accountId, jobType);
-    try (BatchJobContext _ = new BatchJobContext(accountId, jobType)) {
-      metricService.recordMetric(BatchProcessingMetricName.JOB_EXECUTION_TIME_IN_SEC, durationInSeconds);
-    }
+    // disabling it for now --> Ingestion volume was high.
+    //    try (BatchJobContext _ = new BatchJobContext(accountId, jobType)) {
+    //      metricService.recordMetric(BatchProcessingMetricName.JOB_EXECUTION_TIME_IN_SEC, durationInSeconds);
+    //    }
   }
 }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32370)
<!-- Reviewable:end -->
