### PR TITLE
[fix]: [CI-3959]: handle webhook registration

### DIFF
--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/helper/GitSyncConnectorHelper.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/helper/GitSyncConnectorHelper.java
@@ -186,11 +186,19 @@ public class GitSyncConnectorHelper {
 
   public ScmConnector getDecryptedConnector(
       String accountIdentifier, String orgIdentifier, String projectIdentifier, String connectorRef, String repoUrl) {
-    YamlGitConfigDTO yamlGitConfigDTO =
-        yamlGitConfigService.getByProjectIdAndRepo(accountIdentifier, orgIdentifier, projectIdentifier, repoUrl);
+    Optional<YamlGitConfigDTO> yamlGitConfigDTO = yamlGitConfigService.getByProjectIdAndRepoOptional(
+        accountIdentifier, orgIdentifier, projectIdentifier, repoUrl);
+    String repo = null;
+    String connectorBranch = null;
+
+    if (yamlGitConfigDTO.isPresent()) {
+      repo = yamlGitConfigDTO.get().getGitConnectorsRepo();
+      connectorBranch = yamlGitConfigDTO.get().getGitConnectorsBranch();
+    }
+
     try {
-      ScmConnector connector = getScmConnector(accountIdentifier, orgIdentifier, projectIdentifier, connectorRef,
-          yamlGitConfigDTO.getGitConnectorsRepo(), yamlGitConfigDTO.getGitConnectorsBranch());
+      ScmConnector connector =
+          getScmConnector(accountIdentifier, orgIdentifier, projectIdentifier, connectorRef, repo, connectorBranch);
       final ScmConnector scmConnector =
           decryptGitApiAccessHelper.decryptScmApiAccess(connector, accountIdentifier, projectIdentifier, orgIdentifier);
       scmConnector.setUrl(repoUrl);

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/impl/YamlGitConfigServiceImpl.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/impl/YamlGitConfigServiceImpl.java
@@ -542,6 +542,17 @@ public class YamlGitConfigServiceImpl implements YamlGitConfigService {
         .orElseThrow(() -> new InvalidRequestException("No git sync config exists"));
   }
 
+  @Override
+  public Optional<YamlGitConfigDTO> getByProjectIdAndRepoOptional(
+      String accountId, String orgId, String projectId, String repo) {
+    Optional<YamlGitConfig> yamlGitConfig =
+        yamlGitConfigRepository.findByAccountIdAndOrgIdentifierAndProjectIdentifierAndRepo(
+            accountId, orgId, projectId, repo);
+    if (yamlGitConfig.isPresent()) {
+      return yamlGitConfig.map(YamlGitConfigMapper::toYamlGitConfigDTO);
+    }
+    return Optional.empty();
+  }
   private String getYamlGitConfigScopeKey(YamlGitConfigDTO yamlGitConfig) {
     return Stream
         .of(yamlGitConfig.getAccountIdentifier(), yamlGitConfig.getOrganizationIdentifier(),

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/service/YamlGitConfigService.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/service/YamlGitConfigService.java
@@ -46,6 +46,8 @@ public interface YamlGitConfigService {
   List<YamlGitConfigDTO> getByAccountAndRepo(String accountIdentifier, String repo);
 
   YamlGitConfigDTO getByProjectIdAndRepo(String accountId, String orgId, String projectId, String repo);
+  Optional<YamlGitConfigDTO> getByProjectIdAndRepoOptional(
+      String accountId, String orgId, String projectId, String repo);
 
   boolean deleteAll(String accountIdentifier, String orgIdentifier, String projectIdentifier);
 


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32859)
<!-- Reviewable:end -->
