### PR TITLE
fix: [PIE-3606]: Adding logging to exceptions in grpc communication

### DIFF
--- a/884-pms-commons/src/main/java/io/harness/pms/utils/PmsGrpcClientUtils.java
+++ b/884-pms-commons/src/main/java/io/harness/pms/utils/PmsGrpcClientUtils.java
@@ -48,8 +48,8 @@ public class PmsGrpcClientUtils {
     } else if (ex instanceof StatusRuntimeException) {
       return processStatusRuntimeException((StatusRuntimeException) ex);
     } else {
-      return new GeneralException(
-          ex == null ? "Unknown error while communicating with pipeline service" : ExceptionUtils.getMessage(ex));
+      log.error("Unknown Error Occurred, check exception logs", ex);
+      return new GeneralException(ex == null ? "Unknown Error Occurred" : ExceptionUtils.getMessage(ex));
     }
   }
 
@@ -59,8 +59,8 @@ public class PmsGrpcClientUtils {
               ? "Unknown grpc error while communicating with pipeline service"
               : ex.getStatus().getDescription());
     }
-    log.error("Error connecting to pipeline service. Is it running?", ex);
-    return new GeneralException("Error connecting to pipeline service");
+    log.error("Unknown Exception Occurred.", ex);
+    return new GeneralException("Unknown Exception Occurred. Please contact with Harness.");
   }
 
   private RetryPolicy<Object> createRetryPolicy() {

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=74914
+build.number=74915
 build.patch=000
 delegate.version=22.04.12
 delegate.patch=000

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
 build.number=74915
-build.patch=000
+build.patch=001
 delegate.version=22.04.12
 delegate.patch=000


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32632)
<!-- Reviewable:end -->
