### PR TITLE
[fix]: [CDS-36596]: changed artifactPath calculation for Azure WebApp

### DIFF
--- a/400-rest/src/main/java/software/wings/sm/states/azure/artifact/ArtifactStreamAttributesMapper.java
+++ b/400-rest/src/main/java/software/wings/sm/states/azure/artifact/ArtifactStreamAttributesMapper.java
@@ -90,9 +90,7 @@ public class ArtifactStreamAttributesMapper extends ArtifactConnectorMapper {
   }
 
   private String getArtifactoryArtifactPath() {
-    String artifactUrl = getArtifactUrlFromStreamMetadata();
-    String jobName = artifactStreamAttributes.getJobName();
-    return "." + artifactUrl.substring(artifactUrl.lastIndexOf(jobName) + jobName.length());
+    return artifactStreamAttributes.getMetadata().get("artifactPath");
   }
 
   public String getArtifactPath() {

--- a/400-rest/src/test/java/software/wings/sm/states/azure/artifact/ArtifactStreamAttributesMapperTest.java
+++ b/400-rest/src/test/java/software/wings/sm/states/azure/artifact/ArtifactStreamAttributesMapperTest.java
@@ -1,0 +1,56 @@
+package software.wings.sm.states.azure.artifact;
+
+import static io.harness.rule.OwnerRule.VAIBHAV_KUMAR;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.harness.category.element.UnitTests;
+import io.harness.rule.Owner;
+
+import software.wings.WingsBaseTest;
+import software.wings.beans.artifact.Artifact;
+import software.wings.beans.artifact.ArtifactStreamAttributes;
+import software.wings.settings.SettingVariableTypes;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class ArtifactStreamAttributesMapperTest extends WingsBaseTest {
+  @Test
+  @Owner(developers = VAIBHAV_KUMAR)
+  @Category(UnitTests.class)
+  public void testGetArtifactPath() {
+    // Case1: when jobName occurs as a substring inside artifactPath
+    String path = "harness-internal/harness-internal/20211208.2.zip";
+    String jobName1 = "harness-internal";
+    String url1 = "https://harness.jfrog.io/artifactory/harness-internal/harness-internal/20211208.2.zip";
+    Map<String, String> metadata = new HashMap<String, String>() {
+      {
+        put("artifactPath", path);
+        put("url", url1);
+      }
+    };
+
+    Artifact artifact = new Artifact();
+    ArtifactStreamAttributes artifactStreamAttributes = ArtifactStreamAttributes.builder()
+                                                            .artifactStreamType(SettingVariableTypes.ARTIFACTORY.name())
+                                                            .jobName(jobName1)
+                                                            .metadata(metadata)
+                                                            .build();
+    ArtifactStreamAttributesMapper artifactStreamAttributesMapper =
+        new ArtifactStreamAttributesMapper(artifact, artifactStreamAttributes);
+    String result = artifactStreamAttributes.getMetadata().get("artifactPath");
+    assertThat(result).isEqualTo(path);
+
+    // Case2: when there is no overlap between jobName and artifactPath
+    String jobName2 = "test";
+    String url2 = "https://harness.jfrog.io/artifactory/test/harness-internal/20211208.2.zip";
+    artifactStreamAttributes.setJobName(jobName2);
+    metadata.put("url", url2);
+    artifactStreamAttributesMapper = new ArtifactStreamAttributesMapper(artifact, artifactStreamAttributes);
+    result = artifactStreamAttributes.getMetadata().get("artifactPath");
+    assertThat(result).isEqualTo(path);
+  }
+}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32581)
<!-- Reviewable:end -->
