### PR TITLE
fix: [CDS-37447]: Increasing the SSH timeout during execution

### DIFF
--- a/400-rest/src/main/java/software/wings/delegatetasks/validation/capabilitycheck/SSHHostValidationCapabilityCheck.java
+++ b/400-rest/src/main/java/software/wings/delegatetasks/validation/capabilitycheck/SSHHostValidationCapabilityCheck.java
@@ -61,9 +61,10 @@ public class SSHHostValidationCapabilityCheck implements CapabilityCheck {
         capability.getSshVaultConfig());
     try {
       SshSessionConfig hostConnectionTest = createSshSessionConfig(capability);
-      int timeout = (int) ofSeconds(15L).toMillis();
+      int timeout = (int) ofSeconds(60L).toMillis();
+      int sshConnectionTimeout = (int) ofSeconds(120L).toMillis();
       hostConnectionTest.setSocketConnectTimeout(timeout);
-      hostConnectionTest.setSshConnectionTimeout(timeout);
+      hostConnectionTest.setSshConnectionTimeout(sshConnectionTimeout);
       hostConnectionTest.setSshSessionTimeout(timeout);
       performTest(hostConnectionTest);
       capabilityResponseBuilder.validated(true);

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=74972
+build.number=74973
 build.patch=000
 delegate.version=22.04.12
 delegate.patch=000


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/33099)
<!-- Reviewable:end -->
