### PR TITLE
[fix]:[DEL-4041]: fix for watcher to prevent from restart

### DIFF
--- a/960-watcher/src/test/java/io/harness/watcher/service/WatcherServiceImplTest.java
+++ b/960-watcher/src/test/java/io/harness/watcher/service/WatcherServiceImplTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.harness.CategoryTest;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.category.element.UnitTests;
@@ -59,7 +58,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 @OwnedBy(HarnessTeam.DEL)
-public class WatcherServiceImplTest extends CategoryTest {
+public class WatcherServiceImplTest {
   @Mock private TimeLimiter timeLimiter;
   @Mock private MessageService messageService;
   @Mock private WatcherConfiguration watcherConfiguration;
@@ -310,17 +309,6 @@ public class WatcherServiceImplTest extends CategoryTest {
   @Test
   @Owner(developers = MARKO)
   @Category(UnitTests.class)
-  public void testRestartWatcherToUpgradeJre() {
-    try {
-      watcherService.restartWatcherToUpgradeJre("openjdk");
-    } catch (Exception ex) {
-      fail(ex.getMessage());
-    }
-  }
-
-  @Test
-  @Owner(developers = MARKO)
-  @Category(UnitTests.class)
   public void testRestartDelegateToUpgradeJre() {
     try {
       FieldUtils.writeField(watcherService, "clock", Clock.systemDefaultZone(), true);
@@ -376,6 +364,7 @@ public class WatcherServiceImplTest extends CategoryTest {
     when(watcherConfiguration.getDelegateCheckLocation()).thenReturn(DELEGATE_CHECK_LOCATION);
     doReturn(VALID_FIVE_DIGITS_VERSION).when(watcherService).getResponseStringFromUrl();
     when(watcherService.getVersion()).thenReturn(CURRENT_VERSION);
+    doReturn(true).when(watcherService).downloadRunScriptsBeforeRestartingDelegateAndWatcher();
 
     watcherService.checkForWatcherUpgrade();
 
@@ -391,6 +380,7 @@ public class WatcherServiceImplTest extends CategoryTest {
     when(watcherConfiguration.getDelegateCheckLocation()).thenReturn(DELEGATE_CHECK_LOCATION);
     doReturn(VALID_FIVE_DIGITS_WITH_HYPHEN).when(watcherService).getResponseStringFromUrl();
     when(watcherService.getVersion()).thenReturn(CURRENT_VERSION);
+    doReturn(true).when(watcherService).downloadRunScriptsBeforeRestartingDelegateAndWatcher();
 
     watcherService.checkForWatcherUpgrade();
 
@@ -406,6 +396,7 @@ public class WatcherServiceImplTest extends CategoryTest {
     when(watcherConfiguration.getDelegateCheckLocation()).thenReturn(DELEGATE_CHECK_LOCATION);
     doReturn(VALID_SIX_DIGITS_VERSION).when(watcherService).getResponseStringFromUrl();
     when(watcherService.getVersion()).thenReturn(CURRENT_VERSION);
+    doReturn(true).when(watcherService).downloadRunScriptsBeforeRestartingDelegateAndWatcher();
 
     watcherService.checkForWatcherUpgrade();
 
@@ -421,6 +412,7 @@ public class WatcherServiceImplTest extends CategoryTest {
     when(watcherConfiguration.getDelegateCheckLocation()).thenReturn(DELEGATE_CHECK_LOCATION);
     doReturn(VALID_SIX_DIGITS_VERSION_WITH_HYPHEN).when(watcherService).getResponseStringFromUrl();
     when(watcherService.getVersion()).thenReturn(CURRENT_VERSION);
+    doReturn(true).when(watcherService).downloadRunScriptsBeforeRestartingDelegateAndWatcher();
 
     watcherService.checkForWatcherUpgrade();
 

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=75208
+build.number=75209
 build.patch=000
 delegate.version=22.05.11
 delegate.patch=000


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/33244)
<!-- Reviewable:end -->
