### PR TITLE
[feat]: [PL-24756]: Update pool size and interval for InstanceStatsIteratorHandler

### DIFF
--- a/126-instance/src/main/java/io/harness/service/stats/statscollector/InstanceStatsIteratorHandler.java
+++ b/126-instance/src/main/java/io/harness/service/stats/statscollector/InstanceStatsIteratorHandler.java
@@ -56,7 +56,7 @@ public class InstanceStatsIteratorHandler implements Handler<DeploymentAccounts>
         MongoPersistenceIterator.<DeploymentAccounts, MorphiaFilterExpander<DeploymentAccounts>>builder()
             .clazz(DeploymentAccounts.class)
             .fieldName(DeploymentAccountsKeys.instanceStatsMetricsPublisherIteration)
-            .targetInterval(ofMinutes(10))
+            .targetInterval(ofMinutes(30))
             .acceptableExecutionTime(ofSeconds(30))
             .acceptableNoAlertDelay(ofSeconds(30))
             .handler(this)

--- a/126-instance/src/main/java/io/harness/service/stats/statscollector/InstanceStatsIteratorHandler.java
+++ b/126-instance/src/main/java/io/harness/service/stats/statscollector/InstanceStatsIteratorHandler.java
@@ -49,8 +49,8 @@ public class InstanceStatsIteratorHandler implements Handler<DeploymentAccounts>
     persistenceIteratorFactory.createPumpIteratorWithDedicatedThreadPool(
         PersistenceIteratorFactory.PumpExecutorOptions.builder()
             .name("InstanceStatsMetricsPublisher")
-            .poolSize(1)
-            .interval(ofMinutes(10))
+            .poolSize(5)
+            .interval(ofMinutes(30))
             .build(),
         InstanceStatsIteratorHandler.class,
         MongoPersistenceIterator.<DeploymentAccounts, MorphiaFilterExpander<DeploymentAccounts>>builder()


### PR DESCRIPTION
Update pool size and interval for InstanceStatsIteratorHandler

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32418)
<!-- Reviewable:end -->
