### PR TITLE
fix: [CDS-36356]: Added the index on servic_infra_info table

### DIFF
--- a/800-pipeline-service/src/main/java/io/harness/pms/migration/CreateIndexForServiceInfraInfoTable.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/migration/CreateIndexForServiceInfraInfoTable.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.pms.migration;
+
+import io.harness.migration.timescale.NGAbstractTimeScaleMigration;
+
+public class CreateIndexForServiceInfraInfoTable extends NGAbstractTimeScaleMigration {
+  @Override
+  public String getFileName() {
+    return "timescale/create_index_for_service_infra_info.sql";
+  }
+}

--- a/800-pipeline-service/src/main/java/io/harness/pms/migration/PipelineCoreTimeScaleMigrationDetails.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/migration/PipelineCoreTimeScaleMigrationDetails.java
@@ -39,6 +39,7 @@ public class PipelineCoreTimeScaleMigrationDetails implements MigrationDetails {
         .add(Pair.of(5, UpdateTimescaleTableCIWithTriggerInfo.class))
         .add(Pair.of(6, UpdateTsCIWithPR.class))
         .add(Pair.of(7, UpdateTsCIWithIsRepoPrivate.class))
+        .add(Pair.of(8, CreateIndexForServiceInfraInfoTable.class))
         .build();
   }
 }

--- a/800-pipeline-service/src/main/resources/timescale/create_index_for_service_infra_info.sql
+++ b/800-pipeline-service/src/main/resources/timescale/create_index_for_service_infra_info.sql
@@ -4,6 +4,6 @@
 -- https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
 
 BEGIN;
- CREATE UNIQUE INDEX accountId_orgId_projecId_serviceId_service_startts ON service_infra_info
+ CREATE INDEX accountId_orgId_projecId_serviceId_service_startts ON service_infra_info
  (accountid, orgidentifier, projectidentifier, service_id, service_startts);
 COMMIT;

--- a/800-pipeline-service/src/main/resources/timescale/create_index_for_service_infra_info.sql
+++ b/800-pipeline-service/src/main/resources/timescale/create_index_for_service_infra_info.sql
@@ -1,0 +1,9 @@
+-- Copyright 2022 Harness Inc. All rights reserved.
+-- Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+-- that can be found in the licenses directory at the root of this repository, also available at
+-- https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+
+BEGIN;
+ CREATE UNIQUE INDEX accountId_orgId_projecId_serviceId_service_startts ON service_infra_info
+ (accountid, orgidentifier, projectidentifier, service_id, service_startts);
+COMMIT;


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32684)
<!-- Reviewable:end -->
