### PR TITLE
[fix]: [CDS-30561]: Added unit test for metadata-only artifact stream types

### DIFF
--- a/400-rest/src/test/java/software/wings/sm/states/azure/AzureVMSSStateHelperTest.java
+++ b/400-rest/src/test/java/software/wings/sm/states/azure/AzureVMSSStateHelperTest.java
@@ -77,6 +77,8 @@ import software.wings.beans.artifact.Artifact;
 import software.wings.beans.artifact.ArtifactStream;
 import software.wings.beans.artifact.ArtifactStreamAttributes;
 import software.wings.beans.artifact.ArtifactStreamType;
+import software.wings.beans.artifact.DockerArtifactStream;
+import software.wings.beans.artifact.JenkinsArtifactStream;
 import software.wings.beans.command.AzureWebAppCommandUnit;
 import software.wings.beans.command.Command;
 import software.wings.beans.command.CommandUnit;
@@ -1231,5 +1233,43 @@ public class AzureVMSSStateHelperTest extends CategoryTest {
     Optional<Artifact> artifact = azureVMSSStateHelper.getWebAppPackageArtifactForRollback(context, serviceId);
     assertThat(artifact.isPresent()).isTrue();
     assertThat(artifact.get()).isEqualTo(rollbackArtifact);
+  }
+
+  @Test
+  @Owner(developers = OwnerRule.VAIBHAV_KUMAR)
+  @Category(UnitTests.class)
+  public void testMetadataOnlyArtifactStreamTypes() {
+    String serviceId = "serviceUUID";
+    String appId = "appId";
+    List<String> artifactPaths = Collections.singletonList("artifactPath");
+    ExecutionContext context = mock(ExecutionContext.class);
+    Artifact artifact = new Artifact();
+    ServiceElement serviceElement = ServiceElement.builder().uuid(serviceId).build();
+    PhaseElement phaseElement = PhaseElement.builder().serviceElement(serviceElement).build();
+
+    when(context.getAppId()).thenReturn(appId);
+    when(context.getContextElement(any(), any())).thenReturn(phaseElement);
+    when(serviceResourceService.getWithDetails(any(), any())).thenReturn(Service.builder().build());
+
+    // Case 1: JENKINS
+    // Expected behaviour: metadataOnly flag must be set to true
+    JenkinsArtifactStream jenkinsArtifactStream =
+        JenkinsArtifactStream.builder().artifactPaths(artifactPaths).metadataOnly(true).build();
+    when(artifactStreamService.get(any())).thenReturn(jenkinsArtifactStream);
+
+    ArtifactConnectorMapper artifactConnectorMapper = azureVMSSStateHelper.getConnectorMapper(context, artifact);
+
+    assertThat(artifactConnectorMapper.artifactStreamAttributes().isMetadataOnly()).isTrue();
+
+    // Case 2: DOCKER
+    // Expected behaviour: metadataOnly flag must be set to false
+    DockerArtifactStream dockerArtifactStream = DockerArtifactStream.builder().metadataOnly(true).build();
+    Service service = Service.builder().artifactType(ArtifactType.DOCKER).build();
+    when(artifactStreamService.get(any())).thenReturn(dockerArtifactStream);
+    when(serviceResourceService.getWithDetails(any(), any())).thenReturn(service);
+
+    artifactConnectorMapper = azureVMSSStateHelper.getConnectorMapper(context, artifact);
+
+    assertThat(artifactConnectorMapper.artifactStreamAttributes().isMetadataOnly()).isFalse();
   }
 }


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>
