### PR TITLE
[CDS-37311]: Revert jsonignore for selector field

### DIFF
--- a/878-ng-common-utilities/src/main/java/io/harness/plancreator/steps/common/WithDelegateSelector.java
+++ b/878-ng-common-utilities/src/main/java/io/harness/plancreator/steps/common/WithDelegateSelector.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 
 public interface WithDelegateSelector {
-  @JsonIgnore ParameterField<List<TaskSelectorYaml>> getDelegateSelectors();
+  ParameterField<List<TaskSelectorYaml>> getDelegateSelectors();
 
   void setDelegateSelectors(ParameterField<List<TaskSelectorYaml>> delegateSelectors);
 }

--- a/878-ng-common-utilities/src/main/java/io/harness/plancreator/steps/common/WithDelegateSelector.java
+++ b/878-ng-common-utilities/src/main/java/io/harness/plancreator/steps/common/WithDelegateSelector.java
@@ -10,7 +10,6 @@ package io.harness.plancreator.steps.common;
 import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.pms.yaml.ParameterField;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 
 public interface WithDelegateSelector {

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=74970
+build.number=74971
 build.patch=000
 delegate.version=22.04.12
 delegate.patch=000


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/33012)
<!-- Reviewable:end -->
