### PR TITLE
[DEL-0]: fix typo on addDelegateScope API

### DIFF
--- a/400-rest/src/main/resources/graphql/public/delegateMutatation.graphql
+++ b/400-rest/src/main/resources/graphql/public/delegateMutatation.graphql
@@ -9,8 +9,10 @@ extend type Mutation {
     @dataFetcher(name: delegateApproval)
   # Deletes delegate.
   deleteDelegate(input: DeleteDelegateInput!): DeleteDelegatePayload @dataFetcher(name: deleteDelegate)
-  # Add delegate scope
-  addDelegegateScope(input: AddDelegateScopeInput!): AddDelegateScopePayload @dataFetcher(name: addDelegateScope)
+  # Add delegate scope - DEPRECATED
+  addDelegegateScope(input: AddDelegateScopeInput!): AddDelegateScopePayload @dataFetcher(name: addDelegateScope) @deprecated(reason: "Use addDelegateScope.")
+   # Add delegate scope
+  addDelegateScope(input: AddDelegateScopeInput!): AddDelegateScopePayload @dataFetcher(name: addDelegateScope)
   # attach scope to delegate
   attachScopeToDelegate(input: AttachScopeToDelegateInput!): AttachScopeToDelegatePayload
     @dataFetcher(name: attachScopeToDelegate)


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
