### PR TITLE
fix: [DEL-3918]: Remove extraneous logging while fetching delegate configuration

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/AccountServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/AccountServiceImpl.java
@@ -978,8 +978,6 @@ public class AccountServiceImpl implements AccountService {
     if (licenseService.isAccountDeleted(accountId)) {
       throw new InvalidRequestException("Deleted AccountId: " + accountId);
     }
-    log.info("feature flag service {}", featureFlagService);
-    log.info("accountID name {}", accountId);
     if (featureFlagService.isEnabled(DELEGATE_VERSION_FROM_RING, accountId)) {
       log.info("Getting delegate configuration from Delegate ring");
 


### PR DESCRIPTION


You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32457)
<!-- Reviewable:end -->
