### PR TITLE
[Feat]: [CCM-7533]: TTL index in k8s workload collection

### DIFF
--- a/280-batch-processing/src/main/java/io/harness/batch/processing/service/impl/WorkloadRepositoryImpl.java
+++ b/280-batch-processing/src/main/java/io/harness/batch/processing/service/impl/WorkloadRepositoryImpl.java
@@ -22,6 +22,9 @@ import io.harness.persistence.HPersistence;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +74,7 @@ public class WorkloadRepositoryImpl implements WorkloadRepository {
                      .set(K8sWorkloadKeys.namespace, podInfo.getNamespace())
                      .set(K8sWorkloadKeys.uid, topLevelOwner.getUid())
                      .set(K8sWorkloadKeys.kind, topLevelOwner.getKind())
+                     .set(K8sWorkloadKeys.ttl, new Date(Instant.now().plus(90, ChronoUnit.DAYS).toEpochMilli()))
                      .set(K8sWorkloadKeys.labels, encodeDotsInKey(labelMap)),
                  HPersistence.upsertReturnNewOptions))
               != null);

--- a/340-ce-nextgen/src/test/resources/mongo/indexes.txt
+++ b/340-ce-nextgen/src/test/resources/mongo/indexes.txt
@@ -49,6 +49,7 @@ k8sWorkload {"name": "accountId_clusterId_uid", "background": true} {"accountId"
 k8sWorkload {"name": "accountId_lastUpdatedAt_labels", "background": true} {"accountId": 1, "lastUpdatedAt": 1, "labels": 1}
 k8sWorkload {"name": "accountId_name_labels", "background": true} {"accountId": 1, "name": 1, "labels": 1}
 k8sWorkload {"name": "no_dup_cluster", "unique": true} {"clusterId": 1, "uid": 1}
+k8sWorkload {"name": "ttl_1", "background": true, "expireAfterSeconds": 0} {"ttl": 1}
 k8sWorkloadRecommendation {"name": "accountId_dirty", "background": true} {"accountId": 1, "dirty": 1}
 k8sWorkloadRecommendation {"name": "estimatedSavings_1", "background": true} {"estimatedSavings": 1}
 k8sWorkloadRecommendation {"name": "ttl_1", "background": true, "expireAfterSeconds": 0} {"ttl": 1}

--- a/490-ce-commons/src/main/java/io/harness/ccm/commons/entities/k8s/K8sWorkload.java
+++ b/490-ce-commons/src/main/java/io/harness/ccm/commons/entities/k8s/K8sWorkload.java
@@ -12,6 +12,7 @@ import static io.harness.annotations.dev.HarnessTeam.CE;
 import io.harness.annotation.StoreIn;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.mongo.index.CompoundMongoIndex;
+import io.harness.mongo.index.FdTtlIndex;
 import io.harness.mongo.index.MongoIndex;
 import io.harness.mongo.index.SortCompoundMongoIndex;
 import io.harness.ng.DbAliases;
@@ -22,6 +23,7 @@ import io.harness.persistence.UpdatedAtAware;
 import io.harness.persistence.UuidAware;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -118,6 +120,8 @@ public final class K8sWorkload implements PersistentEntity, UuidAware, CreatedAt
   @NotEmpty String uid;
   @NotEmpty String kind;
   Map<String, String> labels;
+
+  @FdTtlIndex private Date ttl;
 
   // Mongo has problems for values having dot/period ('.') character. We replace dot with tilde
   // which is not an allowed k8s label character.


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32647)
<!-- Reviewable:end -->
