### PR TITLE
fix: [CI-3655]: remove redundant checks for plugin images

### DIFF
--- a/320-ci-execution/src/main/java/io/harness/execution/CIExecutionConfigService.java
+++ b/320-ci-execution/src/main/java/io/harness/execution/CIExecutionConfigService.java
@@ -131,69 +131,69 @@ public class CIExecutionConfigService {
                                .version(ciExecutionConfig.getLiteEngineImage())
                                .build());
       }
-      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
-              ciExecutionConfig.getCacheS3Tag())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getArtifactoryUploadConfig().getImage().equals(
-              ciExecutionConfig.getArtifactoryUploadTag())) {
-        deprecatedTags.add(DeprecatedImageInfo.builder()
-                               .tag("ArtifactoryUploadImage")
-                               .version(ciExecutionConfig.getArtifactoryUploadTag())
-                               .build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getCacheGCSConfig().getImage().equals(
-              ciExecutionConfig.getCacheGCSTag())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("CacheGCSImage").version(ciExecutionConfig.getCacheGCSTag()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getS3UploadConfig().getImage().equals(
-              ciExecutionConfig.getS3UploadImage())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("S3UploadImage").version(ciExecutionConfig.getS3UploadImage()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
-              ciExecutionConfig.getCacheS3Tag())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getGcsUploadConfig().getImage().equals(
-              ciExecutionConfig.getGcsUploadImage())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("GCSUploadImage").version(ciExecutionConfig.getGcsUploadImage()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getSecurityConfig().getImage().equals(
-              ciExecutionConfig.getSecurityImage())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("SecurityImage").version(ciExecutionConfig.getGcsUploadImage()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushDockerRegistryConfig().getImage().equals(
-              ciExecutionConfig.getBuildAndPushDockerRegistryImage())) {
-        deprecatedTags.add(DeprecatedImageInfo.builder()
-                               .tag("BuildAndPushDockerImage")
-                               .version(ciExecutionConfig.getBuildAndPushDockerRegistryImage())
-                               .build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getGitCloneConfig().getImage().equals(
-              ciExecutionConfig.getGitCloneImage())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("GitCloneImage").version(ciExecutionConfig.getGitCloneImage()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushECRConfig().getImage().equals(
-              ciExecutionConfig.getBuildAndPushECRImage())) {
-        deprecatedTags.add(DeprecatedImageInfo.builder()
-                               .tag("BuildAndPushECRConfigImage")
-                               .version(ciExecutionConfig.getBuildAndPushECRImage())
-                               .build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushGCRConfig().getImage().equals(
-              ciExecutionConfig.getBuildAndPushGCRImage())) {
-        deprecatedTags.add(DeprecatedImageInfo.builder()
-                               .tag("BuildAndPushGCRConfigImage")
-                               .version(ciExecutionConfig.getBuildAndPushGCRImage())
-                               .build());
-      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
+      //              ciExecutionConfig.getCacheS3Tag())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getArtifactoryUploadConfig().getImage().equals(
+      //              ciExecutionConfig.getArtifactoryUploadTag())) {
+      //        deprecatedTags.add(DeprecatedImageInfo.builder()
+      //                               .tag("ArtifactoryUploadImage")
+      //                               .version(ciExecutionConfig.getArtifactoryUploadTag())
+      //                               .build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getCacheGCSConfig().getImage().equals(
+      //              ciExecutionConfig.getCacheGCSTag())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("CacheGCSImage").version(ciExecutionConfig.getCacheGCSTag()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getS3UploadConfig().getImage().equals(
+      //              ciExecutionConfig.getS3UploadImage())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("S3UploadImage").version(ciExecutionConfig.getS3UploadImage()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
+      //              ciExecutionConfig.getCacheS3Tag())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getGcsUploadConfig().getImage().equals(
+      //              ciExecutionConfig.getGcsUploadImage())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("GCSUploadImage").version(ciExecutionConfig.getGcsUploadImage()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getSecurityConfig().getImage().equals(
+      //              ciExecutionConfig.getSecurityImage())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("SecurityImage").version(ciExecutionConfig.getGcsUploadImage()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushDockerRegistryConfig().getImage().equals(
+      //              ciExecutionConfig.getBuildAndPushDockerRegistryImage())) {
+      //        deprecatedTags.add(DeprecatedImageInfo.builder()
+      //                               .tag("BuildAndPushDockerImage")
+      //                               .version(ciExecutionConfig.getBuildAndPushDockerRegistryImage())
+      //                               .build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getGitCloneConfig().getImage().equals(
+      //              ciExecutionConfig.getGitCloneImage())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("GitCloneImage").version(ciExecutionConfig.getGitCloneImage()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushECRConfig().getImage().equals(
+      //              ciExecutionConfig.getBuildAndPushECRImage())) {
+      //        deprecatedTags.add(DeprecatedImageInfo.builder()
+      //                               .tag("BuildAndPushECRConfigImage")
+      //                               .version(ciExecutionConfig.getBuildAndPushECRImage())
+      //                               .build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushGCRConfig().getImage().equals(
+      //              ciExecutionConfig.getBuildAndPushGCRImage())) {
+      //        deprecatedTags.add(DeprecatedImageInfo.builder()
+      //                               .tag("BuildAndPushGCRConfigImage")
+      //                               .version(ciExecutionConfig.getBuildAndPushGCRImage())
+      //                               .build());
+      //      }
     }
     return deprecatedTags;
   }

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
 build.number=74615
-build.patch=000
+build.patch=001
 delegate.version=22.03.13
 delegate.patch=000


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32376)
<!-- Reviewable:end -->
