### PR TITLE
[CI-3965]: CI manager changes for windows builds in kubernetes

### DIFF
--- a/320-ci-execution/src/main/java/io/harness/ci/integrationstage/CIServiceBuilder.java
+++ b/320-ci-execution/src/main/java/io/harness/ci/integrationstage/CIServiceBuilder.java
@@ -27,6 +27,7 @@ import io.harness.beans.quantity.unit.DecimalQuantityUnit;
 import io.harness.beans.quantity.unit.StorageQuantityUnit;
 import io.harness.beans.serializer.RunTimeInputHandler;
 import io.harness.beans.stages.IntegrationStageConfig;
+import io.harness.beans.yaml.extended.infrastrucutre.OSType;
 import io.harness.ci.config.CIExecutionServiceConfig;
 import io.harness.ci.utils.QuantityUtils;
 import io.harness.delegate.beans.ci.pod.CIContainerType;
@@ -46,8 +47,8 @@ import java.util.Map;
 @OwnedBy(HarnessTeam.CI)
 public class CIServiceBuilder {
   private static final String SEPARATOR = ",";
-  public static List<ContainerDefinitionInfo> createServicesContainerDefinition(
-      StageElementConfig stageElementConfig, PortFinder portFinder, CIExecutionServiceConfig ciExecutionServiceConfig) {
+  public static List<ContainerDefinitionInfo> createServicesContainerDefinition(StageElementConfig stageElementConfig,
+      PortFinder portFinder, CIExecutionServiceConfig ciExecutionServiceConfig, OSType os) {
     List<ContainerDefinitionInfo> containerDefinitionInfos = new ArrayList<>();
     IntegrationStageConfig integrationStage = IntegrationStageUtils.getIntegrationStageConfig(stageElementConfig);
     if (integrationStage.getServiceDependencies() == null
@@ -64,7 +65,7 @@ public class CIServiceBuilder {
       if (dependencyElement.getDependencySpecType() instanceof CIServiceInfo) {
         ContainerDefinitionInfo containerDefinitionInfo =
             createServiceContainerDefinition((CIServiceInfo) dependencyElement.getDependencySpecType(), portFinder,
-                serviceIdx, ciExecutionServiceConfig, stageElementConfig.getIdentifier());
+                serviceIdx, ciExecutionServiceConfig, stageElementConfig.getIdentifier(), os);
         if (containerDefinitionInfo != null) {
           containerDefinitionInfos.add(containerDefinitionInfo);
         }
@@ -75,7 +76,7 @@ public class CIServiceBuilder {
   }
 
   private static ContainerDefinitionInfo createServiceContainerDefinition(CIServiceInfo service, PortFinder portFinder,
-      int serviceIdx, CIExecutionServiceConfig ciExecutionServiceConfig, String identifier) {
+      int serviceIdx, CIExecutionServiceConfig ciExecutionServiceConfig, String identifier, OSType os) {
     Integer port = portFinder.getNextPort();
     service.setGrpcPort(port);
 
@@ -116,7 +117,7 @@ public class CIServiceBuilder {
 
     return ContainerDefinitionInfo.builder()
         .name(containerName)
-        .commands(ServiceContainerUtils.getCommand())
+        .commands(ServiceContainerUtils.getCommand(os))
         .args(ServiceContainerUtils.getArguments(service.getIdentifier(), image, port))
         .envVars(envVariables)
         .containerImageDetails(ContainerImageDetails.builder()

--- a/320-ci-execution/src/main/java/io/harness/ci/integrationstage/K8InitializeStepInfoBuilder.java
+++ b/320-ci-execution/src/main/java/io/harness/ci/integrationstage/K8InitializeStepInfoBuilder.java
@@ -10,6 +10,7 @@ package io.harness.ci.integrationstage;
 import static io.harness.beans.serializer.RunTimeInputHandler.UNRESOLVED_PARAMETER;
 import static io.harness.beans.serializer.RunTimeInputHandler.resolveIntegerParameter;
 import static io.harness.beans.serializer.RunTimeInputHandler.resolveMapParameter;
+import static io.harness.beans.serializer.RunTimeInputHandler.resolveOSType;
 import static io.harness.beans.serializer.RunTimeInputHandler.resolveStringParameter;
 import static io.harness.beans.serializer.RunTimeInputHandler.resolveStringParameterWithDefaultValue;
 import static io.harness.common.CICommonPodConstants.POD_NAME_PREFIX;
@@ -55,6 +56,7 @@ import io.harness.beans.steps.stepinfo.RunTestsStepInfo;
 import io.harness.beans.sweepingoutputs.StageInfraDetails.Type;
 import io.harness.beans.yaml.extended.infrastrucutre.Infrastructure;
 import io.harness.beans.yaml.extended.infrastrucutre.K8sDirectInfraYaml;
+import io.harness.beans.yaml.extended.infrastrucutre.OSType;
 import io.harness.beans.yaml.extended.volumes.CIVolume;
 import io.harness.beans.yaml.extended.volumes.EmptyDirYaml;
 import io.harness.beans.yaml.extended.volumes.HostPathYaml;
@@ -164,13 +166,19 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
       boolean isFirstPod, String podName, String accountId) {
     List<PodSetupInfo> pods = new ArrayList<>();
 
+    if (((K8sDirectInfraYaml) infrastructure).getSpec() == null) {
+      throw new CIStageExecutionException("Input infrastructure can not be empty");
+    }
+    K8sDirectInfraYaml k8sDirectInfraYaml = (K8sDirectInfraYaml) infrastructure;
+    OSType os = resolveOSType(k8sDirectInfraYaml.getSpec().getOs());
+
     Set<Integer> usedPorts = new HashSet<>();
     PortFinder portFinder = PortFinder.builder().startingPort(PORT_STARTING_RANGE).usedPorts(usedPorts).build();
     String workDirPath = STEP_WORK_DIR;
     List<ContainerDefinitionInfo> serviceContainerDefinitionInfos = CIServiceBuilder.createServicesContainerDefinition(
-        stageElementConfig, portFinder, ciExecutionConfigService.getCiExecutionServiceConfig());
+        stageElementConfig, portFinder, ciExecutionConfigService.getCiExecutionServiceConfig(), os);
     List<ContainerDefinitionInfo> stepContainerDefinitionInfos =
-        createStepsContainerDefinition(steps, stageElementConfig, ciExecutionArgs, portFinder, accountId);
+        createStepsContainerDefinition(steps, stageElementConfig, ciExecutionArgs, portFinder, accountId, os);
 
     List<ContainerDefinitionInfo> containerDefinitionInfos = new ArrayList<>();
     containerDefinitionInfos.addAll(serviceContainerDefinitionInfos);
@@ -182,10 +190,6 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
     List<Integer> serviceGrpcPortList = CIServiceBuilder.getServiceGrpcPortList(stageElementConfig);
     IntegrationStageConfig integrationStageConfig = IntegrationStageUtils.getIntegrationStageConfig(stageElementConfig);
 
-    if (((K8sDirectInfraYaml) infrastructure).getSpec() == null) {
-      throw new CIStageExecutionException("Input infrastructure can not be empty");
-    }
-    K8sDirectInfraYaml k8sDirectInfraYaml = (K8sDirectInfraYaml) infrastructure;
     List<PodVolume> volumes = convertVolumes(k8sDirectInfraYaml.getSpec().getVolumes().getValue());
 
     if (integrationStageConfig.getSharedPaths().isExpression()) {
@@ -265,7 +269,8 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
   }
 
   private List<ContainerDefinitionInfo> createStepsContainerDefinition(List<ExecutionWrapperConfig> steps,
-      StageElementConfig integrationStage, CIExecutionArgs ciExecutionArgs, PortFinder portFinder, String accountId) {
+      StageElementConfig integrationStage, CIExecutionArgs ciExecutionArgs, PortFinder portFinder, String accountId,
+      OSType os) {
     List<ContainerDefinitionInfo> containerDefinitionInfos = new ArrayList<>();
     if (steps == null) {
       return containerDefinitionInfos;
@@ -282,7 +287,7 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
         }
 
         ContainerDefinitionInfo containerDefinitionInfo = createStepContainerDefinition(
-            stepElementConfig, integrationStage, ciExecutionArgs, portFinder, stepIndex, accountId);
+            stepElementConfig, integrationStage, ciExecutionArgs, portFinder, stepIndex, accountId, os);
         if (containerDefinitionInfo != null) {
           containerDefinitionInfos.add(containerDefinitionInfo);
         }
@@ -299,7 +304,7 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
             StepElementConfig stepElementConfig =
                 IntegrationStageUtils.getStepElementConfig(executionWrapperInParallel);
             ContainerDefinitionInfo containerDefinitionInfo = createStepContainerDefinition(
-                stepElementConfig, integrationStage, ciExecutionArgs, portFinder, stepIndex, accountId);
+                stepElementConfig, integrationStage, ciExecutionArgs, portFinder, stepIndex, accountId, os);
             if (containerDefinitionInfo != null) {
               containerDefinitionInfos.add(containerDefinitionInfo);
             }
@@ -312,7 +317,7 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
 
   private ContainerDefinitionInfo createStepContainerDefinition(StepElementConfig stepElement,
       StageElementConfig integrationStage, CIExecutionArgs ciExecutionArgs, PortFinder portFinder, int stepIndex,
-      String accountId) {
+      String accountId, OSType os) {
     if (!(stepElement.getStepSpecType() instanceof CIStepInfo)) {
       return null;
     }
@@ -322,7 +327,7 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
     switch (ciStepInfo.getNonYamlInfo().getStepInfoType()) {
       case RUN:
         return createRunStepContainerDefinition((RunStepInfo) ciStepInfo, integrationStage, ciExecutionArgs, portFinder,
-            stepIndex, stepElement.getIdentifier(), stepElement.getName(), accountId);
+            stepIndex, stepElement.getIdentifier(), stepElement.getName(), accountId, os);
       case DOCKER:
       case ECR:
       case GCR:
@@ -336,13 +341,13 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
       case UPLOAD_GCS:
         return createPluginCompatibleStepContainerDefinition((PluginCompatibleStep) ciStepInfo, integrationStage,
             ciExecutionArgs, portFinder, stepIndex, stepElement.getIdentifier(), stepElement.getName(),
-            stepElement.getType(), timeout, accountId);
+            stepElement.getType(), timeout, accountId, os);
       case PLUGIN:
         return createPluginStepContainerDefinition((PluginStepInfo) ciStepInfo, integrationStage, ciExecutionArgs,
-            portFinder, stepIndex, stepElement.getIdentifier(), stepElement.getName(), accountId);
+            portFinder, stepIndex, stepElement.getIdentifier(), stepElement.getName(), accountId, os);
       case RUN_TESTS:
         return createRunTestsStepContainerDefinition((RunTestsStepInfo) ciStepInfo, integrationStage, ciExecutionArgs,
-            portFinder, stepIndex, stepElement.getIdentifier(), accountId);
+            portFinder, stepIndex, stepElement.getIdentifier(), accountId, os);
       default:
         return null;
     }
@@ -350,7 +355,7 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
 
   private ContainerDefinitionInfo createPluginCompatibleStepContainerDefinition(PluginCompatibleStep stepInfo,
       StageElementConfig integrationStage, CIExecutionArgs ciExecutionArgs, PortFinder portFinder, int stepIndex,
-      String identifier, String stepName, String stepType, long timeout, String accountId) {
+      String identifier, String stepName, String stepType, long timeout, String accountId, OSType os) {
     Integer port = portFinder.getNextPort();
 
     String containerName = format("%s%d", STEP_PREFIX, stepIndex);
@@ -366,7 +371,7 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
     }
     return ContainerDefinitionInfo.builder()
         .name(containerName)
-        .commands(StepContainerUtils.getCommand())
+        .commands(StepContainerUtils.getCommand(os))
         .args(StepContainerUtils.getArguments(port))
         .envVars(envVarMap)
         .secretVariables(getSecretVariables(integrationStage))
@@ -389,7 +394,7 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
 
   private ContainerDefinitionInfo createRunStepContainerDefinition(RunStepInfo runStepInfo,
       StageElementConfig integrationStage, CIExecutionArgs ciExecutionArgs, PortFinder portFinder, int stepIndex,
-      String identifier, String name, String accountId) {
+      String identifier, String name, String accountId, OSType os) {
     if (runStepInfo.getImage() == null) {
       throw new CIStageExecutionException("image can't be empty in k8s infrastructure");
     }
@@ -413,7 +418,7 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
 
     return ContainerDefinitionInfo.builder()
         .name(containerName)
-        .commands(StepContainerUtils.getCommand())
+        .commands(StepContainerUtils.getCommand(os))
         .args(StepContainerUtils.getArguments(port))
         .envVars(stepEnvVars)
         .stepIdentifier(identifier)
@@ -436,7 +441,7 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
 
   private ContainerDefinitionInfo createRunTestsStepContainerDefinition(RunTestsStepInfo runTestsStepInfo,
       StageElementConfig integrationStage, CIExecutionArgs ciExecutionArgs, PortFinder portFinder, int stepIndex,
-      String identifier, String accountId) {
+      String identifier, String accountId, OSType os) {
     Integer port = portFinder.getNextPort();
 
     if (runTestsStepInfo.getImage() == null) {
@@ -460,7 +465,7 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
 
     return ContainerDefinitionInfo.builder()
         .name(containerName)
-        .commands(StepContainerUtils.getCommand())
+        .commands(StepContainerUtils.getCommand(os))
         .args(StepContainerUtils.getArguments(port))
         .envVars(stepEnvVars)
         .stepIdentifier(identifier)
@@ -483,7 +488,7 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
 
   private ContainerDefinitionInfo createPluginStepContainerDefinition(PluginStepInfo pluginStepInfo,
       StageElementConfig integrationStage, CIExecutionArgs ciExecutionArgs, PortFinder portFinder, int stepIndex,
-      String identifier, String name, String accountId) {
+      String identifier, String name, String accountId, OSType os) {
     Integer port = portFinder.getNextPort();
 
     String containerName = format("%s%d", STEP_PREFIX, stepIndex);
@@ -498,7 +503,7 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
 
     return ContainerDefinitionInfo.builder()
         .name(containerName)
-        .commands(StepContainerUtils.getCommand())
+        .commands(StepContainerUtils.getCommand(os))
         .args(StepContainerUtils.getArguments(port))
         .envVars(envVarMap)
         .stepIdentifier(identifier)

--- a/320-ci-execution/src/main/java/io/harness/common/CIExecutionConstants.java
+++ b/320-ci-execution/src/main/java/io/harness/common/CIExecutionConstants.java
@@ -48,7 +48,8 @@ public class CIExecutionConstants {
   public static final String PATH_SEPARATOR = "/";
 
   // Constant for
-  public static final String STEP_COMMAND = "/addon/bin/ci-addon";
+  public static final String UNIX_STEP_COMMAND = "/addon/bin/ci-addon";
+  public static final String WIN_STEP_COMMAND = " C:\\addon\\bin\\addon.exe";
   public static final Integer STEP_REQUEST_MEMORY_MIB = 10;
   public static final Integer STEP_REQUEST_MILLI_CPU = 10;
   public static final Integer PORT_STARTING_RANGE = 20002;
@@ -63,8 +64,11 @@ public class CIExecutionConstants {
 
   // Container constants for setting up addon binary
   public static final String SETUP_ADDON_CONTAINER_NAME = "setup-addon";
-  public static final String SETUP_ADDON_ARGS =
+  public static final String UNIX_SETUP_ADDON_ARGS =
       "mkdir -p /addon/bin; mkdir -p /addon/tmp; chmod -R 776 /addon/tmp; cp /usr/local/bin/ci-addon-linux-amd64 /addon/bin/ci-addon; chmod +x /addon/bin/ci-addon; cp /usr/local/bin/java-agent.jar /addon/bin/java-agent.jar; chmod +x /addon/bin/java-agent.jar";
+
+  public static final String WIN_SETUP_ADDON_ARGS =
+      "mkdir /addon/bin; mkdir /addon/tmp; cp C:/addon.exe /addon/bin/addon.exe";
 
   public static final String ADDON_VOLUME = "addon";
   public static final String ADDON_VOL_MOUNT_PATH = "/addon";
@@ -132,6 +136,7 @@ public class CIExecutionConstants {
 
   // Deprecated
   public static final List<String> SH_COMMAND = Collections.unmodifiableList(Arrays.asList("sh", "-c", "--"));
+  public static final List<String> PWSH_COMMAND = Collections.unmodifiableList(Arrays.asList("pwsh", "-Command"));
 
   public static final String IMAGE_PATH_SPLIT_REGEX = ":";
   public static final String PVC_DEFAULT_STORAGE_CLASS = "faster";

--- a/320-ci-execution/src/main/java/io/harness/stateutils/buildstate/K8BuildSetupUtils.java
+++ b/320-ci-execution/src/main/java/io/harness/stateutils/buildstate/K8BuildSetupUtils.java
@@ -10,6 +10,7 @@ package io.harness.stateutils.buildstate;
 import static io.harness.beans.serializer.RunTimeInputHandler.UNRESOLVED_PARAMETER;
 import static io.harness.beans.serializer.RunTimeInputHandler.resolveIntegerParameter;
 import static io.harness.beans.serializer.RunTimeInputHandler.resolveMapParameter;
+import static io.harness.beans.serializer.RunTimeInputHandler.resolveOSType;
 import static io.harness.beans.serializer.RunTimeInputHandler.resolveStringParameter;
 import static io.harness.beans.sweepingoutputs.CISweepingOutputNames.CODE_BASE_CONNECTOR_REF;
 import static io.harness.beans.sweepingoutputs.ContainerPortDetails.PORT_DETAILS;
@@ -67,6 +68,7 @@ import io.harness.beans.sweepingoutputs.K8StageInfraDetails;
 import io.harness.beans.sweepingoutputs.PodCleanupDetails;
 import io.harness.beans.yaml.extended.infrastrucutre.Infrastructure;
 import io.harness.beans.yaml.extended.infrastrucutre.K8sDirectInfraYaml;
+import io.harness.beans.yaml.extended.infrastrucutre.OSType;
 import io.harness.beans.yaml.extended.infrastrucutre.k8.Capabilities;
 import io.harness.beans.yaml.extended.infrastrucutre.k8.SecurityContext;
 import io.harness.beans.yaml.extended.infrastrucutre.k8.Toleration;
@@ -194,6 +196,8 @@ public class K8BuildSetupUtils {
     List<PodToleration> podTolerations = getPodTolerations(k8sDirectInfraYaml.getSpec().getTolerations());
     String priorityClassName = k8sDirectInfraYaml.getSpec().getPriorityClassName().getValue();
     Boolean automountServiceAccountToken = k8sDirectInfraYaml.getSpec().getAutomountServiceAccountToken().getValue();
+    OSType os = resolveOSType(k8sDirectInfraYaml.getSpec().getOs());
+
     NGAccess ngAccess = AmbianceUtils.getNgAccess(ambiance);
 
     PodSetupInfo podSetupInfo = getPodSetupInfo((K8BuildJobEnvInfo) initializeStepInfo.getBuildJobEnvInfo());
@@ -201,7 +205,7 @@ public class K8BuildSetupUtils {
     CIK8PodParams<CIK8ContainerParams> podParams = getPodParams(ngAccess, k8PodDetails, initializeStepInfo, false,
         logPrefix, ambiance, annotations, labels, stageRunAsUser, serviceAccountName, nodeSelector, podTolerations,
         podSetupInfo.getVolumes(), runtime, k8sDirectInfraYaml.getSpec().getNamespace().getValue(), ctrSecurityContext,
-        automountServiceAccountToken, priorityClassName);
+        automountServiceAccountToken, priorityClassName, os);
 
     log.info("Created pod params for pod name [{}]", podSetupInfo.getName());
 
@@ -239,7 +243,7 @@ public class K8BuildSetupUtils {
 
     CIK8PodParams<CIK8ContainerParams> podParams = getPodParams(ngAccess, k8PodDetails, initializeStepInfo, false,
         logPrefix, ambiance, annotations, labels, stageRunAsUser, serviceAccountName, nodeSelector, podTolerations,
-        podSetupInfo.getVolumes(), RUNTIME_CLASS_NAME, namespace, null, null, null);
+        podSetupInfo.getVolumes(), RUNTIME_CLASS_NAME, namespace, null, null, null, OSType.LINUX);
 
     log.info("Created pod params for pod name [{}]", podSetupInfo.getName());
 
@@ -277,8 +281,8 @@ public class K8BuildSetupUtils {
       InitializeStepInfo initializeStepInfo, boolean usePVC, String logPrefix, Ambiance ambiance,
       Map<String, String> annotations, Map<String, String> labels, Integer stageRunAsUser, String serviceAccountName,
       Map<String, String> nodeSelector, List<PodToleration> podTolerations, List<PodVolume> podVolumes, String runtime,
-      String namespace, SecurityContext securityContext, Boolean automountServiceAccountToken,
-      String priorityClassName) {
+      String namespace, SecurityContext securityContext, Boolean automountServiceAccountToken, String priorityClassName,
+      OSType os) {
     PodSetupInfo podSetupInfo = getPodSetupInfo((K8BuildJobEnvInfo) initializeStepInfo.getBuildJobEnvInfo());
     ConnectorDetails harnessInternalImageConnector = null;
     if (isNotEmpty(ciExecutionServiceConfig.getDefaultInternalImageConnector())) {
@@ -296,7 +300,7 @@ public class K8BuildSetupUtils {
 
     CIK8ContainerParams setupAddOnContainerParams = internalContainerParamsProvider.getSetupAddonContainerParams(
         harnessInternalImageConnector, podSetupInfo.getVolumeToMountPath(), podSetupInfo.getWorkDirPath(),
-        getCtrSecurityContext(securityContext), ngAccess.getAccountIdentifier());
+        getCtrSecurityContext(securityContext), ngAccess.getAccountIdentifier(), os);
 
     // Service identifier usage in host alias requires that service identifier does not have capital letter characters
     // or _. For now, removing host alias usage otherwise pod creation itself fails.

--- a/320-ci-execution/src/main/java/io/harness/stateutils/buildstate/providers/InternalContainerParamsProvider.java
+++ b/320-ci-execution/src/main/java/io/harness/stateutils/buildstate/providers/InternalContainerParamsProvider.java
@@ -23,9 +23,10 @@ import static io.harness.common.CIExecutionConstants.HARNESS_WORKSPACE;
 import static io.harness.common.CIExecutionConstants.LITE_ENGINE_CONTAINER_CPU;
 import static io.harness.common.CIExecutionConstants.LITE_ENGINE_CONTAINER_MEM;
 import static io.harness.common.CIExecutionConstants.LITE_ENGINE_CONTAINER_NAME;
-import static io.harness.common.CIExecutionConstants.SETUP_ADDON_ARGS;
+import static io.harness.common.CIExecutionConstants.PWSH_COMMAND;
 import static io.harness.common.CIExecutionConstants.SETUP_ADDON_CONTAINER_NAME;
 import static io.harness.common.CIExecutionConstants.SH_COMMAND;
+import static io.harness.common.CIExecutionConstants.UNIX_SETUP_ADDON_ARGS;
 import static io.harness.data.encoding.EncodingUtils.encodeBase64;
 import static io.harness.delegate.beans.ci.pod.SecretParams.Type.TEXT;
 
@@ -33,6 +34,7 @@ import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.FeatureName;
 import io.harness.beans.sweepingoutputs.K8PodDetails;
+import io.harness.beans.yaml.extended.infrastrucutre.OSType;
 import io.harness.ci.config.CIExecutionServiceConfig;
 import io.harness.ci.integrationstage.IntegrationStageUtils;
 import io.harness.delegate.beans.ci.pod.CIContainerType;
@@ -68,14 +70,18 @@ public class InternalContainerParamsProvider {
 
   public CIK8ContainerParams getSetupAddonContainerParams(ConnectorDetails harnessInternalImageConnector,
       Map<String, String> volumeToMountPath, String workDir, ContainerSecurityContext ctrSecurityContext,
-      String accountIdentifier) {
-    List<String> args = Arrays.asList(SETUP_ADDON_ARGS);
+      String accountIdentifier, OSType os) {
+    List<String> args = Arrays.asList(UNIX_SETUP_ADDON_ARGS);
     Map<String, String> envVars = new HashMap<>();
     envVars.put(HARNESS_WORKSPACE, workDir);
 
     String imageName = ciExecutionConfigService.getAddonImage(accountIdentifier);
     String fullyQualifiedImage =
         IntegrationStageUtils.getFullyQualifiedImageName(imageName, harnessInternalImageConnector);
+    List<String> commands = SH_COMMAND;
+    if (os.equals(OSType.WINDOWS)) {
+      commands = PWSH_COMMAND;
+    }
     return CIK8ContainerParams.builder()
         .name(SETUP_ADDON_CONTAINER_NAME)
         .envVars(envVars)
@@ -85,7 +91,7 @@ public class InternalContainerParamsProvider {
                                        .build())
         .containerSecrets(ContainerSecrets.builder().build())
         .volumeToMountPath(volumeToMountPath)
-        .commands(SH_COMMAND)
+        .commands(commands)
         .args(args)
         .securityContext(ctrSecurityContext)
         .containerResourceParams(getAddonResourceParams())

--- a/320-ci-execution/src/main/java/io/harness/stateutils/buildstate/providers/ServiceContainerUtils.java
+++ b/320-ci-execution/src/main/java/io/harness/stateutils/buildstate/providers/ServiceContainerUtils.java
@@ -11,19 +11,26 @@ import static io.harness.common.CIExecutionConstants.ID_PREFIX;
 import static io.harness.common.CIExecutionConstants.IMAGE_PREFIX;
 import static io.harness.common.CIExecutionConstants.PORT_PREFIX;
 import static io.harness.common.CIExecutionConstants.SERVICE_ARG_COMMAND;
-import static io.harness.common.CIExecutionConstants.STEP_COMMAND;
+import static io.harness.common.CIExecutionConstants.UNIX_STEP_COMMAND;
+import static io.harness.common.CIExecutionConstants.WIN_STEP_COMMAND;
 
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.beans.yaml.extended.infrastrucutre.OSType;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @OwnedBy(HarnessTeam.CI)
 public class ServiceContainerUtils {
-  public static List<String> getCommand() {
+  public static List<String> getCommand(OSType os) {
+    String cmd = UNIX_STEP_COMMAND;
+    if (os.equals(OSType.WINDOWS)) {
+      cmd = WIN_STEP_COMMAND;
+    }
+
     List<String> command = new ArrayList<>();
-    command.add(STEP_COMMAND);
+    command.add(cmd);
     return command;
   }
 

--- a/320-ci-execution/src/main/java/io/harness/stateutils/buildstate/providers/StepContainerUtils.java
+++ b/320-ci-execution/src/main/java/io/harness/stateutils/buildstate/providers/StepContainerUtils.java
@@ -8,19 +8,26 @@
 package io.harness.stateutils.buildstate.providers;
 
 import static io.harness.common.CIExecutionConstants.PORT_PREFIX;
-import static io.harness.common.CIExecutionConstants.STEP_COMMAND;
+import static io.harness.common.CIExecutionConstants.UNIX_STEP_COMMAND;
+import static io.harness.common.CIExecutionConstants.WIN_STEP_COMMAND;
 
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.beans.yaml.extended.infrastrucutre.OSType;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @OwnedBy(HarnessTeam.CI)
 public class StepContainerUtils {
-  public static List<String> getCommand() {
+  public static List<String> getCommand(OSType os) {
+    String cmd = UNIX_STEP_COMMAND;
+    if (os.equals(OSType.WINDOWS)) {
+      cmd = WIN_STEP_COMMAND;
+    }
+
     List<String> command = new ArrayList<>();
-    command.add(STEP_COMMAND);
+    command.add(cmd);
     return command;
   }
 

--- a/320-ci-execution/src/test/java/io/harness/executionplan/CIExecutionPlanTestHelper.java
+++ b/320-ci-execution/src/test/java/io/harness/executionplan/CIExecutionPlanTestHelper.java
@@ -21,9 +21,9 @@ import static io.harness.common.CIExecutionConstants.PLUGIN_ENV_PREFIX;
 import static io.harness.common.CIExecutionConstants.PORT_PREFIX;
 import static io.harness.common.CIExecutionConstants.PORT_STARTING_RANGE;
 import static io.harness.common.CIExecutionConstants.SERVICE_ARG_COMMAND;
-import static io.harness.common.CIExecutionConstants.STEP_COMMAND;
 import static io.harness.common.CIExecutionConstants.STEP_REQUEST_MEMORY_MIB;
 import static io.harness.common.CIExecutionConstants.STEP_REQUEST_MILLI_CPU;
+import static io.harness.common.CIExecutionConstants.UNIX_STEP_COMMAND;
 import static io.harness.delegate.beans.ci.pod.CIContainerType.PLUGIN;
 import static io.harness.delegate.beans.ci.pod.CIContainerType.RUN;
 import static io.harness.delegate.beans.ci.pod.CIContainerType.SERVICE;
@@ -536,7 +536,7 @@ public class CIExecutionPlanTestHelper {
         .envVars(ImmutableMap.of("HARNESS_SERVICE_ENTRYPOINT", "redis", "HARNESS_SERVICE_ARGS", "start"))
         .containerType(SERVICE)
         .args(args)
-        .commands(asList(STEP_COMMAND))
+        .commands(asList(UNIX_STEP_COMMAND))
         .ports(asList(port))
         .containerResourceParams(ContainerResourceParams.builder()
                                      .resourceRequestMilliCpu(SERVICE_LIMIT_CPU)
@@ -564,7 +564,7 @@ public class CIExecutionPlanTestHelper {
         .name(SERVICE_CTR_NAME)
         .containerType(SERVICE)
         .args(args)
-        .commands(asList(STEP_COMMAND))
+        .commands(asList(UNIX_STEP_COMMAND))
         .ports(asList(port))
         .containerResourceParams(ContainerResourceParams.builder()
                                      .resourceRequestMilliCpu(SERVICE_LIMIT_CPU)
@@ -587,7 +587,7 @@ public class CIExecutionPlanTestHelper {
         .name("step-" + index.toString())
         .containerType(RUN)
         .args(Arrays.asList(PORT_PREFIX, port.toString()))
-        .commands(Arrays.asList(STEP_COMMAND))
+        .commands(Arrays.asList(UNIX_STEP_COMMAND))
         .ports(Arrays.asList(port))
         .containerResourceParams(ContainerResourceParams.builder()
                                      .resourceRequestMilliCpu(STEP_REQUEST_MILLI_CPU)
@@ -612,7 +612,7 @@ public class CIExecutionPlanTestHelper {
         .name(RUN_STEP_ID)
         .containerType(RUN)
         .args(asList(PORT_PREFIX, port.toString()))
-        .commands(asList(STEP_COMMAND))
+        .commands(asList(UNIX_STEP_COMMAND))
         .ports(asList(port))
         .containerResourceParams(ContainerResourceParams.builder()
                                      .resourceRequestMilliCpu(STEP_REQUEST_MILLI_CPU)
@@ -637,7 +637,7 @@ public class CIExecutionPlanTestHelper {
         .name("step-" + index.toString())
         .containerType(PLUGIN)
         .args(Arrays.asList(PORT_PREFIX, port.toString()))
-        .commands(Arrays.asList(STEP_COMMAND))
+        .commands(Arrays.asList(UNIX_STEP_COMMAND))
         .ports(Arrays.asList(port))
         .containerResourceParams(ContainerResourceParams.builder()
                                      .resourceRequestMilliCpu(STEP_REQUEST_MILLI_CPU)
@@ -665,7 +665,7 @@ public class CIExecutionPlanTestHelper {
         .name("step-" + index.toString())
         .containerType(PLUGIN)
         .args(Arrays.asList(PORT_PREFIX, port.toString()))
-        .commands(Arrays.asList(STEP_COMMAND))
+        .commands(Arrays.asList(UNIX_STEP_COMMAND))
         .ports(Arrays.asList(port))
         .containerResourceParams(ContainerResourceParams.builder()
                                      .resourceRequestMilliCpu(STEP_REQUEST_MILLI_CPU)
@@ -697,7 +697,7 @@ public class CIExecutionPlanTestHelper {
         .name(CLONE_STEP_ID)
         .containerType(PLUGIN)
         .args(asList(PORT_PREFIX, port.toString()))
-        .commands(asList(STEP_COMMAND))
+        .commands(asList(UNIX_STEP_COMMAND))
         .ports(asList(port))
         .containerResourceParams(ContainerResourceParams.builder()
                                      .resourceRequestMilliCpu(STEP_REQUEST_MILLI_CPU)
@@ -728,7 +728,7 @@ public class CIExecutionPlanTestHelper {
         .name(PLUGIN_STEP_ID)
         .containerType(PLUGIN)
         .args(asList(PORT_PREFIX, port.toString()))
-        .commands(asList(STEP_COMMAND))
+        .commands(asList(UNIX_STEP_COMMAND))
         .ports(asList(port))
         .containerResourceParams(ContainerResourceParams.builder()
                                      .resourceRequestMilliCpu(STEP_REQUEST_MILLI_CPU)

--- a/320-ci-execution/src/test/java/io/harness/stateutils/buildstate/K8BuildSetupUtilsTest.java
+++ b/320-ci-execution/src/test/java/io/harness/stateutils/buildstate/K8BuildSetupUtilsTest.java
@@ -43,6 +43,7 @@ import io.harness.beans.sweepingoutputs.K8PodDetails;
 import io.harness.beans.sweepingoutputs.StepTaskDetails;
 import io.harness.beans.yaml.extended.infrastrucutre.Infrastructure;
 import io.harness.beans.yaml.extended.infrastrucutre.K8sDirectInfraYaml;
+import io.harness.beans.yaml.extended.infrastrucutre.OSType;
 import io.harness.category.element.UnitTests;
 import io.harness.ci.beans.entities.LogServiceConfig;
 import io.harness.ci.beans.entities.TIServiceConfig;
@@ -186,7 +187,7 @@ public class K8BuildSetupUtilsTest extends CIExecutionTestBase {
 
     CIK8PodParams<CIK8ContainerParams> podParams = k8BuildSetupUtils.getPodParams(ngAccess, k8PodDetails,
         ciExecutionPlanTestHelper.getExpectedLiteEngineTaskInfoOnFirstPodWithSetCallbackId(), true, "workspace",
-        ambiance, null, null, null, null, null, null, null, null, infraNamepsace, null, null, null);
+        ambiance, null, null, null, null, null, null, null, null, infraNamepsace, null, null, null, OSType.LINUX);
 
     List<SecretVariableDetails> secretVariableDetails =
         new ArrayList<>(ciExecutionPlanTestHelper.getSecretVariableDetails());

--- a/320-ci-execution/src/test/java/io/harness/stateutils/buildstate/providers/InternalContainerParamsProviderTest.java
+++ b/320-ci-execution/src/test/java/io/harness/stateutils/buildstate/providers/InternalContainerParamsProviderTest.java
@@ -11,10 +11,10 @@ import static io.harness.common.CIExecutionConstants.HARNESS_CI_INDIRECT_LOG_UPL
 import static io.harness.common.CIExecutionConstants.LITE_ENGINE_CONTAINER_NAME;
 import static io.harness.common.CIExecutionConstants.LOG_SERVICE_ENDPOINT_VARIABLE;
 import static io.harness.common.CIExecutionConstants.LOG_SERVICE_TOKEN_VARIABLE;
-import static io.harness.common.CIExecutionConstants.SETUP_ADDON_ARGS;
 import static io.harness.common.CIExecutionConstants.SETUP_ADDON_CONTAINER_NAME;
 import static io.harness.common.CIExecutionConstants.TI_SERVICE_ENDPOINT_VARIABLE;
 import static io.harness.common.CIExecutionConstants.TI_SERVICE_TOKEN_VARIABLE;
+import static io.harness.common.CIExecutionConstants.UNIX_SETUP_ADDON_ARGS;
 import static io.harness.data.structure.UUIDGenerator.generateUuid;
 import static io.harness.rule.OwnerRule.ALEKSANDAR;
 
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import io.harness.beans.FeatureName;
 import io.harness.beans.sweepingoutputs.K8PodDetails;
+import io.harness.beans.yaml.extended.infrastrucutre.OSType;
 import io.harness.category.element.UnitTests;
 import io.harness.delegate.beans.ci.pod.CIContainerType;
 import io.harness.delegate.beans.ci.pod.CIK8ContainerParams;
@@ -54,11 +55,11 @@ public class InternalContainerParamsProviderTest extends CIExecutionTestBase {
     ConnectorDetails connectorDetails = ConnectorDetails.builder().build();
 
     CIK8ContainerParams containerParams = internalContainerParamsProvider.getSetupAddonContainerParams(
-        connectorDetails, null, "workspace", null, "account");
+        connectorDetails, null, "workspace", null, "account", OSType.LINUX);
 
     assertThat(containerParams.getName()).isEqualTo(SETUP_ADDON_CONTAINER_NAME);
     assertThat(containerParams.getContainerType()).isEqualTo(CIContainerType.ADD_ON);
-    assertThat(containerParams.getArgs()).isEqualTo(Collections.singletonList(SETUP_ADDON_ARGS));
+    assertThat(containerParams.getArgs()).isEqualTo(Collections.singletonList(UNIX_SETUP_ADDON_ARGS));
   }
 
   @Test

--- a/330-ci-beans/src/main/java/io/harness/beans/yaml/extended/infrastrucutre/K8sDirectInfraYaml.java
+++ b/330-ci-beans/src/main/java/io/harness/beans/yaml/extended/infrastrucutre/K8sDirectInfraYaml.java
@@ -88,5 +88,8 @@ public class K8sDirectInfraYaml implements Infrastructure {
     @ApiModelProperty(dataType = "io.harness.beans.yaml.extended.infrastrucutre.k8.SecurityContext")
     ParameterField<SecurityContext> containerSecurityContext;
     @ApiModelProperty(dataType = STRING_CLASSPATH) private ParameterField<String> priorityClassName;
+    @YamlSchemaTypes({runtime})
+    @ApiModelProperty(dataType = "io.harness.beans.yaml.extended.infrastrucutre.OSType")
+    private ParameterField<OSType> os;
   }
 }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
