### PR TITLE
fix: [CI-3655]: remove redundant checks for plugin images

### DIFF
--- a/320-ci-execution/src/main/java/io/harness/execution/CIExecutionConfigService.java
+++ b/320-ci-execution/src/main/java/io/harness/execution/CIExecutionConfigService.java
@@ -131,69 +131,69 @@ public class CIExecutionConfigService {
                                .version(ciExecutionConfig.getLiteEngineImage())
                                .build());
       }
-      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
-              ciExecutionConfig.getCacheS3Tag())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getArtifactoryUploadConfig().getImage().equals(
-              ciExecutionConfig.getArtifactoryUploadTag())) {
-        deprecatedTags.add(DeprecatedImageInfo.builder()
-                               .tag("ArtifactoryUploadImage")
-                               .version(ciExecutionConfig.getArtifactoryUploadTag())
-                               .build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getCacheGCSConfig().getImage().equals(
-              ciExecutionConfig.getCacheGCSTag())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("CacheGCSImage").version(ciExecutionConfig.getCacheGCSTag()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getS3UploadConfig().getImage().equals(
-              ciExecutionConfig.getS3UploadImage())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("S3UploadImage").version(ciExecutionConfig.getS3UploadImage()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
-              ciExecutionConfig.getCacheS3Tag())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getGcsUploadConfig().getImage().equals(
-              ciExecutionConfig.getGcsUploadImage())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("GCSUploadImage").version(ciExecutionConfig.getGcsUploadImage()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getSecurityConfig().getImage().equals(
-              ciExecutionConfig.getSecurityImage())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("SecurityImage").version(ciExecutionConfig.getGcsUploadImage()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushDockerRegistryConfig().getImage().equals(
-              ciExecutionConfig.getBuildAndPushDockerRegistryImage())) {
-        deprecatedTags.add(DeprecatedImageInfo.builder()
-                               .tag("BuildAndPushDockerImage")
-                               .version(ciExecutionConfig.getBuildAndPushDockerRegistryImage())
-                               .build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getGitCloneConfig().getImage().equals(
-              ciExecutionConfig.getGitCloneImage())) {
-        deprecatedTags.add(
-            DeprecatedImageInfo.builder().tag("GitCloneImage").version(ciExecutionConfig.getGitCloneImage()).build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushECRConfig().getImage().equals(
-              ciExecutionConfig.getBuildAndPushECRImage())) {
-        deprecatedTags.add(DeprecatedImageInfo.builder()
-                               .tag("BuildAndPushECRConfigImage")
-                               .version(ciExecutionConfig.getBuildAndPushECRImage())
-                               .build());
-      }
-      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushGCRConfig().getImage().equals(
-              ciExecutionConfig.getBuildAndPushGCRImage())) {
-        deprecatedTags.add(DeprecatedImageInfo.builder()
-                               .tag("BuildAndPushGCRConfigImage")
-                               .version(ciExecutionConfig.getBuildAndPushGCRImage())
-                               .build());
-      }
+//      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
+//              ciExecutionConfig.getCacheS3Tag())) {
+//        deprecatedTags.add(
+//            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
+//      }
+//      if (!ciExecutionServiceConfig.getStepConfig().getArtifactoryUploadConfig().getImage().equals(
+//              ciExecutionConfig.getArtifactoryUploadTag())) {
+//        deprecatedTags.add(DeprecatedImageInfo.builder()
+//                               .tag("ArtifactoryUploadImage")
+//                               .version(ciExecutionConfig.getArtifactoryUploadTag())
+//                               .build());
+//      }
+//      if (!ciExecutionServiceConfig.getStepConfig().getCacheGCSConfig().getImage().equals(
+//              ciExecutionConfig.getCacheGCSTag())) {
+//        deprecatedTags.add(
+//            DeprecatedImageInfo.builder().tag("CacheGCSImage").version(ciExecutionConfig.getCacheGCSTag()).build());
+//      }
+//      if (!ciExecutionServiceConfig.getStepConfig().getS3UploadConfig().getImage().equals(
+//              ciExecutionConfig.getS3UploadImage())) {
+//        deprecatedTags.add(
+//            DeprecatedImageInfo.builder().tag("S3UploadImage").version(ciExecutionConfig.getS3UploadImage()).build());
+//      }
+//      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
+//              ciExecutionConfig.getCacheS3Tag())) {
+//        deprecatedTags.add(
+//            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
+//      }
+//      if (!ciExecutionServiceConfig.getStepConfig().getGcsUploadConfig().getImage().equals(
+//              ciExecutionConfig.getGcsUploadImage())) {
+//        deprecatedTags.add(
+//            DeprecatedImageInfo.builder().tag("GCSUploadImage").version(ciExecutionConfig.getGcsUploadImage()).build());
+//      }
+//      if (!ciExecutionServiceConfig.getStepConfig().getSecurityConfig().getImage().equals(
+//              ciExecutionConfig.getSecurityImage())) {
+//        deprecatedTags.add(
+//            DeprecatedImageInfo.builder().tag("SecurityImage").version(ciExecutionConfig.getGcsUploadImage()).build());
+//      }
+//      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushDockerRegistryConfig().getImage().equals(
+//              ciExecutionConfig.getBuildAndPushDockerRegistryImage())) {
+//        deprecatedTags.add(DeprecatedImageInfo.builder()
+//                               .tag("BuildAndPushDockerImage")
+//                               .version(ciExecutionConfig.getBuildAndPushDockerRegistryImage())
+//                               .build());
+//      }
+//      if (!ciExecutionServiceConfig.getStepConfig().getGitCloneConfig().getImage().equals(
+//              ciExecutionConfig.getGitCloneImage())) {
+//        deprecatedTags.add(
+//            DeprecatedImageInfo.builder().tag("GitCloneImage").version(ciExecutionConfig.getGitCloneImage()).build());
+//      }
+//      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushECRConfig().getImage().equals(
+//              ciExecutionConfig.getBuildAndPushECRImage())) {
+//        deprecatedTags.add(DeprecatedImageInfo.builder()
+//                               .tag("BuildAndPushECRConfigImage")
+//                               .version(ciExecutionConfig.getBuildAndPushECRImage())
+//                               .build());
+//      }
+//      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushGCRConfig().getImage().equals(
+//              ciExecutionConfig.getBuildAndPushGCRImage())) {
+//        deprecatedTags.add(DeprecatedImageInfo.builder()
+//                               .tag("BuildAndPushGCRConfigImage")
+//                               .version(ciExecutionConfig.getBuildAndPushGCRImage())
+//                               .build());
+//      }
     }
     return deprecatedTags;
   }

--- a/320-ci-execution/src/main/java/io/harness/execution/CIExecutionConfigService.java
+++ b/320-ci-execution/src/main/java/io/harness/execution/CIExecutionConfigService.java
@@ -131,69 +131,69 @@ public class CIExecutionConfigService {
                                .version(ciExecutionConfig.getLiteEngineImage())
                                .build());
       }
-//      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
-//              ciExecutionConfig.getCacheS3Tag())) {
-//        deprecatedTags.add(
-//            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
-//      }
-//      if (!ciExecutionServiceConfig.getStepConfig().getArtifactoryUploadConfig().getImage().equals(
-//              ciExecutionConfig.getArtifactoryUploadTag())) {
-//        deprecatedTags.add(DeprecatedImageInfo.builder()
-//                               .tag("ArtifactoryUploadImage")
-//                               .version(ciExecutionConfig.getArtifactoryUploadTag())
-//                               .build());
-//      }
-//      if (!ciExecutionServiceConfig.getStepConfig().getCacheGCSConfig().getImage().equals(
-//              ciExecutionConfig.getCacheGCSTag())) {
-//        deprecatedTags.add(
-//            DeprecatedImageInfo.builder().tag("CacheGCSImage").version(ciExecutionConfig.getCacheGCSTag()).build());
-//      }
-//      if (!ciExecutionServiceConfig.getStepConfig().getS3UploadConfig().getImage().equals(
-//              ciExecutionConfig.getS3UploadImage())) {
-//        deprecatedTags.add(
-//            DeprecatedImageInfo.builder().tag("S3UploadImage").version(ciExecutionConfig.getS3UploadImage()).build());
-//      }
-//      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
-//              ciExecutionConfig.getCacheS3Tag())) {
-//        deprecatedTags.add(
-//            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
-//      }
-//      if (!ciExecutionServiceConfig.getStepConfig().getGcsUploadConfig().getImage().equals(
-//              ciExecutionConfig.getGcsUploadImage())) {
-//        deprecatedTags.add(
-//            DeprecatedImageInfo.builder().tag("GCSUploadImage").version(ciExecutionConfig.getGcsUploadImage()).build());
-//      }
-//      if (!ciExecutionServiceConfig.getStepConfig().getSecurityConfig().getImage().equals(
-//              ciExecutionConfig.getSecurityImage())) {
-//        deprecatedTags.add(
-//            DeprecatedImageInfo.builder().tag("SecurityImage").version(ciExecutionConfig.getGcsUploadImage()).build());
-//      }
-//      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushDockerRegistryConfig().getImage().equals(
-//              ciExecutionConfig.getBuildAndPushDockerRegistryImage())) {
-//        deprecatedTags.add(DeprecatedImageInfo.builder()
-//                               .tag("BuildAndPushDockerImage")
-//                               .version(ciExecutionConfig.getBuildAndPushDockerRegistryImage())
-//                               .build());
-//      }
-//      if (!ciExecutionServiceConfig.getStepConfig().getGitCloneConfig().getImage().equals(
-//              ciExecutionConfig.getGitCloneImage())) {
-//        deprecatedTags.add(
-//            DeprecatedImageInfo.builder().tag("GitCloneImage").version(ciExecutionConfig.getGitCloneImage()).build());
-//      }
-//      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushECRConfig().getImage().equals(
-//              ciExecutionConfig.getBuildAndPushECRImage())) {
-//        deprecatedTags.add(DeprecatedImageInfo.builder()
-//                               .tag("BuildAndPushECRConfigImage")
-//                               .version(ciExecutionConfig.getBuildAndPushECRImage())
-//                               .build());
-//      }
-//      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushGCRConfig().getImage().equals(
-//              ciExecutionConfig.getBuildAndPushGCRImage())) {
-//        deprecatedTags.add(DeprecatedImageInfo.builder()
-//                               .tag("BuildAndPushGCRConfigImage")
-//                               .version(ciExecutionConfig.getBuildAndPushGCRImage())
-//                               .build());
-//      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
+      //              ciExecutionConfig.getCacheS3Tag())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getArtifactoryUploadConfig().getImage().equals(
+      //              ciExecutionConfig.getArtifactoryUploadTag())) {
+      //        deprecatedTags.add(DeprecatedImageInfo.builder()
+      //                               .tag("ArtifactoryUploadImage")
+      //                               .version(ciExecutionConfig.getArtifactoryUploadTag())
+      //                               .build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getCacheGCSConfig().getImage().equals(
+      //              ciExecutionConfig.getCacheGCSTag())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("CacheGCSImage").version(ciExecutionConfig.getCacheGCSTag()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getS3UploadConfig().getImage().equals(
+      //              ciExecutionConfig.getS3UploadImage())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("S3UploadImage").version(ciExecutionConfig.getS3UploadImage()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
+      //              ciExecutionConfig.getCacheS3Tag())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getGcsUploadConfig().getImage().equals(
+      //              ciExecutionConfig.getGcsUploadImage())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("GCSUploadImage").version(ciExecutionConfig.getGcsUploadImage()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getSecurityConfig().getImage().equals(
+      //              ciExecutionConfig.getSecurityImage())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("SecurityImage").version(ciExecutionConfig.getGcsUploadImage()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushDockerRegistryConfig().getImage().equals(
+      //              ciExecutionConfig.getBuildAndPushDockerRegistryImage())) {
+      //        deprecatedTags.add(DeprecatedImageInfo.builder()
+      //                               .tag("BuildAndPushDockerImage")
+      //                               .version(ciExecutionConfig.getBuildAndPushDockerRegistryImage())
+      //                               .build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getGitCloneConfig().getImage().equals(
+      //              ciExecutionConfig.getGitCloneImage())) {
+      //        deprecatedTags.add(
+      //            DeprecatedImageInfo.builder().tag("GitCloneImage").version(ciExecutionConfig.getGitCloneImage()).build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushECRConfig().getImage().equals(
+      //              ciExecutionConfig.getBuildAndPushECRImage())) {
+      //        deprecatedTags.add(DeprecatedImageInfo.builder()
+      //                               .tag("BuildAndPushECRConfigImage")
+      //                               .version(ciExecutionConfig.getBuildAndPushECRImage())
+      //                               .build());
+      //      }
+      //      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushGCRConfig().getImage().equals(
+      //              ciExecutionConfig.getBuildAndPushGCRImage())) {
+      //        deprecatedTags.add(DeprecatedImageInfo.builder()
+      //                               .tag("BuildAndPushGCRConfigImage")
+      //                               .version(ciExecutionConfig.getBuildAndPushGCRImage())
+      //                               .build());
+      //      }
     }
     return deprecatedTags;
   }

