### PR TITLE
fix: [CDS-36340]: Resetting workflow triggeredBy when pipelines are resumed

### DIFF
--- a/400-rest/src/main/java/software/wings/resources/ExecutionResource.java
+++ b/400-rest/src/main/java/software/wings/resources/ExecutionResource.java
@@ -296,8 +296,12 @@ public class ExecutionResource {
       @QueryParam("parallelIndexToResume") int parallelIndexToResume,
       @QueryParam("workflowExecutionId") String workflowExecutionId) {
     WorkflowExecution workflowExecution = workflowExecutionService.getWorkflowExecution(appId, workflowExecutionId);
+
     notNullCheck(EXECUTION_DOES_NOT_EXIST + workflowExecutionId, workflowExecution);
     deploymentAuthHandler.authorize(appId, workflowExecution);
+    if (workflowExecution.getExecutionArgs() != null) {
+      workflowExecution.getExecutionArgs().setCreatedByType(CreatedByType.USER);
+    }
     WorkflowExecution resumedExecution =
         workflowExecutionService.triggerPipelineResumeExecution(appId, parallelIndexToResume, workflowExecution);
     resumedExecution.setStateMachine(null);


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32394)
<!-- Reviewable:end -->
