### PR TITLE
[CDS-37311]: Step level delegate selectors not being picked up

### DIFF
--- a/125-cd-nextgen/src/main/java/io/harness/cdng/helm/HelmDeployStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/helm/HelmDeployStepInfo.java
@@ -62,4 +62,9 @@ public class HelmDeployStepInfo extends HelmDeployBaseStepInfo implements CDStep
   public SpecParameters getSpecParameters() {
     return HelmDeployStepParams.infoBuilder().delegateSelectors(delegateSelectors).build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/helm/rollback/HelmRollbackStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/helm/rollback/HelmRollbackStepInfo.java
@@ -62,4 +62,9 @@ public class HelmRollbackStepInfo extends HelmRollbackBaseStepInfo implements CD
   public SpecParameters getSpecParameters() {
     return HelmRollbackStepParams.infoBuilder().delegateSelectors(delegateSelectors).build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sApplyStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sApplyStepInfo.java
@@ -69,4 +69,9 @@ public class K8sApplyStepInfo extends K8sApplyBaseStepInfo implements CDStepInfo
         .delegateSelectors(delegateSelectors)
         .build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sBGSwapServicesStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sBGSwapServicesStepInfo.java
@@ -71,4 +71,9 @@ public class K8sBGSwapServicesStepInfo implements CDStepInfo, Visitable {
         .blueGreenSwapServicesFqn(blueGreenSwapServicesStepFqn)
         .build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sBlueGreenStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sBlueGreenStepInfo.java
@@ -64,4 +64,9 @@ public class K8sBlueGreenStepInfo extends K8sBlueGreenBaseStepInfo implements CD
   public SpecParameters getSpecParameters() {
     return K8sBlueGreenStepParameters.infoBuilder().skipDryRun(skipDryRun).delegateSelectors(delegateSelectors).build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sCanaryDeleteStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sCanaryDeleteStepInfo.java
@@ -66,4 +66,9 @@ public class K8sCanaryDeleteStepInfo implements CDStepInfo, Visitable {
         .canaryDeleteStepFqn(canaryDeleteStepFqn)
         .build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sCanaryStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sCanaryStepInfo.java
@@ -79,4 +79,9 @@ public class K8sCanaryStepInfo extends K8sCanaryBaseStepInfo implements CDStepIn
         .delegateSelectors(delegateSelectors)
         .build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sDeleteStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sDeleteStepInfo.java
@@ -67,4 +67,9 @@ public class K8sDeleteStepInfo extends K8sDeleteBaseStepInfo implements CDStepIn
         .delegateSelectors(this.getDelegateSelectors())
         .build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingRollbackStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingRollbackStepInfo.java
@@ -68,4 +68,9 @@ public class K8sRollingRollbackStepInfo extends K8sRollingRollbackBaseStepInfo i
         .rollingStepFqn(rollingStepFqn)
         .build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingStepInfo.java
@@ -68,4 +68,9 @@ public class K8sRollingStepInfo extends K8sRollingBaseStepInfo implements CDStep
         .canaryStepFqn(canaryStepFqn)
         .build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sScaleStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sScaleStepInfo.java
@@ -71,4 +71,9 @@ public class K8sScaleStepInfo extends K8sScaleBaseStepInfo implements CDStepInfo
         .delegateSelectors(delegateSelectors)
         .build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformApplyStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformApplyStepInfo.java
@@ -107,4 +107,9 @@ public class TerraformApplyStepInfo
     }
     return connectorRefMap;
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformDestroyStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformDestroyStepInfo.java
@@ -108,4 +108,9 @@ public class TerraformDestroyStepInfo
     }
     return connectorRefMap;
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformPlanStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/TerraformPlanStepInfo.java
@@ -101,4 +101,9 @@ public class TerraformPlanStepInfo extends TerraformPlanBaseStepInfo implements 
     connectorRefMap.put("configuration.secretManagerRef", terraformPlanExecutionData.getSecretManagerRef());
     return connectorRefMap;
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/steps/rolllback/TerraformRollbackStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/provision/terraform/steps/rolllback/TerraformRollbackStepInfo.java
@@ -61,4 +61,9 @@ public class TerraformRollbackStepInfo implements CDStepInfo {
         .delegateSelectors(delegateSelectors)
         .build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/860-orchestration-steps/src/main/java/io/harness/plancreator/steps/http/HttpStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/plancreator/steps/http/HttpStepInfo.java
@@ -105,4 +105,9 @@ public class HttpStepInfo extends HttpBaseStepInfo implements PMSStepInfo, Visit
         .url(getUrl())
         .build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/jira/JiraApprovalStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/jira/JiraApprovalStepInfo.java
@@ -82,4 +82,9 @@ public class JiraApprovalStepInfo implements PMSStepInfo, WithConnectorRef, With
     connectorRefMap.put(YAMLFieldNameConstants.CONNECTOR_REF, connectorRef);
     return connectorRefMap;
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/servicenow/ServiceNowApprovalStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/approval/step/servicenow/ServiceNowApprovalStepInfo.java
@@ -84,4 +84,9 @@ public class ServiceNowApprovalStepInfo implements PMSStepInfo, WithConnectorRef
     connectorRefMap.put(YAMLFieldNameConstants.CONNECTOR_REF, connectorRef);
     return connectorRefMap;
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/jira/create/JiraCreateStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/jira/create/JiraCreateStepInfo.java
@@ -84,4 +84,9 @@ public class JiraCreateStepInfo implements PMSStepInfo, WithConnectorRef, WithDe
     connectorRefMap.put(YAMLFieldNameConstants.CONNECTOR_REF, connectorRef);
     return connectorRefMap;
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/jira/update/JiraUpdateStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/jira/update/JiraUpdateStepInfo.java
@@ -85,4 +85,9 @@ public class JiraUpdateStepInfo implements PMSStepInfo, WithConnectorRef, WithDe
     connectorRefMap.put(YAMLFieldNameConstants.CONNECTOR_REF, connectorRef);
     return connectorRefMap;
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/servicenow/create/ServiceNowCreateStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/servicenow/create/ServiceNowCreateStepInfo.java
@@ -84,4 +84,9 @@ public class ServiceNowCreateStepInfo implements PMSStepInfo, WithConnectorRef, 
     connectorRefMap.put(YAMLFieldNameConstants.CONNECTOR_REF, connectorRef);
     return connectorRefMap;
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/servicenow/update/ServiceNowUpdateStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/servicenow/update/ServiceNowUpdateStepInfo.java
@@ -88,4 +88,9 @@ public class ServiceNowUpdateStepInfo implements PMSStepInfo, WithConnectorRef, 
     connectorRefMap.put(YAMLFieldNameConstants.CONNECTOR_REF, connectorRef);
     return connectorRefMap;
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/860-orchestration-steps/src/main/java/io/harness/steps/shellscript/ShellScriptStepInfo.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/shellscript/ShellScriptStepInfo.java
@@ -79,4 +79,9 @@ public class ShellScriptStepInfo
         .delegateSelectors(getDelegateSelectors())
         .build();
   }
+
+  @Override
+  public ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors() {
+    return getDelegateSelectors();
+  }
 }

--- a/878-ng-common-utilities/src/main/java/io/harness/plancreator/steps/common/WithDelegateSelector.java
+++ b/878-ng-common-utilities/src/main/java/io/harness/plancreator/steps/common/WithDelegateSelector.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 
 public interface WithDelegateSelector {
-  @JsonIgnore ParameterField<List<TaskSelectorYaml>> getDelegateSelectors();
+  @JsonIgnore ParameterField<List<TaskSelectorYaml>> fetchDelegateSelectors();
 
   void setDelegateSelectors(ParameterField<List<TaskSelectorYaml>> delegateSelectors);
 }

--- a/878-ng-common-utilities/src/main/java/io/harness/steps/StepUtils.java
+++ b/878-ng-common-utilities/src/main/java/io/harness/steps/StepUtils.java
@@ -436,8 +436,8 @@ public class StepUtils {
         WithDelegateSelector withDelegateSelector = (WithDelegateSelector) stepSpecType;
         // Delegate Selector Precedence: 1)Step -> 2)stepGroup -> 3)Stage ->  4)Pipeline
 
-        ParameterField<List<TaskSelectorYaml>> delegateSelectors = withDelegateSelector.getDelegateSelectors();
-        if (!ParameterField.isNull(withDelegateSelector.getDelegateSelectors())) {
+        ParameterField<List<TaskSelectorYaml>> delegateSelectors = withDelegateSelector.fetchDelegateSelectors();
+        if (!ParameterField.isNull(withDelegateSelector.fetchDelegateSelectors())) {
           setOriginAndDelegateSelectors(delegateSelectors, withDelegateSelector, STEP);
           return;
         }


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
