### PR TITLE
fix: [CI-4356]: added feature for fetching repositories 

### DIFF
--- a/120-ng-manager/src/main/java/io/harness/ng/trialsignup/CIProvisionResource.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/trialsignup/CIProvisionResource.java
@@ -8,10 +8,14 @@
 package io.harness.ng.trialsignup;
 
 import static io.harness.NGCommonEntityConstants.ACCOUNT_PARAM_MESSAGE;
+import static io.harness.NGCommonEntityConstants.ORG_PARAM_MESSAGE;
+import static io.harness.NGCommonEntityConstants.PROJECT_PARAM_MESSAGE;
 import static io.harness.annotations.dev.HarnessTeam.CI;
 
 import io.harness.NGCommonEntityConstants;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.ng.core.OrgIdentifier;
+import io.harness.ng.core.ProjectIdentifier;
 import io.harness.ng.core.dto.ErrorDTO;
 import io.harness.ng.core.dto.FailureDTO;
 import io.harness.ng.core.dto.ResponseDTO;
@@ -83,8 +87,14 @@ public class CIProvisionResource {
   @Path("fetch-repo-list")
   @ApiOperation(value = "Get all repositories of the user from scm", nickname = "getAllUserRepos")
   public ResponseDTO<List<UserRepoResponse>> getAllUserRepos(
-      @NotNull @QueryParam(NGCommonEntityConstants.ACCOUNT_KEY) String accountId,
-      @NotNull @QueryParam("repoRef") String repoRef) {
-    return ResponseDTO.newResponse(provisionService.getAllUserRepos(accountId, repoRef));
+      @Parameter(description = "Connector ID") @QueryParam("connectorRef") String connectorIdentifier,
+      @Parameter(description = ACCOUNT_PARAM_MESSAGE, required = true) @NotBlank @QueryParam(
+          NGCommonEntityConstants.ACCOUNT_KEY) String accountIdentifier,
+      @Parameter(description = ORG_PARAM_MESSAGE) @QueryParam(
+          NGCommonEntityConstants.ORG_KEY) @OrgIdentifier String orgIdentifier,
+      @Parameter(description = PROJECT_PARAM_MESSAGE) @QueryParam(
+          NGCommonEntityConstants.PROJECT_KEY) @ProjectIdentifier String projectIdentifier) {
+    return ResponseDTO.newResponse(
+        provisionService.getAllUserRepos(accountIdentifier, orgIdentifier, projectIdentifier, connectorIdentifier));
   }
 }

--- a/120-ng-manager/src/main/java/io/harness/ng/trialsignup/ProvisionService.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/trialsignup/ProvisionService.java
@@ -332,8 +332,8 @@ public class ProvisionService {
         .build();
   }
 
-  public List<UserRepoResponse> getAllUserRepos(String accountId, String repoRef) {
-    Optional<ConnectorResponseDTO> connector = connectorService.getByRef(accountId, null, null, repoRef);
+  public List<UserRepoResponse> getAllUserRepos(String accountId, String orgIdentifier, String projectIdentifier, String repoRef) {
+    Optional<ConnectorResponseDTO> connector = connectorService.getByRef(accountId, orgIdentifier, projectIdentifier, repoRef);
     connector.orElseThrow(
         () -> new InvalidArgumentsException(format("connector %s was not found in account %s", repoRef, accountId)));
     ScmConnector decryptedConnector = gitSyncConnectorHelper.getDecryptedConnector(


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
