### PR TITLE
fix: [CDS-37343]: Add DelegateTaskResponse in kyroRegistrar revert hot fix

### DIFF
--- a/930-delegate-tasks/src/main/java/io/harness/serializer/kryo/DelegateTasksKryoRegistrar.java
+++ b/930-delegate-tasks/src/main/java/io/harness/serializer/kryo/DelegateTasksKryoRegistrar.java
@@ -87,7 +87,6 @@ import software.wings.beans.trigger.WebhookTriggerParameters;
 import software.wings.beans.yaml.GitFetchFilesFromMultipleRepoResult;
 import software.wings.delegatetasks.BambooTask;
 import software.wings.delegatetasks.DelegateStateType;
-import software.wings.delegatetasks.GcbDelegateResponse;
 import software.wings.delegatetasks.buildsource.BuildCollectParameters;
 import software.wings.delegatetasks.buildsource.BuildSourceExecutionResponse;
 import software.wings.delegatetasks.buildsource.BuildSourceParameters;
@@ -550,6 +549,5 @@ public class DelegateTasksKryoRegistrar implements KryoRegistrar {
     kryo.register(CollaborationProviderRequest.CommunicationType.class, 5307);
     kryo.register(CollaborationProviderRequest.class, 5306);
     kryo.register(CollaborationProviderResponse.class, 5308);
-    kryo.register(GcbDelegateResponse.class, 74090);
   }
 }

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=75112
+build.number=75114
 build.patch=000
 delegate.version=22.05.10
 delegate.patch=000

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=75113
+build.number=75112
 build.patch=000
 delegate.version=22.05.10
 delegate.patch=000


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/33063)
<!-- Reviewable:end -->
