### PR TITLE
fix: [CDS-36785]: Revert OneOf in PipelineInfoConfig

### DIFF
--- a/860-orchestration-steps/src/main/java/io/harness/plancreator/pipeline/PipelineInfoConfig.java
+++ b/860-orchestration-steps/src/main/java/io/harness/plancreator/pipeline/PipelineInfoConfig.java
@@ -21,7 +21,6 @@ import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.pms.yaml.YamlNode;
 import io.harness.template.yaml.TemplateLinkConfig;
-import io.harness.validation.OneOfSet;
 import io.harness.validator.NGRegexValidatorConstants;
 import io.harness.yaml.YamlSchemaTypes;
 import io.harness.yaml.core.VariableExpression;
@@ -56,11 +55,6 @@ import org.springframework.data.annotation.TypeAlias;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @FieldDefaults(level = AccessLevel.PRIVATE)
 @TypeAlias("pipelineInfoConfig")
-@OneOfSet(
-    fields =
-        {"flowControl, properties, notificationRules, allowStageExecutions, timeout, stages, variables, delegateSelectors",
-            "template"},
-    requiredFieldNames = {"stages", "template"})
 public class PipelineInfoConfig {
   @JsonProperty(YamlNode.UUID_FIELD_NAME)
   @Getter(onMethod_ = { @ApiModelProperty(hidden = true) })

--- a/860-orchestration-steps/src/test/resources/schema/Pipelines/all.json
+++ b/860-orchestration-steps/src/test/resources/schema/Pipelines/all.json
@@ -1749,138 +1749,98 @@
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
     "PipelineInfoConfig": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "identifier",
-            "name",
-            "stages"
-          ],
-          "properties": {
-            "allowStageExecutions": {
-              "type": "boolean"
-            },
-            "delegateSelectors": {
-              "oneOf": [
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                {
-                  "type": "string",
-                  "pattern": "^<\\+input>(\\.(allowedValues|regex)\\(.+?\\))*$",
-                  "minLength": 1
-                }
-              ]
-            },
-            "description": {
-              "type": "string"
-            },
-            "flowControl": {
-              "$ref": "#/definitions/FlowControlConfig"
-            },
-            "identifier": {
-              "type": "string",
-              "pattern": "^[a-zA-Z_][0-9a-zA-Z_$]{0,63}$"
-            },
-            "name": {
-              "type": "string",
-              "pattern": "^[a-zA-Z_][-0-9a-zA-Z_\\s]{0,63}$"
-            },
-            "notificationRules": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/NotificationRules"
-              }
-            },
-            "orgIdentifier": {
-              "type": "string"
-            },
-            "projectIdentifier": {
-              "type": "string"
-            },
-            "properties": {
-              "$ref": "#/definitions/NGProperties"
-            },
-            "stages": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/StageElementWrapperConfig"
-              },
-              "maxItems": 2147483647,
-              "minItems": 1
-            },
-            "tags": {
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "timeout": {
-              "type": "string",
-              "pattern": "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(<\\+input>.*)|(.*<\\+.*>.*))$"
-            },
-            "variables": {
-              "type": "array",
-              "items": {
-                "oneOf": [
-                  {
-                    "$ref": "#/definitions/NumberNGVariable"
-                  },
-                  {
-                    "$ref": "#/definitions/SecretNGVariable"
-                  },
-                  {
-                    "$ref": "#/definitions/StringNGVariable"
-                  }
-                ]
-              }
-            }
-          },
-          "additionalProperties": false
+      "type": "object",
+      "required": [
+        "identifier",
+        "name"
+      ],
+      "properties": {
+        "allowStageExecutions": {
+          "type": "boolean"
         },
-        {
-          "type": "object",
-          "required": [
-            "identifier",
-            "name",
-            "template"
-          ],
-          "properties": {
-            "description": {
-              "type": "string"
-            },
-            "identifier": {
-              "type": "string",
-              "pattern": "^[a-zA-Z_][0-9a-zA-Z_$]{0,63}$"
-            },
-            "name": {
-              "type": "string",
-              "pattern": "^[a-zA-Z_][-0-9a-zA-Z_\\s]{0,63}$"
-            },
-            "orgIdentifier": {
-              "type": "string"
-            },
-            "projectIdentifier": {
-              "type": "string"
-            },
-            "tags": {
-              "type": "object",
-              "additionalProperties": {
+        "delegateSelectors": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
                 "type": "string"
               }
             },
-            "template": {
-              "$ref": "#/definitions/TemplateLinkConfig"
+            {
+              "type": "string",
+              "pattern": "^<\\+input>(\\.(allowedValues|regex)\\(.+?\\))*$",
+              "minLength": 1
             }
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "flowControl": {
+          "$ref": "#/definitions/FlowControlConfig"
+        },
+        "identifier": {
+          "type": "string",
+          "pattern": "^[a-zA-Z_][0-9a-zA-Z_$]{0,63}$"
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^[a-zA-Z_][-0-9a-zA-Z_\\s]{0,63}$"
+        },
+        "notificationRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NotificationRules"
+          }
+        },
+        "orgIdentifier": {
+          "type": "string"
+        },
+        "projectIdentifier": {
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/NGProperties"
+        },
+        "stages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StageElementWrapperConfig"
           },
-          "additionalProperties": false
+          "maxItems": 2147483647,
+          "minItems": 1
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "template": {
+          "$ref": "#/definitions/TemplateLinkConfig"
+        },
+        "timeout": {
+          "type": "string",
+          "pattern": "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(<\\+input>.*)|(.*<\\+.*>.*))$"
+        },
+        "variables": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/NumberNGVariable"
+              },
+              {
+                "$ref": "#/definitions/SecretNGVariable"
+              },
+              {
+                "$ref": "#/definitions/StringNGVariable"
+              }
+            ]
+          }
         }
-      ]
+      },
+      "$schema": "http://json-schema.org/draft-07/schema#"
     },
     "PmsEmailChannel": {
       "allOf": [


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32577)
<!-- Reviewable:end -->
