### PR TITLE
techdebt: [PL-0]: Fix NGYamlUtils to not re-configure common ObjectMapper

### DIFF
--- a/970-ng-commons/src/main/java/io/harness/ng/core/utils/NGYamlUtils.java
+++ b/970-ng-commons/src/main/java/io/harness/ng/core/utils/NGYamlUtils.java
@@ -28,7 +28,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 @OwnedBy(DX)
 public class NGYamlUtils {
-  private static ObjectMapper yamlMapper =
+  private static final ObjectMapper YAML_MAPPER =
       new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES))
           .setSerializationInclusion(JsonInclude.Include.NON_NULL)
           .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
@@ -45,12 +45,13 @@ public class NGYamlUtils {
     }
     String yamlString;
     try {
-      objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-      objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-      objectMapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
-      objectMapper.configure(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, false);
-      final JsonNode jsonNode = objectMapper.valueToTree(yamlObject);
-      yamlString = yamlMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonNode);
+      ObjectMapper internalMapper = objectMapper.copy();
+      internalMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+      internalMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+      internalMapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
+      internalMapper.configure(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, false);
+      final JsonNode jsonNode = internalMapper.valueToTree(yamlObject);
+      yamlString = YAML_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(jsonNode);
     } catch (JsonProcessingException e) {
       throw new InvalidRequestException(
           String.format("Cannot create yaml from YamlObject %s", yamlObject.toString()), e);

--- a/970-ng-commons/src/main/java/io/harness/ng/core/utils/NGYamlUtils.java
+++ b/970-ng-commons/src/main/java/io/harness/ng/core/utils/NGYamlUtils.java
@@ -28,7 +28,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 @OwnedBy(DX)
 public class NGYamlUtils {
-  private static final ObjectMapper YAML_MAPPER =
+  private static ObjectMapper yamlMapper =
       new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES))
           .setSerializationInclusion(JsonInclude.Include.NON_NULL)
           .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