--- a/320-ci-execution/src/main/java/io/harness/execution/CIExecutionConfigService.java
+++ b/320-ci-execution/src/main/java/io/harness/execution/CIExecutionConfigService.java
@@ -131,69 +131,6 @@ public class CIExecutionConfigService {
                                .version(ciExecutionConfig.getLiteEngineImage())
                                .build());
       }
-      //      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
-      //              ciExecutionConfig.getCacheS3Tag())) {
-      //        deprecatedTags.add(
-      //            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
-      //      }
-      //      if (!ciExecutionServiceConfig.getStepConfig().getArtifactoryUploadConfig().getImage().equals(
-      //              ciExecutionConfig.getArtifactoryUploadTag())) {
-      //        deprecatedTags.add(DeprecatedImageInfo.builder()
-      //                               .tag("ArtifactoryUploadImage")
-      //                               .version(ciExecutionConfig.getArtifactoryUploadTag())
-      //                               .build());
-      //      }
-      //      if (!ciExecutionServiceConfig.getStepConfig().getCacheGCSConfig().getImage().equals(
-      //              ciExecutionConfig.getCacheGCSTag())) {
-      //        deprecatedTags.add(
-      //            DeprecatedImageInfo.builder().tag("CacheGCSImage").version(ciExecutionConfig.getCacheGCSTag()).build());
-      //      }
-      //      if (!ciExecutionServiceConfig.getStepConfig().getS3UploadConfig().getImage().equals(
-      //              ciExecutionConfig.getS3UploadImage())) {
-      //        deprecatedTags.add(
-      //            DeprecatedImageInfo.builder().tag("S3UploadImage").version(ciExecutionConfig.getS3UploadImage()).build());
-      //      }
-      //      if (!ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage().equals(
-      //              ciExecutionConfig.getCacheS3Tag())) {
-      //        deprecatedTags.add(
-      //            DeprecatedImageInfo.builder().tag("CacheS3Image").version(ciExecutionConfig.getCacheS3Tag()).build());
-      //      }
-      //      if (!ciExecutionServiceConfig.getStepConfig().getGcsUploadConfig().getImage().equals(
-      //              ciExecutionConfig.getGcsUploadImage())) {
-      //        deprecatedTags.add(
-      //            DeprecatedImageInfo.builder().tag("GCSUploadImage").version(ciExecutionConfig.getGcsUploadImage()).build());
-      //      }
-      //      if (!ciExecutionServiceConfig.getStepConfig().getSecurityConfig().getImage().equals(
-      //              ciExecutionConfig.getSecurityImage())) {
-      //        deprecatedTags.add(
-      //            DeprecatedImageInfo.builder().tag("SecurityImage").version(ciExecutionConfig.getGcsUploadImage()).build());
-      //      }
-      //      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushDockerRegistryConfig().getImage().equals(
-      //              ciExecutionConfig.getBuildAndPushDockerRegistryImage())) {
-      //        deprecatedTags.add(DeprecatedImageInfo.builder()
-      //                               .tag("BuildAndPushDockerImage")
-      //                               .version(ciExecutionConfig.getBuildAndPushDockerRegistryImage())
-      //                               .build());
-      //      }
-      //      if (!ciExecutionServiceConfig.getStepConfig().getGitCloneConfig().getImage().equals(
-      //              ciExecutionConfig.getGitCloneImage())) {
-      //        deprecatedTags.add(
-      //            DeprecatedImageInfo.builder().tag("GitCloneImage").version(ciExecutionConfig.getGitCloneImage()).build());
-      //      }
-      //      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushECRConfig().getImage().equals(
-      //              ciExecutionConfig.getBuildAndPushECRImage())) {
-      //        deprecatedTags.add(DeprecatedImageInfo.builder()
-      //                               .tag("BuildAndPushECRConfigImage")
-      //                               .version(ciExecutionConfig.getBuildAndPushECRImage())
-      //                               .build());
-      //      }
-      //      if (!ciExecutionServiceConfig.getStepConfig().getBuildAndPushGCRConfig().getImage().equals(
-      //              ciExecutionConfig.getBuildAndPushGCRImage())) {
-      //        deprecatedTags.add(DeprecatedImageInfo.builder()
-      //                               .tag("BuildAndPushGCRConfigImage")
-      //                               .version(ciExecutionConfig.getBuildAndPushGCRImage())
-      //                               .build());
-      //      }
     }
     return deprecatedTags;
   }

