### PR TITLE
[SRM-10588]: Add event classes for monitored service audit trail events

### DIFF
--- a/300-cv-nextgen/src/main/java/io/harness/cvng/events/AbstractMonitoredServiceConfigurationEvent.java
+++ b/300-cv-nextgen/src/main/java/io/harness/cvng/events/AbstractMonitoredServiceConfigurationEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.cvng.events;
+
+import static io.harness.data.structure.EmptyPredicate.isEmpty;
+import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
+
+import io.harness.event.Event;
+import io.harness.ng.core.AccountScope;
+import io.harness.ng.core.OrgScope;
+import io.harness.ng.core.ProjectScope;
+import io.harness.ng.core.ResourceScope;
+
+import com.google.common.base.Preconditions;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+public abstract class AbstractMonitoredServiceConfigurationEvent implements Event {
+  private String accountIdentifier;
+  private String orgIdentifier;
+  private String projectIdentifier;
+
+  @Override
+  public ResourceScope getResourceScope() {
+    Preconditions.checkNotNull(accountIdentifier);
+    if (isNotEmpty(projectIdentifier) && isNotEmpty(orgIdentifier)) {
+      return new ProjectScope(accountIdentifier, orgIdentifier, projectIdentifier);
+    }
+
+    if (isEmpty(projectIdentifier) && isNotEmpty(orgIdentifier)) {
+      return new OrgScope(accountIdentifier, orgIdentifier);
+    }
+
+    return new AccountScope(accountIdentifier);
+  }
+}

--- a/300-cv-nextgen/src/main/java/io/harness/cvng/events/MonitoredServiceCreateEvent.java
+++ b/300-cv-nextgen/src/main/java/io/harness/cvng/events/MonitoredServiceCreateEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.cvng.events;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.audit.ResourceTypeConstants;
+import io.harness.cvng.core.beans.monitoredService.MonitoredServiceDTO;
+import io.harness.ng.core.Resource;
+import io.harness.ng.core.ResourceConstants;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@OwnedBy(HarnessTeam.CV)
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MonitoredServiceCreateEvent extends AbstractMonitoredServiceConfigurationEvent {
+  private MonitoredServiceDTO monitoredServiceDTO;
+  private String monitoredServiceGroupId;
+
+  @Override
+  public Resource getResource() {
+    Map<String, String> labels = new HashMap<>();
+    labels.put(ResourceConstants.LABEL_KEY_RESOURCE_NAME, monitoredServiceDTO.getName());
+    return Resource.builder()
+        .identifier(monitoredServiceGroupId)
+        .labels(labels)
+        .type(ResourceTypeConstants.SERVICE)
+        .build();
+  }
+
+  @Override
+  public String getEventType() {
+    return "MonitoredServiceCreateEvent";
+  }
+}

--- a/300-cv-nextgen/src/main/java/io/harness/cvng/events/MonitoredServiceDeleteEvent.java
+++ b/300-cv-nextgen/src/main/java/io/harness/cvng/events/MonitoredServiceDeleteEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.cvng.events;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.audit.ResourceTypeConstants;
+import io.harness.cvng.core.beans.monitoredService.MonitoredServiceDTO;
+import io.harness.ng.core.Resource;
+import io.harness.ng.core.ResourceConstants;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@OwnedBy(HarnessTeam.CV)
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MonitoredServiceDeleteEvent extends AbstractMonitoredServiceConfigurationEvent {
+  private MonitoredServiceDTO monitoredServiceDTO;
+  private String monitoredServiceGroupId;
+
+  @Override
+  public Resource getResource() {
+    Map<String, String> labels = new HashMap<>();
+    labels.put(ResourceConstants.LABEL_KEY_RESOURCE_NAME, monitoredServiceDTO.getName());
+    return Resource.builder()
+        .identifier(monitoredServiceGroupId)
+        .labels(labels)
+        .type(ResourceTypeConstants.SERVICE)
+        .build();
+  }
+
+  @Override
+  public String getEventType() {
+    return "MonitoredServiceDeleteEvent";
+  }
+}

--- a/300-cv-nextgen/src/main/java/io/harness/cvng/events/MonitoredServiceToggleEvent.java
+++ b/300-cv-nextgen/src/main/java/io/harness/cvng/events/MonitoredServiceToggleEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.cvng.events;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.audit.ResourceTypeConstants;
+import io.harness.cvng.core.beans.monitoredService.MonitoredServiceDTO;
+import io.harness.ng.core.Resource;
+import io.harness.ng.core.ResourceConstants;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@OwnedBy(HarnessTeam.CV)
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MonitoredServiceToggleEvent extends AbstractMonitoredServiceConfigurationEvent {
+  private MonitoredServiceDTO monitoredServiceDTO;
+  private String monitoredServiceGroupId;
+
+  @Override
+  public Resource getResource() {
+    Map<String, String> labels = new HashMap<>();
+    labels.put(ResourceConstants.LABEL_KEY_RESOURCE_NAME, monitoredServiceDTO.getName());
+    return Resource.builder()
+        .identifier(monitoredServiceGroupId)
+        .labels(labels)
+        .type(ResourceTypeConstants.SERVICE)
+        .build();
+  }
+
+  @Override
+  public String getEventType() {
+    return "MonitoredServiceToggleEvent";
+  }
+}

--- a/300-cv-nextgen/src/main/java/io/harness/cvng/events/MonitoredServiceUpdateEvent.java
+++ b/300-cv-nextgen/src/main/java/io/harness/cvng/events/MonitoredServiceUpdateEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.cvng.events;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.audit.ResourceTypeConstants;
+import io.harness.cvng.core.beans.monitoredService.MonitoredServiceDTO;
+import io.harness.ng.core.Resource;
+import io.harness.ng.core.ResourceConstants;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@OwnedBy(HarnessTeam.CV)
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MonitoredServiceUpdateEvent extends AbstractMonitoredServiceConfigurationEvent {
+  private MonitoredServiceDTO monitoredServiceDTO;
+  private String monitoredServiceGroupId;
+
+  @Override
+  public Resource getResource() {
+    Map<String, String> labels = new HashMap<>();
+    labels.put(ResourceConstants.LABEL_KEY_RESOURCE_NAME, monitoredServiceDTO.getName());
+    return Resource.builder()
+        .identifier(monitoredServiceGroupId)
+        .labels(labels)
+        .type(ResourceTypeConstants.SERVICE)
+        .build();
+  }
+
+  @Override
+  public String getEventType() {
+    return "MonitoredServiceUpdateEvent";
+  }
+}


### PR DESCRIPTION
You can use the following comments to re-trigger PR Checks

- Compile: `trigger compile`
- runAeriformCheck: `trigger AeriformCheck`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
