### PR TITLE
fix: [CDS-37510]: do workflow variable allowed values check only when variable value is provided

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/trigger/TriggerServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/trigger/TriggerServiceImpl.java
@@ -1417,6 +1417,9 @@ public class TriggerServiceImpl implements TriggerService {
 
   @VisibleForTesting
   void validateWorkflowVariable(Map<String, String> nameToVariableValueMap, List<Variable> workflowVariables) {
+    if (isEmpty(nameToVariableValueMap)) {
+      return;
+    }
     for (Variable variable : workflowVariables) {
       List<String> allowedValues = variable.getAllowedList();
       if (isNotEmpty(allowedValues)) {

--- a/400-rest/src/main/java/software/wings/service/impl/trigger/TriggerServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/trigger/TriggerServiceImpl.java
@@ -164,7 +164,6 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -1416,14 +1415,16 @@ public class TriggerServiceImpl implements TriggerService {
     return workflowExecution;
   }
 
-  private void validateWorkflowVariable(Map<String, String> nameToVariableValueMap, List<Variable> workflowVariables) {
+  @VisibleForTesting
+  void validateWorkflowVariable(Map<String, String> nameToVariableValueMap, List<Variable> workflowVariables) {
     for (Variable variable : workflowVariables) {
-      if (isNotEmpty(variable.getAllowedValues())) {
-        List<String> allowedValues = Arrays.asList(variable.getAllowedValues().split(","));
+      List<String> allowedValues = variable.getAllowedList();
+      if (isNotEmpty(allowedValues)) {
         String variableValue = nameToVariableValueMap.get(variable.getName());
         if (isNotEmpty(variableValue) && !allowedValues.contains(variableValue)) {
-          throw new WingsException(
-              "Trigger rejected because a passed workflow variable was not present in allowed values");
+          throw new WingsException(String.format(
+              "Trigger rejected because passed workflow variable %s was not present in allowed values list [%s]",
+              variableValue, String.join(",", allowedValues)));
         }
       }
     }

--- a/400-rest/src/main/java/software/wings/service/impl/trigger/TriggerServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/trigger/TriggerServiceImpl.java
@@ -1425,8 +1425,8 @@ public class TriggerServiceImpl implements TriggerService {
       if (isNotEmpty(allowedValues)) {
         String variableValue = nameToVariableValueMap.get(variable.getName());
         if (isNotEmpty(variableValue) && !allowedValues.contains(variableValue)) {
-          throw new WingsException(String.format(
-              "Trigger rejected because passed workflow variable %s was not present in allowed values list [%s]",
+          throw new InvalidRequestException(String.format(
+              "Trigger rejected because passed workflow variable value %s was not present in allowed values list [%s]",
               variableValue, String.join(",", allowedValues)));
         }
       }

--- a/400-rest/src/main/java/software/wings/service/impl/trigger/TriggerServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/trigger/TriggerServiceImpl.java
@@ -1416,11 +1416,12 @@ public class TriggerServiceImpl implements TriggerService {
     return workflowExecution;
   }
 
-  static void validateWorkflowVariable(Map<String, String> workflowVariables, List<Variable> allowedValues) {
-    for (Variable x : allowedValues) {
-      if (isNotEmpty(x.getAllowedValues())) {
-        List<String> allowedVals = Arrays.asList(x.getAllowedValues().split(","));
-        if (!allowedVals.contains(workflowVariables.get(x.getName()))) {
+  private void validateWorkflowVariable(Map<String, String> nameToVariableValueMap, List<Variable> workflowVariables) {
+    for (Variable variable : workflowVariables) {
+      if (isNotEmpty(variable.getAllowedValues())) {
+        List<String> allowedValues = Arrays.asList(variable.getAllowedValues().split(","));
+        String variableValue = nameToVariableValueMap.get(variable.getName());
+        if (isNotEmpty(variableValue) && !allowedValues.contains(variableValue)) {
           throw new WingsException(
               "Trigger rejected because a passed workflow variable was not present in allowed values");
         }

--- a/400-rest/src/test/java/software/wings/service/impl/trigger/TriggerServiceTest.java
+++ b/400-rest/src/test/java/software/wings/service/impl/trigger/TriggerServiceTest.java
@@ -543,7 +543,7 @@ public class TriggerServiceTest extends WingsBaseTest {
     List<Variable> allowedValues = new ArrayList<>();
     allowedValues.add(var1);
     allowedValues.add(var2);
-    assertThatThrownBy(() -> TriggerServiceImpl.validateWorkflowVariable(workflowVariables, allowedValues))
+    assertThatThrownBy(() -> triggerService.validateWorkflowVariable(workflowVariables, allowedValues))
         .isInstanceOf(WingsException.class)
         .hasMessageContaining("Trigger rejected because a passed workflow variable was not present in allowed values");
   }

--- a/400-rest/src/test/java/software/wings/service/impl/trigger/TriggerServiceTest.java
+++ b/400-rest/src/test/java/software/wings/service/impl/trigger/TriggerServiceTest.java
@@ -527,6 +527,7 @@ public class TriggerServiceTest extends WingsBaseTest {
 
     verify(pipelineService, times(2)).readPipeline(APP_ID, PIPELINE_ID, true);
   }
+
   @Test
   @Owner(developers = ATHARVA)
   @Category(UnitTests.class)
@@ -536,17 +537,19 @@ public class TriggerServiceTest extends WingsBaseTest {
     workflowVariables.put("var2", "val2");
     Variable var1 = new Variable();
     var1.setName("var1");
+    var1.setAllowedList(asList("val1", "val3"));
     Variable var2 = new Variable();
     var2.setName("var2");
-    var1.setAllowedValues("val1,val3");
-    var2.setAllowedValues("val4,val5");
+    var2.setAllowedList(asList("val4", "val5"));
     List<Variable> allowedValues = new ArrayList<>();
     allowedValues.add(var1);
     allowedValues.add(var2);
     assertThatThrownBy(() -> triggerService.validateWorkflowVariable(workflowVariables, allowedValues))
-        .isInstanceOf(WingsException.class)
-        .hasMessageContaining("Trigger rejected because a passed workflow variable was not present in allowed values");
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessage(
+            "Trigger rejected because passed workflow variable value val2 was not present in allowed values [val4,val5]");
   }
+
   @Test(expected = InvalidRequestException.class)
   @Owner(developers = MILOS)
   @Category(UnitTests.class)

--- a/400-rest/src/test/java/software/wings/service/impl/trigger/TriggerServiceTest.java
+++ b/400-rest/src/test/java/software/wings/service/impl/trigger/TriggerServiceTest.java
@@ -547,7 +547,7 @@ public class TriggerServiceTest extends WingsBaseTest {
     assertThatThrownBy(() -> triggerService.validateWorkflowVariable(workflowVariables, allowedValues))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage(
-            "Trigger rejected because passed workflow variable value val2 was not present in allowed values [val4,val5]");
+            "Trigger rejected because passed workflow variable value val2 was not present in allowed values list [val4,val5]");
   }
 
   @Test(expected = InvalidRequestException.class)


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/33153)
<!-- Reviewable:end -->