--- a/320-ci-execution/src/test/java/io/harness/tiserviceclient/CIExecutionConfigServiceTest.java
+++ b/320-ci-execution/src/test/java/io/harness/tiserviceclient/CIExecutionConfigServiceTest.java
@@ -117,44 +117,44 @@ public class CIExecutionConfigServiceTest extends CIExecutionTestBase {
     assertThat(ciExecutionConfigService.getDeprecatedTags("acct")).isEqualTo(Arrays.asList());
   }
 
-  @Test
-  @Owner(developers = AMAN)
-  @Category(UnitTests.class)
-  public void getDeprecatedImages() {
-    CIExecutionConfig executionConfig = CIExecutionConfig.builder()
-                                            .accountIdentifier("acct")
-                                            .buildAndPushDockerRegistryImage("bpdr:1.2.2")
-                                            .addOnImage("harness/ci-addon:1.0.0")
-                                            .liteEngineImage("harness/ci-lite-engine:1.0.0")
-                                            .gitCloneImage("gc:1.2.2")
-                                            .buildAndPushDockerRegistryImage("bpdr:1.2.2")
-                                            .buildAndPushECRImage("bpecr:1.2.2")
-                                            .buildAndPushGCRImage("bpgcr:1.2.2")
-                                            .gcsUploadImage("gcsupload:1.2.2")
-                                            .s3UploadImage("s3upload:1.2.2")
-                                            .artifactoryUploadTag("art:1.2.2")
-                                            .securityImage("sc:1.2.2")
-                                            .cacheGCSTag("cachegcs:1.2.2")
-                                            .cacheS3Tag("caches3:1.2.2")
-                                            .gcsUploadImage("gcsUpload:1.2.2")
-                                            .build();
-    when(cIExecutionConfigRepository.findFirstByAccountIdentifier("acct")).thenReturn(Optional.of(executionConfig));
-    List<DeprecatedImageInfo> deprecatedImageInfos =
-        Arrays.asList(DeprecatedImageInfo.builder().tag("AddonImage").version("harness/ci-addon:1.0.0").build(),
-            DeprecatedImageInfo.builder().tag("LiteEngineImage").version("harness/ci-lite-engine:1.0.0").build(),
-            DeprecatedImageInfo.builder().tag("CacheS3Image").version("caches3:1.2.2").build(),
-            DeprecatedImageInfo.builder().tag("ArtifactoryUploadImage").version("art:1.2.2").build(),
-            DeprecatedImageInfo.builder().tag("CacheGCSImage").version("cachegcs:1.2.2").build(),
-            DeprecatedImageInfo.builder().tag("S3UploadImage").version("s3upload:1.2.2").build(),
-            DeprecatedImageInfo.builder().tag("CacheS3Image").version("caches3:1.2.2").build(),
-            DeprecatedImageInfo.builder().tag("GCSUploadImage").version("gcsUpload:1.2.2").build(),
-            DeprecatedImageInfo.builder().tag("SecurityImage").version("gcsUpload:1.2.2").build(),
-            DeprecatedImageInfo.builder().tag("BuildAndPushDockerImage").version("bpdr:1.2.2").build(),
-            DeprecatedImageInfo.builder().tag("GitCloneImage").version("gc:1.2.2").build(),
-            DeprecatedImageInfo.builder().tag("BuildAndPushECRConfigImage").version("bpecr:1.2.2").build(),
-            DeprecatedImageInfo.builder().tag("BuildAndPushGCRConfigImage").version("bpgcr:1.2.2").build());
-    assertThat(ciExecutionConfigService.getDeprecatedTags("acct")).isEqualTo(deprecatedImageInfos);
-  }
+  //  @Test
+  //  @Owner(developers = AMAN)
+  //  @Category(UnitTests.class)
+  //  public void getDeprecatedImages() {
+  //    CIExecutionConfig executionConfig = CIExecutionConfig.builder()
+  //                                            .accountIdentifier("acct")
+  //                                            .buildAndPushDockerRegistryImage("bpdr:1.2.2")
+  //                                            .addOnImage("harness/ci-addon:1.0.0")
+  //                                            .liteEngineImage("harness/ci-lite-engine:1.0.0")
+  //                                            .gitCloneImage("gc:1.2.2")
+  //                                            .buildAndPushDockerRegistryImage("bpdr:1.2.2")
+  //                                            .buildAndPushECRImage("bpecr:1.2.2")
+  //                                            .buildAndPushGCRImage("bpgcr:1.2.2")
+  //                                            .gcsUploadImage("gcsupload:1.2.2")
+  //                                            .s3UploadImage("s3upload:1.2.2")
+  //                                            .artifactoryUploadTag("art:1.2.2")
+  //                                            .securityImage("sc:1.2.2")
+  //                                            .cacheGCSTag("cachegcs:1.2.2")
+  //                                            .cacheS3Tag("caches3:1.2.2")
+  //                                            .gcsUploadImage("gcsUpload:1.2.2")
+  //                                            .build();
+  //    when(cIExecutionConfigRepository.findFirstByAccountIdentifier("acct")).thenReturn(Optional.of(executionConfig));
+  //    List<DeprecatedImageInfo> deprecatedImageInfos =
+  //        Arrays.asList(DeprecatedImageInfo.builder().tag("AddonImage").version("harness/ci-addon:1.0.0").build(),
+  //            DeprecatedImageInfo.builder().tag("LiteEngineImage").version("harness/ci-lite-engine:1.0.0").build(),
+  //            DeprecatedImageInfo.builder().tag("CacheS3Image").version("caches3:1.2.2").build(),
+  //            DeprecatedImageInfo.builder().tag("ArtifactoryUploadImage").version("art:1.2.2").build(),
+  //            DeprecatedImageInfo.builder().tag("CacheGCSImage").version("cachegcs:1.2.2").build(),
+  //            DeprecatedImageInfo.builder().tag("S3UploadImage").version("s3upload:1.2.2").build(),
+  //            DeprecatedImageInfo.builder().tag("CacheS3Image").version("caches3:1.2.2").build(),
+  //            DeprecatedImageInfo.builder().tag("GCSUploadImage").version("gcsUpload:1.2.2").build(),
+  //            DeprecatedImageInfo.builder().tag("SecurityImage").version("gcsUpload:1.2.2").build(),
+  //            DeprecatedImageInfo.builder().tag("BuildAndPushDockerImage").version("bpdr:1.2.2").build(),
+  //            DeprecatedImageInfo.builder().tag("GitCloneImage").version("gc:1.2.2").build(),
+  //            DeprecatedImageInfo.builder().tag("BuildAndPushECRConfigImage").version("bpecr:1.2.2").build(),
+  //            DeprecatedImageInfo.builder().tag("BuildAndPushGCRConfigImage").version("bpgcr:1.2.2").build());
+  //    assertThat(ciExecutionConfigService.getDeprecatedTags("acct")).isEqualTo(deprecatedImageInfos);
+  //  }
 
   @Test
   @Owner(developers = AMAN)

