### PR TITLE
fix: [DEL-4019]: 

### DIFF
--- a/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
+++ b/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
@@ -1594,7 +1594,7 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
         switchStorageMsgSent = true;
       }
       if (sendJreInformationToWatcher) {
-        log.debug("Sending Delegate JRE: {} MigrateTo JRE: {} to watcher", System.getProperty(JAVA_VERSION),
+        log.info("Sending Delegate JRE: {} MigrateTo JRE: {} to watcher", System.getProperty(JAVA_VERSION),
             migrateToJreVersion);
         statusData.put(DELEGATE_JRE_VERSION, System.getProperty(JAVA_VERSION));
         statusData.put(MIGRATE_TO_JRE_VERSION, migrateToJreVersion);

--- a/360-cg-manager/config.yml
+++ b/360-cg-manager/config.yml
@@ -586,7 +586,7 @@ jreConfigs:
     jreTarPath: jre/openjdk-8u242/jre_x64_${OS}_8u242b08.tar.gz
     alpnJarPath: tools/alpn/release/8.1.13.v20181017/alpn-boot-8.1.13.v20181017.jar
   openjdk11014_9:
-    version: 11.0.14_9
+    version: 11.0.14
     jreDirectory: jdk-11.0.14+9-jre
     jreMacDirectory: jdk-11.0.14+9-jre
     jreTarPath: jre/openjdk-11.0.14_9/OpenJDK11U-jre_x64_${OS}_hotspot_11.0.14_9.tar.gz

--- a/960-watcher/src/main/java/io/harness/watcher/service/WatcherServiceImpl.java
+++ b/960-watcher/src/main/java/io/harness/watcher/service/WatcherServiceImpl.java
@@ -924,7 +924,7 @@ public class WatcherServiceImpl implements WatcherService {
   public void restartDelegateToUpgradeJre(String delegateJreVersion, String migrateToJreVersion) {
     if (!delegateJreVersion.equals(migrateToJreVersion)
         && clock.millis() - delegateRestartedToUpgradeJreAt > DELEGATE_RESTART_TO_UPGRADE_JRE_TIMEOUT) {
-      log.debug("Delegate JRE: {} MigrateTo JRE: {} ", delegateJreVersion, migrateToJreVersion);
+      log.info("Delegate JRE: {} MigrateTo JRE: {} ", delegateJreVersion, migrateToJreVersion);
       boolean downloadSuccessful = downloadRunScriptsBeforeRestartingDelegateAndWatcher();
       if (downloadSuccessful) {
         delegateRestartedToUpgradeJreAt = clock.millis();
@@ -943,7 +943,7 @@ public class WatcherServiceImpl implements WatcherService {
   @VisibleForTesting
   public void restartWatcherToUpgradeJre(String migrateToJreVersion) {
     if (!migrateToJreVersion.equals(watcherJreVersion) && !watcherRestartedToUpgradeJre) {
-      log.debug("Watcher JRE: {} MigrateTo JRE: {} ", watcherJreVersion, migrateToJreVersion);
+      log.info("Watcher JRE: {} MigrateTo JRE: {} ", watcherJreVersion, migrateToJreVersion);
       boolean downloadSuccessful = downloadRunScriptsBeforeRestartingDelegateAndWatcher();
       if (downloadSuccessful) {
         watcherRestartedToUpgradeJre = true;


### PR DESCRIPTION
Fixing JRE version number to match what's returned by `java.version` system property

You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