@@ -45,13 +45,12 @@ public class NGYamlUtils {
     }
     String yamlString;
     try {
-      ObjectMapper internalMapper = objectMapper.copy();
-      internalMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-      internalMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-      internalMapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
-      internalMapper.configure(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, false);
-      final JsonNode jsonNode = internalMapper.valueToTree(yamlObject);
-      yamlString = YAML_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(jsonNode);
+      objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+      objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+      objectMapper.configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
+      objectMapper.configure(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, false);
+      final JsonNode jsonNode = objectMapper.valueToTree(yamlObject);
+      yamlString = yamlMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonNode);
     } catch (JsonProcessingException e) {
       throw new InvalidRequestException(
           String.format("Cannot create yaml from YamlObject %s", yamlObject.toString()), e);

--- a/970-ng-commons/src/main/java/io/serializer/HObjectMapper.java
+++ b/970-ng-commons/src/main/java/io/serializer/HObjectMapper.java
@@ -37,11 +37,13 @@ public class HObjectMapper {
   public static ObjectMapper get() {
     ObjectMapper mapper = new ObjectMapper();
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true);
     return mapper;
   }
 
   public static ObjectMapper configureObjectMapperForNG(ObjectMapper mapper) {
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true);
     AnnotationAwareJsonSubtypeResolver subtypeResolver =
         AnnotationAwareJsonSubtypeResolver.newInstance(mapper.getSubtypeResolver());
     mapper.setSubtypeResolver(subtypeResolver);

--- a/970-ng-commons/src/main/java/io/serializer/HObjectMapper.java
+++ b/970-ng-commons/src/main/java/io/serializer/HObjectMapper.java
@@ -37,13 +37,11 @@ public class HObjectMapper {
   public static ObjectMapper get() {
     ObjectMapper mapper = new ObjectMapper();
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true);
     return mapper;
   }
 
   public static ObjectMapper configureObjectMapperForNG(ObjectMapper mapper) {
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true);
     AnnotationAwareJsonSubtypeResolver subtypeResolver =
         AnnotationAwareJsonSubtypeResolver.newInstance(mapper.getSubtypeResolver());
     mapper.setSubtypeResolver(subtypeResolver);

--- a/platform-service/Readme.MD
+++ b/platform-service/Readme.MD
@@ -1,0 +1,34 @@
+# Platform Service
+
+## Overview
+
+Platform Service is an umbrella microservice for 3 modules -
+1. Notifications
+2. Auditing
+3. Resource Group Management
+
+## Local Development with Platform Service
+
+Common setup instructions are present in the root [README.md](https://github.com/harness/harness-core/blob/develop/README.md) of the repository.
+
+
+## Building, Testing and Releasing Platform Service
+
+Platform service has to be managed in different environments (PR, Pre-QA, QA, Prod, On-Prem). Listed below are the Build and Release Pipelines:
+
+1. PR 
+    1. [Feature Build](https://app.harness.io/ng/#/account/vpCkHKsDSxK9_KYfjCTMKA/ci/orgs/default/projects/FEATUREBUILDS/pipelines/PlatformServiceFeatureBuild/pipeline-studio/)
+2. Pre-QA
+    1. [Build](https://app.harness.io/ng/#/account/vpCkHKsDSxK9_KYfjCTMKA/ci/orgs/default/projects/RELEASEMANAGEMENT/pipelines/PlatformServiceDevelopBuild/pipeline-studio/)
+    2. [Deployment](https://app.harness.io/#/account/wFHXHD0RRQWoO8tIZT5YVw/app/-jRbnwPZRoOLj2NEhrbJnQ/pipelines/qcL3cAvPSQe1_nIR_TTCPA/edit)
+3. QA
+    1. [Release Branch Cut](https://stage.harness.io/ng/#/account/wFHXHD0RRQWoO8tIZT5YVw/ci/orgs/Harness/projects/RELEASEBUILDS/pipelines/CutPlatformServiceReleaseBranch/pipeline-studio/)
+    2. [Build](https://stage.harness.io/ng/#/account/wFHXHD0RRQWoO8tIZT5YVw/ci/orgs/Harness/projects/RELEASEBUILDS/pipelines/PlatformServiceSaaSReleaseBuild/pipeline-studio/)
+    3. [Deployment](https://stage.harness.io/ng/#/account/wFHXHD0RRQWoO8tIZT5YVw/cd/orgs/Harness/projects/Operations/pipelines/Platform_Service/pipeline-studio/)
+4. SAAS
+    1. [Deployment](https://stage.harness.io/ng/#/account/wFHXHD0RRQWoO8tIZT5YVw/cd/orgs/Harness/projects/Operations/pipelines/Platform_Service/pipeline-studio/)
+5. On-Prem
+    1. [Build](https://stage.harness.io/ng/#/account/wFHXHD0RRQWoO8tIZT5YVw/ci/orgs/Harness/projects/RELEASEBUILDS/pipelines/PlatformServiceOnPremReleaseBuild/pipeline-studio/)
+
+    
+    

--- a/platform-service/build/container/BUILD.bazel
+++ b/platform-service/build/container/BUILD.bazel
@@ -19,8 +19,8 @@ container_image(
 pkg_tar(
     name = "files",
     srcs = [
-        "//platform-service/service:config.yml",
-        "//platform-service/service:keystore.jks",
+        "//platform-service/config:config.yml",
+        "//platform-service/config:keystore.jks",
     ],
     files = {
         "@alpn_boot_8.1.13.v20181017//file": "alpn-boot-8.1.13.v20181017.jar",

--- a/platform-service/config/BUILD.bazel
+++ b/platform-service/config/BUILD.bazel
@@ -1,0 +1,7 @@
+exports_files(
+    [
+        "keystore.jks",
+        "config.yml",
+    ],
+    visibility = ["//platform-service/build:__subpackages__"],
+)

--- a/platform-service/service/BUILD.bazel
+++ b/platform-service/service/BUILD.bazel
@@ -12,7 +12,7 @@ java_binary(
         "//platform-service/modules/resource-group-service/src/main/resources:resource",
         "//platform-service/service/src/main/resources:resource",
     ],
-    visibility = ["//visibility:private"],
+    visibility = ["//platform-service/build:__subpackages__"],
     runtime_deps = [
         "//platform-service/modules/notification-service/src/main/resources",
         "//platform-service/modules/resource-group-service/src/main/resources",
@@ -773,8 +773,3 @@ java_library(
 run_tests()
 
 run_analysis()
-
-exports_files([
-    "keystore.jks",
-    "config.yml",
-])


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32916)
<!-- Reviewable:end -->
