### PR TITLE
fix: [CI-4473]: remove timeout

### DIFF
--- a/960-api-services/src/main/java/io/harness/git/GitClientV2Impl.java
+++ b/960-api-services/src/main/java/io/harness/git/GitClientV2Impl.java
@@ -136,7 +136,7 @@ import org.eclipse.jgit.treewalk.CanonicalTreeParser;
 @OwnedBy(CDP)
 public class GitClientV2Impl implements GitClientV2 {
   private static final int GIT_COMMAND_TIMEOUT = 60;
-  private static final int GIT_COMMAND_RETRY = 2;
+  private static final int GIT_COMMAND_RETRY = 3;
   @Inject private GitClientHelper gitClientHelper;
   /**
    * factory for creating HTTP connections. By default, JGit uses JDKHttpConnectionFactory which doesn't work well with
@@ -337,7 +337,7 @@ public class GitClientV2Impl implements GitClientV2 {
       lsRemoteCommand = (LsRemoteCommand) getAuthConfiguredCommand(lsRemoteCommand, request);
       RetryPolicy<Object> retryPolicy = getRetryPolicyForCommand(format("[Retrying failed git validation, attempt: {}"),
           format("Git validation failed after retrying {} times"));
-      lsRemoteCommand.setTimeout(GIT_COMMAND_TIMEOUT).setRemote(repoUrl).setHeads(true).setTags(true);
+      lsRemoteCommand.setRemote(repoUrl).setHeads(true).setTags(true);
       final LsRemoteCommand finalLsRemoteCommand = lsRemoteCommand;
       Failsafe.with(retryPolicy).get(() -> finalLsRemoteCommand.call());
       log.info(


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
