### PR TITLE
fix: [CDS-37798]: Support vanity URL in notifications

### DIFF
--- a/800-pipeline-service/src/main/java/io/harness/pms/helpers/PipelineExpressionHelper.javn
+++ b/800-pipeline-service/src/main/java/io/harness/pms/helpers/PipelineExpressionHelper.javn
@@ -1,4 +1,6 @@
-/*
+/wq
+q
+*
  * Copyright 2021 Harness Inc. All rights reserved.
  * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
  * that can be found in the licenses directory at the root of this repository, also available at
@@ -15,6 +17,9 @@ import io.harness.pms.execution.utils.AmbianceUtils;
 import io.harness.pms.pipeline.PipelineEntity;
 import io.harness.pms.pipeline.PipelineEntityUtils;
 import io.harness.pms.pipeline.service.PMSPipelineService;
+B
+import io.harness.pms.plan.execution.beans.PipelineExecutionSummaryEntity;
+import io.harness.pms.plan.execution.service.PmsExecutionSummaryService;
 import io.harness.remote.client.RestClientUtils;
 
 import com.google.inject.Inject;

--- a/800-pipeline-service/src/test/java/io/harness/pms/helpers/PipelineExpressionHelperTest.java
+++ b/800-pipeline-service/src/test/java/io/harness/pms/helpers/PipelineExpressionHelperTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.pms.helpers;
+
+import static io.harness.rule.OwnerRule.DEEPAK_PUTHRAYA;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.harness.CategoryTest;
+import io.harness.PipelineServiceConfiguration;
+import io.harness.account.AccountClient;
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.pms.contracts.ambiance.Ambiance;
+import io.harness.pms.contracts.plan.ExecutionMetadata;
+import io.harness.pms.plan.execution.SetupAbstractionKeys;
+import io.harness.pms.plan.execution.service.PmsExecutionSummaryService;
+import io.harness.rest.RestResponse;
+import io.harness.rule.Owner;
+
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import retrofit2.Call;
+import retrofit2.Response;
+
+@OwnedBy(HarnessTeam.PIPELINE)
+public class PipelineExpressionHelperTest extends CategoryTest {
+  @Mock PmsExecutionSummaryService pmsExecutionSummaryService;
+  @Mock PipelineServiceConfiguration pipelineServiceConfiguration;
+  @Mock AccountClient accountClient;
+  @InjectMocks PipelineExpressionHelper pipelineExpressionHelper;
+  Ambiance ambiance = null;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    ExecutionMetadata metadata =
+        Ambiance.newBuilder().getMetadataBuilder().setPipelineIdentifier("pipeline_test").setModuleType("ci").build();
+    ambiance = Ambiance.newBuilder()
+                   .putSetupAbstractions(SetupAbstractionKeys.accountId, "__ACCOUNT_ID__")
+                   .putSetupAbstractions(SetupAbstractionKeys.orgIdentifier, "org_test")
+                   .putSetupAbstractions(SetupAbstractionKeys.projectIdentifier, "project_test")
+                   .setPlanExecutionId("PLAN_EXECUTION_ID")
+                   .setMetadata(metadata)
+                   .build();
+    when(pipelineServiceConfiguration.getPipelineServiceBaseUrl()).thenReturn("https://app.harness.io/ng/#");
+  }
+
+  @Test
+  @Owner(developers = DEEPAK_PUTHRAYA)
+  @Category(UnitTests.class)
+  public void testGenerationOfURLWithoutVanity() throws IOException {
+    Call vanityUrlCall = mock(Call.class);
+    when(vanityUrlCall.execute()).thenReturn(Response.success(new RestResponse<>("")));
+    when(accountClient.getVanityUrl(anyString())).thenReturn(vanityUrlCall);
+    assertThat(pipelineExpressionHelper.generateUrl(ambiance))
+        .isEqualTo(
+            "https://app.harness.io/ng/#/account/__ACCOUNT_ID__/ci/orgs/org_test/projects/project_test/pipelines/pipeline_test/executions/PLAN_EXECUTION_ID/pipeline");
+  }
+
+  @Test
+  @Owner(developers = DEEPAK_PUTHRAYA)
+  @Category(UnitTests.class)
+  public void testGenerationOfURLWithVanity() throws IOException {
+    Call vanityUrlCall = mock(Call.class);
+    when(vanityUrlCall.execute()).thenReturn(Response.success(new RestResponse<>("https://vanity.harness.io")));
+    when(accountClient.getVanityUrl(anyString())).thenReturn(vanityUrlCall);
+    assertThat(pipelineExpressionHelper.generateUrl(ambiance))
+        .isEqualTo(
+            "https://vanity.harness.io/ng/#/account/__ACCOUNT_ID__/ci/orgs/org_test/projects/project_test/pipelines/pipeline_test/executions/PLAN_EXECUTION_ID/pipeline");
+  }
+}

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=75121
+build.number=75122
 build.patch=000
 delegate.version=22.05.10
 delegate.patch=000


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
