### PR TITLE
fix: [CI-4462]: Update addon GetTests to handle nested testsuite

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=75216
+build.number=75217
 build.patch=000
 delegate.version=22.05.11
 delegate.patch=000

--- a/product/ci/addon/testreports/junit/junit_test.go
+++ b/product/ci/addon/testreports/junit/junit_test.go
@@ -23,6 +23,7 @@ var (
 	prefix  = "junit_test_999/"
 	report1 = "testdata/reportWithPassFail.xml"
 	report2 = "testdata/reportWithSkipError.xml"
+	report3 = "testdata/reportWithNestedTestSuite.xml"
 )
 
 func getBaseDir() string {
@@ -136,6 +137,59 @@ func expectedErrorTest() *types.TestCase {
 	}
 }
 
+func expectedNestedTests() []*types.TestCase {
+	test1 := &types.TestCase{
+		Name: "test1",
+		ClassName: "t.st.c.ApiControllerTest",
+		SuiteName: "t\\st\\c\\ApiControllerTest",
+		Result: types.Result{
+			Status: types.StatusPassed,
+		},
+		DurationMs: 1000,
+	}
+
+	test2 := &types.TestCase{
+		Name: "test17",
+		ClassName: "t.st.c.ApiControllerTest",
+		SuiteName: "t\\st\\c\\ApiControllerTest",
+		Result: types.Result{
+			Status: types.StatusPassed,
+		},
+		DurationMs: 1000,
+	}
+
+	test3 := &types.TestCase{
+		Name: "test20",
+		ClassName: "t.st.c.RedirectControllerTest",
+		SuiteName: "t\\st\\c\\RedirectControllerTest",
+		Result: types.Result{
+			Status: types.StatusPassed,
+		},
+		DurationMs: 2000,
+	}
+
+	test4 := &types.TestCase{
+		Name: "test29",
+		ClassName: "t.st.c.RouteDispatcherTest",
+		SuiteName: "t\\st\\c\\RouteDispatcherTest",
+		Result: types.Result{
+			Status: types.StatusPassed,
+		},
+		DurationMs: 2000,
+	}
+
+	test5 := &types.TestCase{
+		Name: "test40",
+		ClassName: "t.st.c.PdoAdapterTest",
+		SuiteName: "t\\st\\c\\PdoAdapterTest",
+		Result: types.Result{
+			Status: types.StatusPassed,
+		},
+		DurationMs: 2000,
+	}
+	return []*types.TestCase{test1, test2, test3, test4, test5}
+}
+
 func TestGetTests_All(t *testing.T) {
 	err := createNestedDir("a/b/c/d")
 	if err != nil {
@@ -146,6 +200,10 @@ func TestGetTests_All(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = copy(report2, "a/b/c/d/report2.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = copy(report3, "a/b/report3.xml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,6 +218,7 @@ func TestGetTests_All(t *testing.T) {
 		tests = append(tests, tc)
 	}
 	exp := []*types.TestCase{expectedPassedTest(), expectedErrorTest(), expectedFailedTest(), expectedSkippedTest()}
+	exp = append(exp, expectedNestedTests()...)
 	assert.ElementsMatch(t, exp, tests)
 	//assert.NotNil(t, nil)
 }

--- a/product/ci/addon/testreports/junit/testdata/reportWithNestedTestSuite.xml
+++ b/product/ci/addon/testreports/junit/testdata/reportWithNestedTestSuite.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="STest" tests="5" assertions="20" errors="0" failures="0" skipped="0" time="8">
+    <testsuite name="t\st\c\ApiControllerTest" file="/harness/tests/unit/Controller/ApiControllerTest.php" tests="17" assertions="9" errors="0" failures="0" skipped="0" time="2">
+        <testcase name="test1" class="t\st\c\ApiControllerTest" classname="t.st.c.ApiControllerTest" file="/harness/tests/unit/Controller/ApiControllerTest.php" line="15" assertions="3" time="1"/>
+        <testcase name="test17" class="t\st\c\ApiControllerTest" classname="t.st.c.ApiControllerTest" file="/harness/tests/unit/Controller/ApiControllerTest.php" line="254" assertions="6" time="1"/>
+    </testsuite>
+    <testsuite name="t\st\c\RedirectControllerTest" file="/harness/tests/unit/Controller/RedirectControllerTest.php" tests="3" assertions="2" errors="0" failures="0" skipped="0" time="2">
+      <testcase name="test20" class="t\st\c\RedirectControllerTest" classname="t.st.c.RedirectControllerTest" file="/harness/tests/unit/Controller/RedirectControllerTest.php" line="48" assertions="2" time="2"/>
+    </testsuite>
+    <testsuite name="t\st\c\RouteDispatcherTest" file="/harness/tests/unit/RouteDispatcherTest.php" tests="7" assertions="1" errors="0" failures="0" skipped="0" time="2">
+      <testcase name="test29" class="t\st\c\RouteDispatcherTest" classname="t.st.c.RouteDispatcherTest" file="/harness/tests/unit/RouteDispatcherTest.php" line="143" assertions="1" time="2"/>
+    </testsuite>
+    <testsuite name="t\st\c\PdoAdapterTest" file="/harness/tests/unit/Storage/Adapter/PdoAdapterTest.php" tests="11" assertions="2" errors="0" failures="0" skipped="0" time="2">
+      <testcase name="test40" class="t\st\c\PdoAdapterTest" classname="t.st.c.PdoAdapterTest" file="/harness/tests/unit/Storage/Adapter/PdoAdapterTest.php" line="130" assertions="2" time="2"/>
+    </testsuite>
+  </testsuite>
+</testsuites>


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/33284)
<!-- Reviewable:end -->
