### PR TITLE
[feat]: [OPA-172]: Send correct entity metadata to Policy Manager

### DIFF
--- a/860-orchestration-steps/src/main/java/io/harness/steps/policy/step/PolicyStep.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/policy/step/PolicyStep.java
@@ -88,8 +88,9 @@ public class PolicyStep implements SyncExecutable<StepElementParameters> {
     try {
       String policySetsQueryParam = PolicyStepHelper.getPolicySetsStringForQueryParam(policySets);
       JsonNode payloadObject = YamlUtils.readTree(payload).getNode().getCurrJsonNode();
-      opaEvaluationResponseHolder = SafeHttpCall.executeWithErrorMessage(opaServiceClient.evaluateWithCredentialsByID(
-          accountId, orgIdentifier, projectIdentifier, policySetsQueryParam, payloadObject));
+      opaEvaluationResponseHolder = SafeHttpCall.executeWithErrorMessage(
+          opaServiceClient.evaluateWithCredentialsByID(accountId, orgIdentifier, projectIdentifier,
+              policySetsQueryParam, PolicyStepHelper.getEntityMetadataString(stepParameters.getName()), payloadObject));
     } catch (InvalidRequestException ex) {
       return PolicyStepHelper.buildPolicyEvaluationErrorStepResponse(ex.getMessage());
     } catch (Exception ex) {

--- a/860-orchestration-steps/src/main/java/io/harness/steps/policy/step/PolicyStepHelper.java
+++ b/860-orchestration-steps/src/main/java/io/harness/steps/policy/step/PolicyStepHelper.java
@@ -14,6 +14,7 @@ import static io.harness.pms.sdk.core.steps.io.StepResponse.builder;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.eraro.ErrorCode;
 import io.harness.eraro.Level;
+import io.harness.exception.UnexpectedException;
 import io.harness.opaclient.model.OpaConstants;
 import io.harness.opaclient.model.OpaEvaluationResponseHolder;
 import io.harness.opaclient.model.OpaPolicySetEvaluationResponse;
@@ -24,9 +25,15 @@ import io.harness.pms.contracts.execution.failure.FailureType;
 import io.harness.pms.sdk.core.steps.io.StepResponse;
 import io.harness.pms.yaml.YamlField;
 import io.harness.pms.yaml.YamlUtils;
+import io.harness.serializer.JsonUtils;
 
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
@@ -65,6 +72,15 @@ public class PolicyStepHelper {
 
   public StepResponse buildFailureStepResponse(ErrorCode errorCode, String message, FailureType failureType) {
     return buildFailureStepResponse(errorCode, message, failureType, null);
+  }
+
+  public String getEntityMetadataString(String stepName) {
+    Map<String, String> metadataMap = ImmutableMap.<String, String>builder().put("entityName", stepName).build();
+    try {
+      return URLEncoder.encode(JsonUtils.asJson(metadataMap), StandardCharsets.UTF_8.toString());
+    } catch (UnsupportedEncodingException e) {
+      throw new UnexpectedException("Unable to encode entity metadata JSON into URL String");
+    }
   }
 
   public StepResponse buildFailureStepResponse(

--- a/860-orchestration-steps/src/test/java/io/harness/steps/policy/step/PolicyStepHelperTest.java
+++ b/860-orchestration-steps/src/test/java/io/harness/steps/policy/step/PolicyStepHelperTest.java
@@ -83,6 +83,19 @@ public class PolicyStepHelperTest extends CategoryTest {
   @Test
   @Owner(developers = NAMAN)
   @Category(UnitTests.class)
+  public void testGetEntityMetadataString() {
+    String stepName = "noSpaces";
+    String entityMetadataString = PolicyStepHelper.getEntityMetadataString(stepName);
+    assertThat(entityMetadataString).isEqualTo("%7B%22entityName%22%3A%22noSpaces%22%7D");
+
+    stepName = "has Spaces";
+    entityMetadataString = PolicyStepHelper.getEntityMetadataString(stepName);
+    assertThat(entityMetadataString).isEqualTo("%7B%22entityName%22%3A%22has+Spaces%22%7D");
+  }
+
+  @Test
+  @Owner(developers = NAMAN)
+  @Category(UnitTests.class)
   public void testBuildPolicyEvaluationFailureMessage() {
     OpaEvaluationResponseHolder evaluationResponse0 =
         OpaEvaluationResponseHolder.builder()

--- a/860-orchestration-steps/src/test/java/io/harness/steps/policy/step/PolicyStepTest.java
+++ b/860-orchestration-steps/src/test/java/io/harness/steps/policy/step/PolicyStepTest.java
@@ -62,6 +62,7 @@ public class PolicyStepTest extends CategoryTest {
   String accountId = "acc";
   String orgId = "org";
   String projectId = "proj";
+  String stepName = "step name";
   List<String> projLevelPolicySet;
   StepElementParameters stepParameters;
   Call<OpaEvaluationResponseHolder> request;
@@ -142,10 +143,11 @@ public class PolicyStepTest extends CategoryTest {
             .type("Custom")
             .policySpec(CustomPolicyStepSpec.builder().payload(ParameterField.createValueField(payload)).build())
             .build();
-    stepParameters = StepElementParameters.builder().spec(policyStepSpecParameters).build();
+    stepParameters = StepElementParameters.builder().name(stepName).spec(policyStepSpecParameters).build();
 
     String urlPolicySets = "ps1";
-    when(opaServiceClient.evaluateWithCredentialsByID(accountId, orgId, projectId, urlPolicySets, payloadObj))
+    when(opaServiceClient.evaluateWithCredentialsByID(accountId, orgId, projectId, urlPolicySets,
+             PolicyStepHelper.getEntityMetadataString(stepName), payloadObj))
         .thenReturn(request);
     when(SafeHttpCall.executeWithErrorMessage(request)).thenThrow(new HttpResponseException(400, "My Invalid Request"));
     StepResponse stepResponse = policyStep.executeSync(ambiance, stepParameters, null, null);
@@ -166,10 +168,11 @@ public class PolicyStepTest extends CategoryTest {
             .type("Custom")
             .policySpec(CustomPolicyStepSpec.builder().payload(ParameterField.createValueField(payload)).build())
             .build();
-    stepParameters = StepElementParameters.builder().spec(policyStepSpecParameters).build();
+    stepParameters = StepElementParameters.builder().name(stepName).spec(policyStepSpecParameters).build();
 
     String urlPolicySets = "ps1";
-    when(opaServiceClient.evaluateWithCredentialsByID(accountId, orgId, projectId, urlPolicySets, payloadObj))
+    when(opaServiceClient.evaluateWithCredentialsByID(accountId, orgId, projectId, urlPolicySets,
+             PolicyStepHelper.getEntityMetadataString(stepName), payloadObj))
         .thenReturn(request);
     String errorString = "{\n"
         + "    \"identifier\" : \"thisSet\",\n"
@@ -194,10 +197,11 @@ public class PolicyStepTest extends CategoryTest {
             .type("Custom")
             .policySpec(CustomPolicyStepSpec.builder().payload(ParameterField.createValueField(payload)).build())
             .build();
-    stepParameters = StepElementParameters.builder().spec(policyStepSpecParameters).build();
+    stepParameters = StepElementParameters.builder().name(stepName).spec(policyStepSpecParameters).build();
 
     String urlPolicySets = "ps1";
-    when(opaServiceClient.evaluateWithCredentialsByID(accountId, orgId, projectId, urlPolicySets, payloadObj))
+    when(opaServiceClient.evaluateWithCredentialsByID(accountId, orgId, projectId, urlPolicySets,
+             PolicyStepHelper.getEntityMetadataString(stepName), payloadObj))
         .thenReturn(request);
 
     OpaEvaluationResponseHolder evaluationResponse =
@@ -227,10 +231,11 @@ public class PolicyStepTest extends CategoryTest {
             .type("Custom")
             .policySpec(CustomPolicyStepSpec.builder().payload(ParameterField.createValueField(payload)).build())
             .build();
-    stepParameters = StepElementParameters.builder().spec(policyStepSpecParameters).build();
+    stepParameters = StepElementParameters.builder().name(stepName).spec(policyStepSpecParameters).build();
 
     String urlPolicySets = "ps1";
-    when(opaServiceClient.evaluateWithCredentialsByID(accountId, orgId, projectId, urlPolicySets, payloadObj))
+    when(opaServiceClient.evaluateWithCredentialsByID(accountId, orgId, projectId, urlPolicySets,
+             PolicyStepHelper.getEntityMetadataString(stepName), payloadObj))
         .thenReturn(request);
 
     OpaEvaluationResponseHolder evaluationResponse = OpaEvaluationResponseHolder.builder().status("pass").build();

--- a/870-orchestration/src/main/java/io/harness/engine/GovernanceServiceImpl.java
+++ b/870-orchestration/src/main/java/io/harness/engine/GovernanceServiceImpl.java
@@ -87,8 +87,7 @@ public class GovernanceServiceImpl implements GovernanceService {
             pipelineField.getNode().getField(YAMLFieldNameConstants.PIPELINE).getNode().getIdentifier();
         String pipelineName = pipelineField.getNode().getField(YAMLFieldNameConstants.PIPELINE).getNode().getName();
         String entityString = getEntityString(accountId, orgIdentifier, projectIdentifier, pipelineIdentifier);
-        String entityMetadata = getEntityMetadataString(
-            accountId, orgIdentifier, projectIdentifier, pipelineIdentifier, pipelineName, planExecutionId);
+        String entityMetadata = getEntityMetadataString(pipelineIdentifier, pipelineName, planExecutionId);
         String userIdentifier = getUserIdentifier();
 
         response = SafeHttpCall.executeWithExceptions(
@@ -114,14 +113,11 @@ public class GovernanceServiceImpl implements GovernanceService {
     return URLEncoder.encode(entityStringRaw, StandardCharsets.UTF_8.toString());
   }
 
-  private String getEntityMetadataString(String accountId, String orgIdentifier, String projectIdentifier,
-      String pipelineIdentifier, String pipelineName, String planExecutionId) throws UnsupportedEncodingException {
+  private String getEntityMetadataString(String pipelineIdentifier, String pipelineName, String planExecutionId)
+      throws UnsupportedEncodingException {
     Map<String, String> metadataMap = ImmutableMap.<String, String>builder()
-                                          .put("accountIdentifier", accountId)
-                                          .put("orgIdentifier", orgIdentifier)
-                                          .put("projectIdentifier", projectIdentifier)
                                           .put("pipelineIdentifier", pipelineIdentifier)
-                                          .put("pipelineName", pipelineName)
+                                          .put("entityName", pipelineName)
                                           .put("executionIdentifier", planExecutionId)
                                           .build();
     return URLEncoder.encode(JsonUtils.asJson(metadataMap), StandardCharsets.UTF_8.toString());

--- a/950-opa-client/src/main/java/io/harness/opaclient/OpaServiceClient.java
+++ b/950-opa-client/src/main/java/io/harness/opaclient/OpaServiceClient.java
@@ -30,5 +30,5 @@ public interface OpaServiceClient {
   @POST(API_PREFIX + "evaluate-by-ids")
   Call<OpaEvaluationResponseHolder> evaluateWithCredentialsByID(@Query("accountIdentifier") String accountId,
       @Query("orgIdentifier") String orgId, @Query("projectIdentifier") String projId, @Query("ids") String policySets,
-      @Body Object context);
+      @Query("entityMetadata") String entityMetadata, @Body Object context);
 }


### PR DESCRIPTION
All requests to Policy Manager have an 'entityMetadata' query param, which is supposed to have a key value pair with key 'entityName'. The value of entityName will be displayed in the Policy Evaluations tab. In this PR, the pipeline name is sent to the Policy Manager for pipeline save/runs as entityName, and the policy step name is sent for policy steps. This behaviour has been discussed with the OPA team.
<img width="1275" alt="Screenshot 2022-05-19 at 1 28 25 AM" src="https://user-images.githubusercontent.com/68542540/169145365-860349df-04f6-4a2d-990f-64c81626a75b.png">

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/33320)
<!-- Reviewable:end -->