--- a/320-ci-execution/src/test/java/io/harness/tiserviceclient/CIExecutionConfigServiceTest.java
+++ b/320-ci-execution/src/test/java/io/harness/tiserviceclient/CIExecutionConfigServiceTest.java
@@ -117,45 +117,6 @@ public class CIExecutionConfigServiceTest extends CIExecutionTestBase {
     assertThat(ciExecutionConfigService.getDeprecatedTags("acct")).isEqualTo(Arrays.asList());
   }
 
-  //  @Test
-  //  @Owner(developers = AMAN)
-  //  @Category(UnitTests.class)
-  //  public void getDeprecatedImages() {
-  //    CIExecutionConfig executionConfig = CIExecutionConfig.builder()
-  //                                            .accountIdentifier("acct")
-  //                                            .buildAndPushDockerRegistryImage("bpdr:1.2.2")
-  //                                            .addOnImage("harness/ci-addon:1.0.0")
-  //                                            .liteEngineImage("harness/ci-lite-engine:1.0.0")
-  //                                            .gitCloneImage("gc:1.2.2")
-  //                                            .buildAndPushDockerRegistryImage("bpdr:1.2.2")
-  //                                            .buildAndPushECRImage("bpecr:1.2.2")
-  //                                            .buildAndPushGCRImage("bpgcr:1.2.2")
-  //                                            .gcsUploadImage("gcsupload:1.2.2")
-  //                                            .s3UploadImage("s3upload:1.2.2")
-  //                                            .artifactoryUploadTag("art:1.2.2")
-  //                                            .securityImage("sc:1.2.2")
-  //                                            .cacheGCSTag("cachegcs:1.2.2")
-  //                                            .cacheS3Tag("caches3:1.2.2")
-  //                                            .gcsUploadImage("gcsUpload:1.2.2")
-  //                                            .build();
-  //    when(cIExecutionConfigRepository.findFirstByAccountIdentifier("acct")).thenReturn(Optional.of(executionConfig));
-  //    List<DeprecatedImageInfo> deprecatedImageInfos =
-  //        Arrays.asList(DeprecatedImageInfo.builder().tag("AddonImage").version("harness/ci-addon:1.0.0").build(),
-  //            DeprecatedImageInfo.builder().tag("LiteEngineImage").version("harness/ci-lite-engine:1.0.0").build(),
-  //            DeprecatedImageInfo.builder().tag("CacheS3Image").version("caches3:1.2.2").build(),
-  //            DeprecatedImageInfo.builder().tag("ArtifactoryUploadImage").version("art:1.2.2").build(),
-  //            DeprecatedImageInfo.builder().tag("CacheGCSImage").version("cachegcs:1.2.2").build(),
-  //            DeprecatedImageInfo.builder().tag("S3UploadImage").version("s3upload:1.2.2").build(),
-  //            DeprecatedImageInfo.builder().tag("CacheS3Image").version("caches3:1.2.2").build(),
-  //            DeprecatedImageInfo.builder().tag("GCSUploadImage").version("gcsUpload:1.2.2").build(),
-  //            DeprecatedImageInfo.builder().tag("SecurityImage").version("gcsUpload:1.2.2").build(),
-  //            DeprecatedImageInfo.builder().tag("BuildAndPushDockerImage").version("bpdr:1.2.2").build(),
-  //            DeprecatedImageInfo.builder().tag("GitCloneImage").version("gc:1.2.2").build(),
-  //            DeprecatedImageInfo.builder().tag("BuildAndPushECRConfigImage").version("bpecr:1.2.2").build(),
-  //            DeprecatedImageInfo.builder().tag("BuildAndPushGCRConfigImage").version("bpgcr:1.2.2").build());
-  //    assertThat(ciExecutionConfigService.getDeprecatedTags("acct")).isEqualTo(deprecatedImageInfos);
-  //  }
-
   @Test
   @Owner(developers = AMAN)
   @Category(UnitTests.class)

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
 build.number=74806
-build.patch=000
+build.patch=001
 delegate.version=22.04.11
 delegate.patch=000


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32377)
<!-- Reviewable:end -->
