### PR TITLE
fix: [DEL-4086]: Change Kryo CachedFieldNameStrategy to DEFAULT

### DIFF
--- a/980-commons/BUILD.bazel
+++ b/980-commons/BUILD.bazel
@@ -113,6 +113,7 @@ java_library(
         "//990-commons-test:module",
         "//999-annotations:module",
         "@maven//:com_auth0_java_jwt",
+        "@maven//:com_esotericsoftware_kryo",
         "@maven//:com_fasterxml_jackson_core_jackson_annotations",
         "@maven//:com_fasterxml_jackson_core_jackson_core",
         "@maven//:com_fasterxml_jackson_core_jackson_databind",

--- a/980-commons/src/main/java/io/harness/serializer/HKryo.java
+++ b/980-commons/src/main/java/io/harness/serializer/HKryo.java
@@ -100,7 +100,7 @@ public class HKryo extends Kryo {
     super(classResolver, new MapReferenceResolver(), new DefaultStreamFactory());
     setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(new StdInstantiatorStrategy()));
     setDefaultSerializer(CompatibleFieldSerializer.class);
-    getFieldSerializerConfig().setCachedFieldNameStrategy(FieldSerializer.CachedFieldNameStrategy.EXTENDED);
+    getFieldSerializerConfig().setCachedFieldNameStrategy(FieldSerializer.CachedFieldNameStrategy.DEFAULT);
     getFieldSerializerConfig().setCopyTransient(false);
     setRegistrationRequired(true);
 

--- a/980-commons/src/test/java/io/harness/serializer/KryoSerializerDtoTest.java
+++ b/980-commons/src/test/java/io/harness/serializer/KryoSerializerDtoTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.serializer;
+
+import static io.harness.rule.OwnerRule.JOHANNES;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.harness.CategoryTest;
+import io.harness.category.element.UnitTests;
+import io.harness.rule.Owner;
+
+import com.esotericsoftware.kryo.Kryo;
+import java.util.Arrays;
+import java.util.HashSet;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Slf4j
+public class KryoSerializerDtoTest extends CategoryTest {
+  public static final Integer REGISTRATION_ID = 421;
+
+  private static final KryoSerializer originalSerializer =
+      new KryoSerializer(new HashSet<>(Arrays.asList(OriginalRegistrar.class)));
+  private static final KryoSerializer dtoSerializer =
+      new KryoSerializer(new HashSet<>(Arrays.asList(DtoRegistrar.class)));
+
+  @Test
+  @Owner(developers = JOHANNES)
+  @Category(UnitTests.class)
+  public void testSerializationFromOriginalToDto() {
+    Original source = Original.builder().name("someName").value(42).originalOnlyField(2.1).build();
+
+    byte[] serializedOriginal = originalSerializer.asBytes(source);
+    OriginalDTO deserializedAsDto = (OriginalDTO) dtoSerializer.asObject(serializedOriginal);
+
+    assertThat(deserializedAsDto.getName()).isEqualTo(source.getName());
+    assertThat(deserializedAsDto.getValue()).isEqualTo(source.getValue());
+  }
+
+  @Test
+  @Owner(developers = JOHANNES)
+  @Category(UnitTests.class)
+  public void testSerializationFromDtoToOriginal() {
+    OriginalDTO sourceDto = OriginalDTO.builder().name("someName").value(42).build();
+
+    byte[] serializedDto = dtoSerializer.asBytes(sourceDto);
+    Original deserializedAsOriginal = (Original) originalSerializer.asObject(serializedDto);
+
+    assertThat(deserializedAsOriginal.getName()).isEqualTo(sourceDto.getName());
+    assertThat(deserializedAsOriginal.getValue()).isEqualTo(sourceDto.getValue());
+
+    // original only field should be the default value
+    assertThat(deserializedAsOriginal.getOriginalOnlyField())
+        .isEqualTo(Original.builder().build().getOriginalOnlyField());
+  }
+
+  @Data
+  @Builder
+  public static class Original {
+    private String name;
+    private int value;
+    private double originalOnlyField;
+  }
+
+  @Data
+  @Builder
+  public static class OriginalDTO {
+    private String name;
+    private int value;
+  }
+
+  public static class OriginalRegistrar implements KryoRegistrar {
+    @Override
+    public void register(Kryo kryo) {
+      kryo.register(Original.class, REGISTRATION_ID);
+    }
+  }
+
+  public static class DtoRegistrar implements KryoRegistrar {
+    @Override
+    public void register(Kryo kryo) {
+      kryo.register(OriginalDTO.class, REGISTRATION_ID);
+    }
+  }
+}


### PR DESCRIPTION
As part of removing 400-rest dependency from 260-delegate we are replacing some storage entities that are sent to the delegate with DTO classes that have only the necessary fields.
To avoid constant delegate / manager release orchestrations for every DTO required when using a new KRYO registrationId for the DTO, we are reusing the same one.

Theoretically, this should be compatible between any manager and delegate version, as we still send all required fields.
However, we noticed that KRYO is using the classname in the field serialization, which means that for example for a class `Original` with field `name` it will serialize it as `Original.name`. Because of that, it is unable to find that same field in `OriginalDto` during deserialization (and the other way around).

This is caused by the following line in our HKryo class:
`getFieldSerializerConfig().setCachedFieldNameStrategy(FieldSerializer.CachedFieldNameStrategy.EXTENDED);`

This PR is changing the strategy to DEFAULT, which won't include the class name in the serialized fields and thus allows seemless serialization between the original and the DTO.

Also adding a UT to verify the behavior and ensure it isn't changed!

## IMPORTANT
This has the potential impact of breaking behavior in case we have classes where the BASE class fields with the same name as the extending class - though that hopefully shouldn't be the case.

Also, we are trying to see if there are any other implications.

---- 
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/33177)
<!-- Reviewable:end -->
