### PR TITLE
[fix]: [CCM-7534]: k8sWorkload query change use workload uid

### DIFF
--- a/280-batch-processing/src/main/java/io/harness/batch/processing/service/impl/WorkloadRepositoryImpl.java
+++ b/280-batch-processing/src/main/java/io/harness/batch/processing/service/impl/WorkloadRepositoryImpl.java
@@ -103,6 +103,16 @@ public class WorkloadRepositoryImpl implements WorkloadRepository {
   }
 
   @Override
+  public List<K8sWorkload> getWorkloadByWorkloadUid(String accountId, String clusterId, Set<String> workloadUid) {
+    return hPersistence.createQuery(K8sWorkload.class, excludeAuthorityCount)
+        .filter(K8sWorkloadKeys.accountId, accountId)
+        .filter(K8sWorkloadKeys.clusterId, clusterId)
+        .field(K8sWorkloadKeys.uid)
+        .in(workloadUid)
+        .asList();
+  }
+
+  @Override
   public List<K8sWorkload> getWorkloadWithoutSorting(
       String accountId, String clusterId, String namespace, Set<String> workloadName) {
     return hPersistence.createQuery(K8sWorkload.class, excludeAuthorityCount)

--- a/280-batch-processing/src/main/java/io/harness/batch/processing/service/intfc/WorkloadRepository.java
+++ b/280-batch-processing/src/main/java/io/harness/batch/processing/service/intfc/WorkloadRepository.java
@@ -18,6 +18,7 @@ import java.util.Set;
 public interface WorkloadRepository {
   void savePodWorkload(String accountId, PodInfo podInfo);
   List<K8sWorkload> getWorkload(String accountId, String clusterId, String namespace, Set<String> workloadName);
+  List<K8sWorkload> getWorkloadByWorkloadUid(String accountId, String clusterId, Set<String> workloadUid);
   List<K8sWorkload> getWorkloadWithoutSorting(
       String accountId, String clusterId, String namespace, Set<String> workloadName);
   Optional<K8sWorkload> getWorkload(String accountId, String clusterId, String uid);

--- a/280-batch-processing/src/main/java/io/harness/batch/processing/tasklet/ClusterDataToBigQueryTasklet.java
+++ b/280-batch-processing/src/main/java/io/harness/batch/processing/tasklet/ClusterDataToBigQueryTasklet.java
@@ -98,6 +98,18 @@ public class ClusterDataToBigQueryTasklet implements Tasklet {
     }
   }
 
+  @Value
+  @EqualsAndHashCode
+  @VisibleForTesting
+  public static class AccountClusterKey {
+    String accountId;
+    String clusterId;
+
+    public static AccountClusterKey getAccountClusterKeyFromInstanceData(InstanceBillingData instanceBillingData) {
+      return new AccountClusterKey(instanceBillingData.getAccountId(), instanceBillingData.getClusterId());
+    }
+  }
+
   @Override
   public RepeatStatus execute(StepContribution stepContribution, ChunkContext chunkContext) throws Exception {
     JobParameters parameters = chunkContext.getStepContext().getStepExecution().getJobParameters();
@@ -145,8 +157,6 @@ public class ClusterDataToBigQueryTasklet implements Tasklet {
   @VisibleForTesting
   public List<ClusterBillingData> getClusterBillingDataForBatch(
       String accountId, BatchJobType batchJobType, List<InstanceBillingData> instanceBillingDataList) {
-    List<ClusterBillingData> clusterBillingDataList = new ArrayList<>();
-
     Map<String, Map<String, String>> instanceIdToLabelMapping = new HashMap<>();
     List<String> instanceIdList =
         instanceBillingDataList.stream()
@@ -161,6 +171,12 @@ public class ClusterDataToBigQueryTasklet implements Tasklet {
       instanceIdToLabelMapping = instanceDataService.fetchLabelsForGivenInstances(accountId, instanceIdList);
     }
 
+    return getClusterBillingDataForBatchWorkloadUid(instanceBillingDataList, instanceIdToLabelMapping);
+  }
+
+  public List<ClusterBillingData> getClusterBillingDataForBatchWorkloadName(String accountId, BatchJobType batchJobType,
+      List<InstanceBillingData> instanceBillingDataList, Map<String, Map<String, String>> instanceIdToLabelMapping) {
+    List<ClusterBillingData> clusterBillingDataList = new ArrayList<>();
     Map<Key, List<InstanceBillingData>> instanceBillingDataGrouped =
         instanceBillingDataList.stream().collect(Collectors.groupingBy(Key::getKeyFromInstanceData));
 
@@ -176,6 +192,32 @@ public class ClusterDataToBigQueryTasklet implements Tasklet {
         Map<String, String> labels = labelMap.get(
             new K8SWorkloadService.CacheKey(instanceBillingData.getAccountId(), instanceBillingData.getClusterId(),
                 instanceBillingData.getNamespace(), instanceBillingData.getWorkloadName()));
+        ClusterBillingData clusterBillingData = convertInstanceBillingDataToAVROObjects(
+            instanceBillingData, labels, instanceIdToLabelMapping.get(instanceBillingData.getInstanceId()));
+        clusterBillingDataList.add(clusterBillingData);
+      }
+    }
+    log.info("Finished Querying data");
+
+    return clusterBillingDataList;
+  }
+
+  public List<ClusterBillingData> getClusterBillingDataForBatchWorkloadUid(
+      List<InstanceBillingData> instanceBillingDataList, Map<String, Map<String, String>> instanceIdToLabelMapping) {
+    List<ClusterBillingData> clusterBillingDataList = new ArrayList<>();
+    Map<AccountClusterKey, List<InstanceBillingData>> instanceBillingDataGrouped =
+        instanceBillingDataList.stream().collect(
+            Collectors.groupingBy(AccountClusterKey::getAccountClusterKeyFromInstanceData));
+
+    log.info("Started Querying data {}", instanceBillingDataGrouped.size());
+    for (AccountClusterKey accountClusterKey : instanceBillingDataGrouped.keySet()) {
+      List<InstanceBillingData> instances = instanceBillingDataGrouped.get(accountClusterKey);
+      Map<K8SWorkloadService.WorkloadUidCacheKey, Map<String, String>> labelMap =
+          getLabelMapForClusterGroup(instances, accountClusterKey);
+
+      for (InstanceBillingData instanceBillingData : instances) {
+        Map<String, String> labels = labelMap.get(new K8SWorkloadService.WorkloadUidCacheKey(
+            instanceBillingData.getAccountId(), instanceBillingData.getClusterId(), instanceBillingData.getTaskId()));
         ClusterBillingData clusterBillingData = convertInstanceBillingDataToAVROObjects(
             instanceBillingData, labels, instanceIdToLabelMapping.get(instanceBillingData.getInstanceId()));
         clusterBillingDataList.add(clusterBillingData);
@@ -205,6 +247,31 @@ public class ClusterDataToBigQueryTasklet implements Tasklet {
     workloads.forEach(workload
         -> labelMap.put(new K8SWorkloadService.CacheKey(accountId, clusterId, namespace, workload.getName()),
             workload.getLabels()));
+    return labelMap;
+  }
+
+  @VisibleForTesting
+  public Map<K8SWorkloadService.WorkloadUidCacheKey, Map<String, String>> getLabelMapForClusterGroup(
+      List<InstanceBillingData> instanceBillingDataList, AccountClusterKey accountClusterKey) {
+    String accountId = accountClusterKey.getAccountId();
+    String clusterId = accountClusterKey.getClusterId();
+    Set<String> workloadUids =
+        instanceBillingDataList.stream()
+            .filter(instanceBillingData
+                -> ImmutableSet.of(InstanceType.K8S_POD_FARGATE.name(), InstanceType.K8S_POD.name())
+                       .contains(instanceBillingData.getInstanceType()))
+            .map(InstanceBillingData::getTaskId)
+            .collect(Collectors.toSet());
+
+    List<K8sWorkload> workloads = new ArrayList<>();
+    if (!workloadUids.isEmpty()) {
+      workloads = workloadRepository.getWorkloadByWorkloadUid(accountId, clusterId, workloadUids);
+    }
+
+    Map<K8SWorkloadService.WorkloadUidCacheKey, Map<String, String>> labelMap = new HashMap<>();
+    workloads.forEach(workload
+        -> labelMap.put(
+            new K8SWorkloadService.WorkloadUidCacheKey(accountId, clusterId, workload.getUid()), workload.getLabels()));
     return labelMap;
   }
 

--- a/280-batch-processing/src/main/java/io/harness/batch/processing/tasklet/support/K8SWorkloadService.java
+++ b/280-batch-processing/src/main/java/io/harness/batch/processing/tasklet/support/K8SWorkloadService.java
@@ -40,6 +40,14 @@ public class K8SWorkloadService extends CacheUtils {
     @Nullable private String workloadName;
   }
 
+  @Value
+  @EqualsAndHashCode
+  public static class WorkloadUidCacheKey {
+    private String accountId;
+    private String clusterId;
+    private String workloadUid;
+  }
+
   public void updateK8sWorkloadLabelCache(CacheKey key, Set<String> workloadNames) {
     List<K8sWorkload> workloads =
         workloadRepository.getWorkload(key.getAccountId(), key.getClusterId(), key.getNamespace(), workloadNames);

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
 build.number=74109
-build.patch=021
+build.patch=022
 delegate.version=22.02.12
 delegate.patch=000


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32727)
<!-- Reviewable:end -->
