### PR TITLE
[CDS-34235]: supporting empty script in custom artifact

### DIFF
--- a/400-rest/src/main/java/software/wings/beans/artifact/CustomArtifactStream.java
+++ b/400-rest/src/main/java/software/wings/beans/artifact/CustomArtifactStream.java
@@ -108,7 +108,7 @@ public class CustomArtifactStream extends ArtifactStream {
 
   @Override
   public boolean shouldValidate() {
-    return true;
+    return Boolean.TRUE.equals(getCollectionEnabled());
   }
 
   @Data

--- a/400-rest/src/main/java/software/wings/service/impl/artifact/ArtifactCollectionServiceAsyncImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/artifact/ArtifactCollectionServiceAsyncImpl.java
@@ -188,6 +188,12 @@ public class ArtifactCollectionServiceAsyncImpl implements ArtifactCollectionSer
 
   @Override
   public Artifact collectNewArtifacts(String appId, ArtifactStream artifactStream, String buildNumber) {
+    if (CUSTOM.name().equals(artifactStream.getArtifactStreamType())) {
+      Artifact artifact = saveCustomArtifactWithNoScript((CustomArtifactStream) artifactStream, buildNumber);
+      if (artifact != null) {
+        return artifact;
+      }
+    }
     List<BuildDetails> builds =
         buildSourceService.getBuilds(appId, artifactStream.getUuid(), artifactStream.getSettingId());
     if (isNotEmpty(builds)) {
@@ -198,6 +204,21 @@ public class ArtifactCollectionServiceAsyncImpl implements ArtifactCollectionSer
       }
     }
     return null;
+  }
+
+  private Artifact saveCustomArtifactWithNoScript(CustomArtifactStream artifactStream, String buildNumber) {
+    CustomArtifactStream.Script versionScript =
+        artifactStream.getScripts()
+            .stream()
+            .filter(script
+                -> script.getAction() == null || script.getAction() == CustomArtifactStream.Action.FETCH_VERSIONS)
+            .findFirst()
+            .orElse(null);
+    if (isNotEmpty(versionScript.getScriptString())) {
+      return null;
+    }
+    BuildDetails buildDetails = BuildDetails.Builder.aBuildDetails().withNumber(buildNumber).build();
+    return artifactService.create(artifactCollectionUtils.getArtifact(artifactStream, buildDetails));
   }
 
   @Override

--- a/400-rest/src/main/java/software/wings/service/impl/artifact/CustomBuildSourceServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/artifact/CustomBuildSourceServiceImpl.java
@@ -33,6 +33,7 @@ import software.wings.service.intfc.artifact.CustomBuildSourceService;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.validation.executable.ValidateOnExecution;


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
