### PR TITLE
techdebt: [PIE-2752]: Remove 860-orchestration-steps dependency from ci and ng

### DIFF
--- a/127-cd-nextgen-entities/BUILD.bazel
+++ b/127-cd-nextgen-entities/BUILD.bazel
@@ -12,7 +12,6 @@ java_library(
     deps = [
         "//:lombok",
         "//400-rest:module",
-        "//860-orchestration-steps:module",  # This should be removed from here
         "//878-ng-common-utilities:module",
         "//879-pms-sdk:module",
         "//960-ng-core-beans:module",

--- a/320-ci-execution/src/main/java/io/harness/ci/plan/creator/filter/CIStageFilterJsonCreator.java
+++ b/320-ci-execution/src/main/java/io/harness/ci/plan/creator/filter/CIStageFilterJsonCreator.java
@@ -39,6 +39,7 @@ import io.harness.pms.yaml.YamlField;
 import io.harness.pms.yaml.YamlNode;
 import io.harness.pms.yaml.YamlUtils;
 import io.harness.stateutils.buildstate.ConnectorUtils;
+import io.harness.steps.CIStepSpecTypeConstants;
 import io.harness.steps.StepSpecTypeConstants;
 import io.harness.walktree.visitor.SimpleVisitorFactory;
 import io.harness.yaml.extended.ci.codebase.CodeBase;
@@ -57,7 +58,7 @@ public class CIStageFilterJsonCreator extends GenericStageFilterJsonCreator {
 
   @Override
   public Set<String> getSupportedStageTypes() {
-    return ImmutableSet.of(StepSpecTypeConstants.CI_STAGE, StepSpecTypeConstants.SECURITY_STAGE);
+    return ImmutableSet.of(CIStepSpecTypeConstants.CI_STAGE, StepSpecTypeConstants.SECURITY_STAGE);
   }
 
   @Override

--- a/320-ci-execution/src/main/java/io/harness/ci/plan/creator/stage/IntegrationStagePMSPlanCreator.java
+++ b/320-ci-execution/src/main/java/io/harness/ci/plan/creator/stage/IntegrationStagePMSPlanCreator.java
@@ -54,6 +54,7 @@ import io.harness.serializer.KryoSerializer;
 import io.harness.states.CISpecStep;
 import io.harness.states.IntegrationStageStepPMS;
 import io.harness.stateutils.buildstate.ConnectorUtils;
+import io.harness.steps.CIStepSpecTypeConstants;
 import io.harness.steps.StepSpecTypeConstants;
 import io.harness.yaml.extended.ci.codebase.CodeBase;
 import io.harness.yaml.utils.JsonPipelineUtils;
@@ -120,7 +121,7 @@ public class IntegrationStagePMSPlanCreator extends GenericStagePlanCreator {
 
   @Override
   public Set<String> getSupportedStageTypes() {
-    return ImmutableSet.of(StepSpecTypeConstants.CI_STAGE, StepSpecTypeConstants.SECURITY_STAGE);
+    return ImmutableSet.of(CIStepSpecTypeConstants.CI_STAGE, StepSpecTypeConstants.SECURITY_STAGE);
   }
 
   @Override

--- a/330-ci-beans/BUILD.bazel
+++ b/330-ci-beans/BUILD.bazel
@@ -3,10 +3,10 @@ load("//:tools/bazel/GenTestRules.bzl", "run_tests")
 load("//:tools/bazel/macros.bzl", "run_analysis")
 
 shared_dependencies = [
-    "//860-orchestration-steps:module",  # This needs to be removed from here
     "//878-ng-common-utilities:module",
     "//879-pms-sdk:module",
     "//930-delegate-tasks:module",
+    "//945-account-mgmt:module",
     "//960-persistence:module",
     "//999-annotations:module",
     "//product/ci/engine/proto:ciengine_java_proto",

--- a/330-ci-beans/src/main/java/io/harness/beans/stages/IntegrationStageNode.java
+++ b/330-ci-beans/src/main/java/io/harness/beans/stages/IntegrationStageNode.java
@@ -15,7 +15,7 @@ import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME;
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.plancreator.stages.stage.StageInfoConfig;
-import io.harness.steps.StepSpecTypeConstants;
+import io.harness.steps.CIStepSpecTypeConstants;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -30,7 +30,7 @@ import org.springframework.data.annotation.TypeAlias;
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-@JsonTypeName(StepSpecTypeConstants.CI_STAGE)
+@JsonTypeName(CIStepSpecTypeConstants.CI_STAGE)
 @TypeAlias("IntegrationStageNode")
 @OwnedBy(CI)
 @RecasterAlias("io.harness.beans.stages.IntegrationStageNode")
@@ -42,7 +42,7 @@ public class IntegrationStageNode extends IntegrationAbstractStageNode {
   IntegrationStageConfigImpl integrationStageConfig;
   @Override
   public String getType() {
-    return StepSpecTypeConstants.CI_STAGE;
+    return CIStepSpecTypeConstants.CI_STAGE;
   }
 
   @Override
@@ -51,7 +51,7 @@ public class IntegrationStageNode extends IntegrationAbstractStageNode {
   }
 
   public enum StepType {
-    CI(StepSpecTypeConstants.CI_STAGE);
+    CI(CIStepSpecTypeConstants.CI_STAGE);
     @Getter String name;
     StepType(String name) {
       this.name = name;

--- a/330-ci-beans/src/main/java/io/harness/serializer/CiBeansRegistrars.java
+++ b/330-ci-beans/src/main/java/io/harness/serializer/CiBeansRegistrars.java
@@ -52,7 +52,6 @@ public class CiBeansRegistrars {
           .addAll(SecretManagerClientRegistrars.kryoRegistrars)
           .addAll(ConnectorBeansRegistrars.kryoRegistrars)
           .addAll(YamlBeansModuleRegistrars.kryoRegistrars)
-          .addAll(OrchestrationStepsModuleRegistrars.kryoRegistrars)
           .addAll(DelegateTaskRegistrars.kryoRegistrars)
           .add(CIBeansKryoRegistrar.class)
           .build();
@@ -63,7 +62,6 @@ public class CiBeansRegistrars {
           .addAll(NGCoreBeansRegistrars.morphiaRegistrars)
           .addAll(SecretManagerClientRegistrars.morphiaRegistrars)
           .addAll(YamlBeansModuleRegistrars.morphiaRegistrars)
-          .addAll(OrchestrationStepsModuleRegistrars.morphiaRegistrars)
           .addAll(DelegateTaskRegistrars.morphiaRegistrars)
           .add(CIBeansMorphiaRegistrar.class)
           .add(YamlMorphiaRegistrar.class)

--- a/330-ci-beans/src/main/java/io/harness/steps/CIStepSpecTypeConstants.java
+++ b/330-ci-beans/src/main/java/io/harness/steps/CIStepSpecTypeConstants.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.steps;
+
+import static io.harness.annotations.dev.HarnessTeam.PIPELINE;
+
+import io.harness.annotations.dev.HarnessModule;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.annotations.dev.TargetModule;
+
+@OwnedBy(PIPELINE)
+@TargetModule(HarnessModule._860_ORCHESTRATION_STEPS)
+public interface CIStepSpecTypeConstants {
+  String CI_STAGE = "CI";
+}

--- a/330-ci-beans/src/test/java/io/harness/beans/yaml/CIPmsPipelineYamlTest.java
+++ b/330-ci-beans/src/test/java/io/harness/beans/yaml/CIPmsPipelineYamlTest.java
@@ -8,6 +8,7 @@
 package io.harness.beans.yaml;
 
 import static io.harness.annotations.dev.HarnessTeam.CI;
+import static io.harness.annotations.dev.HarnessTeam.PIPELINE;
 import static io.harness.rule.OwnerRule.ALEKSANDAR;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,21 +18,28 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.stages.IntegrationStageConfig;
 import io.harness.category.element.UnitTests;
 import io.harness.plancreator.execution.ExecutionWrapperConfig;
-import io.harness.plancreator.pipeline.PipelineConfig;
 import io.harness.plancreator.stages.StageElementWrapperConfig;
 import io.harness.plancreator.stages.stage.StageElementConfig;
 import io.harness.plancreator.steps.StepElementConfig;
 import io.harness.rule.Owner;
 import io.harness.utils.YamlPipelineUtils;
+import io.harness.yaml.core.VariableExpression;
 import io.harness.yaml.core.properties.CIProperties;
 import io.harness.yaml.core.properties.NGProperties;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
+import javax.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.springframework.data.annotation.TypeAlias;
 
 @Slf4j
 @OwnedBy(CI)
@@ -65,5 +73,21 @@ public class CIPmsPipelineYamlTest extends CiBeansTestBase {
         }
       }
     }
+  }
+
+  @OwnedBy(PIPELINE)
+  @Value
+  @Builder
+  @TypeAlias("pipelineConfig")
+  private static class PipelineConfig {
+    @JsonProperty("pipeline") PipelineInfoConfig pipelineInfoConfig;
+  }
+
+  @Data
+  @Builder
+  private static class PipelineInfoConfig {
+    @VariableExpression NGProperties properties;
+
+    @Singular @Size(min = 1) @VariableExpression(skipVariableExpression = true) List<StageElementWrapperConfig> stages;
   }
 }

--- a/870-orchestration/src/main/java/io/harness/steps/StepSpecTypeConstants.java
+++ b/870-orchestration/src/main/java/io/harness/steps/StepSpecTypeConstants.java
@@ -30,7 +30,6 @@ public interface StepSpecTypeConstants {
   String SERVICENOW_UPDATE = "ServiceNowUpdate";
   String APPROVAL_STAGE = "Approval";
   String DEPLOYMENT_STAGE = "Deployment";
-  String CI_STAGE = "CI";
   String SECURITY_STAGE = "SecurityTests";
   String FEATURE_FLAG_STAGE = "FeatureFlag";
   String POLICY_STEP = "Policy";

--- a/882-pms-sdk-core/src/main/java/io/harness/pms/sdk/core/execution/events/node/resume/NodeResumeEventHandler.java
+++ b/882-pms-sdk-core/src/main/java/io/harness/pms/sdk/core/execution/events/node/resume/NodeResumeEventHandler.java
@@ -89,22 +89,6 @@ public class NodeResumeEventHandler extends PmsBaseEventHandler<NodeResumeEvent>
     String nodeExecutionId = AmbianceUtils.obtainCurrentRuntimeId(event.getAmbiance());
     Preconditions.checkArgument(isNotBlank(nodeExecutionId), "nodeExecutionId is null or empty");
     try {
-      if (event.getAsyncError()) {
-        log.info("Async Error for the Event Sending Error Response");
-        ErrorResponseData errorResponseData = (ErrorResponseData) response.values().iterator().next();
-        StepResponseProto stepResponse =
-            StepResponseProto.newBuilder()
-                .setStatus(Status.ERRORED)
-                .setFailureInfo(FailureInfo.newBuilder()
-                                    .addAllFailureTypes(EngineExceptionUtils.transformToOrchestrationFailureTypes(
-                                        errorResponseData.getFailureTypes()))
-                                    .setErrorMessage(errorResponseData.getErrorMessage())
-                                    .build())
-                .build();
-        sdkNodeExecutionService.handleStepResponse(event.getAmbiance(), stepResponse);
-        return;
-      }
-
       processor.handleResume(buildResumePackage(event, response));
     } catch (Exception ex) {
       log.error("Error while resuming execution", ex);


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/32958)
<!-- Reviewable:end -->
