### PR TITLE
[feat]: [PIE-3817]: Generate stages execution list using flag value in pipeline yaml

### DIFF
--- a/800-pipeline-service/src/main/java/io/harness/pms/pipeline/PipelineEntity.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/pipeline/PipelineEntity.java
@@ -160,8 +160,4 @@ public class PipelineEntity
   public String getInvalidYamlString() {
     return yaml;
   }
-
-  public boolean shouldAllowStageExecutions() {
-    return allowStageExecutions != null && allowStageExecutions;
-  }
 }

--- a/800-pipeline-service/src/main/java/io/harness/pms/plan/execution/ExecutionHelper.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/plan/execution/ExecutionHelper.java
@@ -185,7 +185,7 @@ public class ExecutionHelper {
           stagesExecutionInfo.getPipelineYamlToRun());
       planExecutionMetadataBuilder.expandedPipelineJson(expandedJson);
       PlanExecutionMetadata planExecutionMetadata = planExecutionMetadataBuilder.build();
-      BasicPipeline basicPipeline = YamlUtils.read(planExecutionMetadata.getYaml(), BasicPipeline.class);
+      basicPipeline = YamlUtils.read(planExecutionMetadata.getYaml(), BasicPipeline.class);
       ExecutionMetadata executionMetadata = buildExecutionMetadata(pipelineEntity.getIdentifier(), moduleType,
           triggerInfo, pipelineEntity, executionId, retryExecutionInfo, basicPipeline.getNotificationRules());
       return ExecArgs.builder().metadata(executionMetadata).planExecutionMetadata(planExecutionMetadata).build();

--- a/800-pipeline-service/src/main/java/io/harness/pms/plan/execution/ExecutionHelper.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/plan/execution/ExecutionHelper.java
@@ -155,13 +155,13 @@ public class ExecutionHelper {
       RetryExecutionInfo retryExecutionInfo = buildRetryInfo(isRetry, originalExecutionId);
 
       String pipelineYaml = getPipelineYamlAndValidate(mergedRuntimeInputYaml, pipelineEntity);
+      BasicPipeline basicPipeline = YamlUtils.read(pipelineYaml, BasicPipeline.class);
       StagesExecutionInfo stagesExecutionInfo = StagesExecutionInfo.builder()
                                                     .isStagesExecution(false)
                                                     .pipelineYamlToRun(pipelineYaml)
-                                                    .allowStagesExecution(pipelineEntity.shouldAllowStageExecutions())
+                                                    .allowStagesExecution(basicPipeline.isAllowStageExecutions())
                                                     .build();
       if (EmptyPredicate.isNotEmpty(stagesToRun)) {
-        BasicPipeline basicPipeline = YamlUtils.read(pipelineYaml, BasicPipeline.class);
         if (!basicPipeline.isAllowStageExecutions()) {
           throw new InvalidRequestException(
               String.format("Stage executions are not allowed for pipeline [%s]", basicPipeline.getIdentifier()));

--- a/800-pipeline-service/src/main/java/io/harness/pms/plan/execution/PlanExecutionResource.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/plan/execution/PlanExecutionResource.java
@@ -610,18 +610,18 @@ public class PlanExecutionResource {
     }
     PipelineEntity pipelineEntity = optionalPipelineEntity.get();
     String yaml = pipelineEntity.getYaml();
-    boolean shouldAllowStageExecutions = pipelineEntity.shouldAllowStageExecutions();
     if (featureFlagService.isEnabled(accountId, NG_PIPELINE_TEMPLATE)
         && Boolean.TRUE.equals(optionalPipelineEntity.get().getTemplateReference())) {
       yaml = pipelineTemplateHelper
                  .resolveTemplateRefsInPipeline(accountId, orgIdentifier, projectIdentifier, pipelineEntity.getYaml())
                  .getMergedPipelineYaml();
-      try {
-        BasicPipeline basicPipeline = YamlUtils.read(yaml, BasicPipeline.class);
-        shouldAllowStageExecutions = basicPipeline.isAllowStageExecutions();
-      } catch (IOException e) {
-        throw new InvalidRequestException("Cannot create pipeline entity due to " + e.getMessage(), e);
-      }
+    }
+    boolean shouldAllowStageExecutions;
+    try {
+      BasicPipeline basicPipeline = YamlUtils.read(yaml, BasicPipeline.class);
+      shouldAllowStageExecutions = basicPipeline.isAllowStageExecutions();
+    } catch (IOException e) {
+      throw new InvalidRequestException("Cannot create pipeline entity due to " + e.getMessage(), e);
     }
 
     if (!shouldAllowStageExecutions) {

--- a/800-pipeline-service/src/test/java/io/harness/pms/plan/execution/PlanExecutionResourceTest.java
+++ b/800-pipeline-service/src/test/java/io/harness/pms/plan/execution/PlanExecutionResourceTest.java
@@ -89,7 +89,6 @@ public class PlanExecutionResourceTest extends CategoryTest {
                  .identifier(PIPELINE_IDENTIFIER)
                  .name(PIPELINE_IDENTIFIER)
                  .yaml(yaml)
-                 .allowStageExecutions(true)
                  .build();
   }
 


### PR DESCRIPTION
Pipeline YAML has a flag `allowStageExecutions` whose value is also stored in the DB. However, we need to remove the usage of the DB flag now, because the with git simplification, the YAML on Git can easily be outdated wrt the DB entry. Hence, we need to use the value of the flag in the YAML and not in the DB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/33499)
<!-- Reviewable:end -->
