### PR TITLE
feat: [Pl-25475]: Support of secrets for UserGroup notifications

### DIFF
--- a/platform-service/modules/notification-service/BUILD.bazel
+++ b/platform-service/modules/notification-service/BUILD.bazel
@@ -16,7 +16,6 @@ java_library(
     ],
     deps = [
         "//:lombok",
-        "//870-orchestration:module",
         "//890-sm-core:module",
         "//910-delegate-service-driver:module",
         "//920-delegate-service-beans:module",

--- a/platform-service/modules/notification-service/BUILD.bazel
+++ b/platform-service/modules/notification-service/BUILD.bazel
@@ -16,6 +16,7 @@ java_library(
     ],
     deps = [
         "//:lombok",
+        "//870-orchestration:module",
         "//890-sm-core:module",
         "//910-delegate-service-driver:module",
         "//920-delegate-service-beans:module",

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/evaluator/SecretExpressionEvaluator.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/evaluator/SecretExpressionEvaluator.java
@@ -1,7 +1,7 @@
 package io.harness.notification.evaluator;
 
-import io.harness.engine.expressions.functors.SecretFunctor;
 import io.harness.expression.EngineExpressionEvaluator;
+import io.harness.notification.functor.SecretFunctor;
 
 public class SecretExpressionEvaluator extends EngineExpressionEvaluator {
   private final long expressionFunctorToken;

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/evaluator/SecretExpressionEvaluator.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/evaluator/SecretExpressionEvaluator.java
@@ -1,0 +1,19 @@
+package io.harness.notification.evaluator;
+
+import io.harness.engine.expressions.functors.SecretFunctor;
+import io.harness.expression.EngineExpressionEvaluator;
+
+public class SecretExpressionEvaluator extends EngineExpressionEvaluator {
+  private final long expressionFunctorToken;
+
+  public SecretExpressionEvaluator(long expressionFunctorToken) {
+    super(null);
+    this.expressionFunctorToken = expressionFunctorToken;
+  }
+
+  @Override
+  protected void initialize() {
+    super.initialize();
+    this.addToContext("secrets", new SecretFunctor(expressionFunctorToken));
+  }
+}

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/functor/SecretFunctor.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/functor/SecretFunctor.java
@@ -1,0 +1,18 @@
+package io.harness.notification.functor;
+
+import io.harness.expression.ExpressionFunctor;
+
+import lombok.Value;
+
+@Value
+public class SecretFunctor implements ExpressionFunctor {
+  long expressionFunctorToken;
+
+  public SecretFunctor(long expressionFunctorToken) {
+    this.expressionFunctorToken = expressionFunctorToken;
+  }
+
+  public Object getValue(String secretIdentifier) {
+    return "${ngSecretManager.obtain(\"" + secretIdentifier + "\", " + expressionFunctorToken + ")}";
+  }
+}

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/MSTeamsServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/MSTeamsServiceImpl.java
@@ -207,7 +207,8 @@ public class MSTeamsServiceImpl implements ChannelService {
     List<String> recipients = new ArrayList<>(msTeamDetails.getMsTeamKeysList());
     if (isNotEmpty(msTeamDetails.getUserGroupList())) {
       List<String> resolvedRecipients = notificationSettingsService.getNotificationRequestForUserGroups(
-          msTeamDetails.getUserGroupList(), NotificationChannelType.MSTEAMS, notificationRequest.getAccountId());
+          msTeamDetails.getUserGroupList(), NotificationChannelType.MSTEAMS, notificationRequest.getAccountId(),
+          notificationRequest.getMsTeam().getExpressionFunctorToken());
       recipients.addAll(resolvedRecipients);
     }
     return recipients.stream().distinct().collect(Collectors.toList());

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/MailServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/MailServiceImpl.java
@@ -219,7 +219,7 @@ public class MailServiceImpl implements ChannelService {
     List<String> recipients = new ArrayList<>(emailDetails.getEmailIdsList());
     if (isNotEmpty(emailDetails.getUserGroupList())) {
       List<String> resolvedRecipients = notificationSettingsService.getNotificationRequestForUserGroups(
-          emailDetails.getUserGroupList(), NotificationChannelType.EMAIL, notificationRequest.getAccountId());
+          emailDetails.getUserGroupList(), NotificationChannelType.EMAIL, notificationRequest.getAccountId(), 0L);
       recipients.addAll(resolvedRecipients);
     }
     return recipients.stream().distinct().collect(Collectors.toList());

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
@@ -156,6 +156,7 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
     } else {
       if (!notificationSetting.isEmpty()) {
         if (notificationSetting.get(0).startsWith(EXPR_START) && notificationSetting.get(0).endsWith(EXPR_END)) {
+          log.info("Resolving UserGroup expression: {}" , notificationSetting.get(0));
           if (!VALID_EXPRESSION_PATTERN.matcher(notificationSetting.get(0)).matches()) {
             throw new InvalidRequestException("Expression provided is not valid");
           }
@@ -165,6 +166,7 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
           if (resolvedExpressions == null) {
             throw new InvalidRequestException("Expression provided is not valid");
           }
+          log.info("Parsed Expression {}", resolvedExpressions);
           return (List<String>) resolvedExpressions;
         } else {
           return notificationSetting;

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
@@ -41,11 +41,10 @@ import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -57,6 +56,7 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
   private final UserClient userClient;
   private final NotificationSettingRepository notificationSettingRepository;
   private final SmtpConfigClient smtpConfigClient;
+  private static final Pattern VALID_EXPRESSION_PATTERN = Pattern.compile("</+secrets.getValue([a-zA-Z])>");
 
   private List<UserGroupDTO> getUserGroups(List<String> userGroupIds) {
     if (isEmpty(userGroupIds)) {
@@ -159,6 +159,7 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
           if (!notificationSetting.get(0).contains("secrets.getValue")) {
             throw new InvalidRequestException("Expression provided is not valid");
           }
+          log.info("Resolving UserGroup expression" +notificationSetting.get(0) );
           SecretExpressionEvaluator evaluator = new SecretExpressionEvaluator(expressionFunctorToken);
           try {
             Object object = evaluator.resolve(notificationSetting, true);

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
@@ -153,20 +153,18 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
   @VisibleForTesting
   List<String> resolveUserGroups(
       NotificationChannelType notificationChannelType, List<String> notificationSetting, long expressionFunctorToken) {
-    if (!notificationChannelType.equals(NotificationChannelType.EMAIL)) {
-      if (!notificationSetting.isEmpty()) {
-        if (notificationSetting.get(0).startsWith(EXPR_START) && notificationSetting.get(0).endsWith(EXPR_END)) {
-          if (!VALID_EXPRESSION_PATTERN.matcher(notificationSetting.get(0)).matches()) {
-            throw new InvalidRequestException(INVALID_EXPRESSION_EXCEPTION);
-          }
-          log.info("Resolving UserGroup secrets expression");
-          SecretExpressionEvaluator evaluator = new SecretExpressionEvaluator(expressionFunctorToken);
-          Object resolvedExpressions = evaluator.resolve(notificationSetting, true);
-          if (resolvedExpressions == null) {
-            throw new InvalidRequestException(INVALID_EXPRESSION_EXCEPTION);
-          }
-          return (List<String>) resolvedExpressions;
+    if (!notificationChannelType.equals(NotificationChannelType.EMAIL) && !notificationSetting.isEmpty()) {
+      if (notificationSetting.get(0).startsWith(EXPR_START) && notificationSetting.get(0).endsWith(EXPR_END)) {
+        if (!VALID_EXPRESSION_PATTERN.matcher(notificationSetting.get(0)).matches()) {
+          throw new InvalidRequestException(INVALID_EXPRESSION_EXCEPTION);
         }
+        log.info("Resolving UserGroup secrets expression");
+        SecretExpressionEvaluator evaluator = new SecretExpressionEvaluator(expressionFunctorToken);
+        Object resolvedExpressions = evaluator.resolve(notificationSetting, true);
+        if (resolvedExpressions == null) {
+          throw new InvalidRequestException(INVALID_EXPRESSION_EXCEPTION);
+        }
+        return (List<String>) resolvedExpressions;
       }
     }
     return notificationSetting;

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
@@ -157,17 +157,15 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
     } else {
       if (!notificationSetting.isEmpty()) {
         if (notificationSetting.get(0).startsWith(EXPR_START) && notificationSetting.get(0).endsWith(EXPR_END)) {
-          log.info("Resolving UserGroup expression: {}" , notificationSetting.get(0));
           if (!VALID_EXPRESSION_PATTERN.matcher(notificationSetting.get(0)).matches()) {
             throw new InvalidRequestException("Expression provided is not valid");
           }
-          log.info("Resolving UserGroup expression");
+          log.info("Resolving UserGroup secrets expression");
           SecretExpressionEvaluator evaluator = new SecretExpressionEvaluator(expressionFunctorToken);
           Object resolvedExpressions = evaluator.resolve(notificationSetting, true);
           if (resolvedExpressions == null) {
             throw new InvalidRequestException("Expression provided is not valid");
           }
-          log.info("Parsed Expression {}", resolvedExpressions);
           return (List<String>) resolvedExpressions;
         } else {
           return notificationSetting;

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
@@ -166,6 +166,7 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
             if (object == null) {
               throw new InvalidRequestException("Expression provided is not valid");
             }
+            log.info("Resolved UserGroups successfully: " + object);
             return (List<String>) object;
           } catch (Exception e) {
             throw new InvalidRequestException("Provided is not a valid expression", e);

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
@@ -166,7 +166,8 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
             if (object == null) {
               throw new InvalidRequestException("Expression provided is not valid");
             }
-            log.info("Resolved UserGroups successfully: " + object);
+            List<String> temp = (List<String>) object;
+            log.info("Resolved UserGroups successfully: " + temp.get(0));
             return (List<String>) object;
           } catch (Exception e) {
             throw new InvalidRequestException("Provided is not a valid expression", e);

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
@@ -56,7 +56,8 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
   private final UserClient userClient;
   private final NotificationSettingRepository notificationSettingRepository;
   private final SmtpConfigClient smtpConfigClient;
-  private static final Pattern VALID_EXPRESSION_PATTERN = Pattern.compile("\\<\\+secrets.getValue\\(\\'\\w*\\'\\)>");
+  private static final Pattern VALID_EXPRESSION_PATTERN =
+      Pattern.compile("\\<\\+secrets.getValue\\((\\\"|\\')\\w*(\\\"|\\')\\)>");
 
   private List<UserGroupDTO> getUserGroups(List<String> userGroupIds) {
     if (isEmpty(userGroupIds)) {

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
@@ -12,6 +12,8 @@ import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.remote.client.NGRestUtils.getResponse;
 
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.engine.expressions.functors.SecretFunctor;
+import io.harness.expression.SecretString;
 import io.harness.ng.core.dto.UserGroupDTO;
 import io.harness.ng.core.dto.UserGroupFilterDTO;
 import io.harness.ng.core.notification.NotificationSettingConfigDTO;
@@ -20,6 +22,7 @@ import io.harness.notification.NotificationChannelType;
 import io.harness.notification.NotificationRequest;
 import io.harness.notification.SmtpConfig;
 import io.harness.notification.entities.NotificationSetting;
+import io.harness.notification.evaluator.SecretExpressionEvaluator;
 import io.harness.notification.remote.SmtpConfigClient;
 import io.harness.notification.remote.SmtpConfigResponse;
 import io.harness.notification.repositories.NotificationSettingRepository;
@@ -39,6 +42,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -113,9 +117,10 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
 
   @Override
   public List<String> getNotificationRequestForUserGroups(List<NotificationRequest.UserGroup> notificationUserGroups,
-      NotificationChannelType notificationChannelType, String accountId) {
+      NotificationChannelType notificationChannelType, String accountId, long expressionFunctorToken) {
     List<UserGroupDTO> userGroups = getUserGroups(notificationUserGroups, accountId);
-    return getNotificationSettings(notificationChannelType, userGroups, accountId);
+    List<String> notificationSetting = getNotificationSettings(notificationChannelType, userGroups, accountId);
+    return resolveUserGroups(notificationSetting, expressionFunctorToken);
   }
 
   @Override
@@ -138,6 +143,16 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
       }
     }
     return Lists.newArrayList(notificationSettings);
+  }
+
+  private List<String> resolveUserGroups(List<String> notificationSetting, long expressionFunctorToken) {
+    if (notificationSetting.get(0)) {
+    }
+    SecretExpressionEvaluator evaluator = new SecretExpressionEvaluator(expressionFunctorToken);
+    Object object = evaluator.resolve(notificationSetting, true);
+    if (object == null) {
+    }
+    return Stream.of(object).map(Object::toString).collect(Collectors.toList());
   }
 
   @Override

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/PagerDutyServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/PagerDutyServiceImpl.java
@@ -210,7 +210,8 @@ public class PagerDutyServiceImpl implements ChannelService {
     List<String> recipients = new ArrayList<>(pagerDutyDetails.getPagerDutyIntegrationKeysList());
     if (isNotEmpty(pagerDutyDetails.getUserGroupList())) {
       List<String> resolvedRecipients = notificationSettingsService.getNotificationRequestForUserGroups(
-          pagerDutyDetails.getUserGroupList(), NotificationChannelType.PAGERDUTY, notificationRequest.getAccountId());
+          pagerDutyDetails.getUserGroupList(), NotificationChannelType.PAGERDUTY, notificationRequest.getAccountId(),
+          notificationRequest.getPagerDuty().getExpressionFunctorToken());
       recipients.addAll(resolvedRecipients);
     }
     return recipients.stream().distinct().collect(Collectors.toList());

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/SlackServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/SlackServiceImpl.java
@@ -144,14 +144,6 @@ public class SlackServiceImpl implements ChannelService {
                                                     .build();
       String taskId = delegateGrpcClientWrapper.submitAsyncTask(delegateTaskRequest, Duration.ZERO);
       log.info("Async delegate task created with taskID {}", taskId);
-      log.info("((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getSlackWebhookUrls().get(0) {}", ((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getSlackWebhookUrls().get(0));
-//      log.info("((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getMessage {}", ((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getMessage());
-//      log.info("((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getNotificationId {}", ((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getNotificationId());
-//      log.info("Async delegate task created with delegateTaskRequest ACCOUNT_IDENTIFIER {}", delegateTaskRequest.getTaskSetupAbstractions().get(ACCOUNT_IDENTIFIER));
-//      log.info("Async delegate task created with delegateTaskRequest PROJECT_IDENTIFIER {}", delegateTaskRequest.getTaskSetupAbstractions().get(PROJECT_IDENTIFIER));
-//      log.info("Async delegate task created with delegateTaskRequest ORG_IDENTIFIER {}", delegateTaskRequest.getTaskSetupAbstractions().get(ORG_IDENTIFIER));
-//      log.info("Async delegate task created with delegateTaskRequest expressionFunctorToken {}", delegateTaskRequest.getExpressionFunctorToken());
-//      log.info("Async delegate task created with delegateTaskRequest account id {}", delegateTaskRequest.getAccountId());
       processingResponse = NotificationProcessingResponse.allSent(slackWebhookUrls.size());
     } else {
       processingResponse = slackSender.send(slackWebhookUrls, message, notificationId);

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/SlackServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/SlackServiceImpl.java
@@ -144,6 +144,14 @@ public class SlackServiceImpl implements ChannelService {
                                                     .build();
       String taskId = delegateGrpcClientWrapper.submitAsyncTask(delegateTaskRequest, Duration.ZERO);
       log.info("Async delegate task created with taskID {}", taskId);
+      log.info("((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getSlackWebhookUrls().get(0) {}", ((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getSlackWebhookUrls().get(0));
+      log.info("((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getMessage {}", ((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getMessage());
+      log.info("((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getNotificationId {}", ((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getNotificationId());
+      log.info("Async delegate task created with delegateTaskRequest ACCOUNT_IDENTIFIER {}", delegateTaskRequest.getTaskSetupAbstractions().get(ACCOUNT_IDENTIFIER));
+      log.info("Async delegate task created with delegateTaskRequest PROJECT_IDENTIFIER {}", delegateTaskRequest.getTaskSetupAbstractions().get(PROJECT_IDENTIFIER));
+      log.info("Async delegate task created with delegateTaskRequest ORG_IDENTIFIER {}", delegateTaskRequest.getTaskSetupAbstractions().get(ORG_IDENTIFIER));
+      log.info("Async delegate task created with delegateTaskRequest expressionFunctorToken {}", delegateTaskRequest.getExpressionFunctorToken());
+      log.info("Async delegate task created with delegateTaskRequest account id {}", delegateTaskRequest.getAccountId());
       processingResponse = NotificationProcessingResponse.allSent(slackWebhookUrls.size());
     } else {
       processingResponse = slackSender.send(slackWebhookUrls, message, notificationId);

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/SlackServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/SlackServiceImpl.java
@@ -145,13 +145,13 @@ public class SlackServiceImpl implements ChannelService {
       String taskId = delegateGrpcClientWrapper.submitAsyncTask(delegateTaskRequest, Duration.ZERO);
       log.info("Async delegate task created with taskID {}", taskId);
       log.info("((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getSlackWebhookUrls().get(0) {}", ((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getSlackWebhookUrls().get(0));
-      log.info("((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getMessage {}", ((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getMessage());
-      log.info("((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getNotificationId {}", ((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getNotificationId());
-      log.info("Async delegate task created with delegateTaskRequest ACCOUNT_IDENTIFIER {}", delegateTaskRequest.getTaskSetupAbstractions().get(ACCOUNT_IDENTIFIER));
-      log.info("Async delegate task created with delegateTaskRequest PROJECT_IDENTIFIER {}", delegateTaskRequest.getTaskSetupAbstractions().get(PROJECT_IDENTIFIER));
-      log.info("Async delegate task created with delegateTaskRequest ORG_IDENTIFIER {}", delegateTaskRequest.getTaskSetupAbstractions().get(ORG_IDENTIFIER));
-      log.info("Async delegate task created with delegateTaskRequest expressionFunctorToken {}", delegateTaskRequest.getExpressionFunctorToken());
-      log.info("Async delegate task created with delegateTaskRequest account id {}", delegateTaskRequest.getAccountId());
+//      log.info("((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getMessage {}", ((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getMessage());
+//      log.info("((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getNotificationId {}", ((SlackTaskParams) delegateTaskRequest.getTaskParameters()).getNotificationId());
+//      log.info("Async delegate task created with delegateTaskRequest ACCOUNT_IDENTIFIER {}", delegateTaskRequest.getTaskSetupAbstractions().get(ACCOUNT_IDENTIFIER));
+//      log.info("Async delegate task created with delegateTaskRequest PROJECT_IDENTIFIER {}", delegateTaskRequest.getTaskSetupAbstractions().get(PROJECT_IDENTIFIER));
+//      log.info("Async delegate task created with delegateTaskRequest ORG_IDENTIFIER {}", delegateTaskRequest.getTaskSetupAbstractions().get(ORG_IDENTIFIER));
+//      log.info("Async delegate task created with delegateTaskRequest expressionFunctorToken {}", delegateTaskRequest.getExpressionFunctorToken());
+//      log.info("Async delegate task created with delegateTaskRequest account id {}", delegateTaskRequest.getAccountId());
       processingResponse = NotificationProcessingResponse.allSent(slackWebhookUrls.size());
     } else {
       processingResponse = slackSender.send(slackWebhookUrls, message, notificationId);
@@ -172,6 +172,6 @@ public class SlackServiceImpl implements ChannelService {
           notificationRequest.getSlack().getExpressionFunctorToken());
       recipients.addAll(resolvedRecipients);
     }
-    return recipients.stream().distinct().collect(Collectors.toList());
+    return recipients.stream().distinct().filter(str -> !str.isEmpty()).collect(Collectors.toList());
   }
 }

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/SlackServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/SlackServiceImpl.java
@@ -160,7 +160,8 @@ public class SlackServiceImpl implements ChannelService {
     List<String> recipients = new ArrayList<>(slackChannelDetails.getSlackWebHookUrlsList());
     if (isNotEmpty(slackChannelDetails.getUserGroupList())) {
       List<String> resolvedRecipients = notificationSettingsService.getNotificationRequestForUserGroups(
-          slackChannelDetails.getUserGroupList(), NotificationChannelType.SLACK, notificationRequest.getAccountId());
+          slackChannelDetails.getUserGroupList(), NotificationChannelType.SLACK, notificationRequest.getAccountId(),
+          notificationRequest.getSlack().getExpressionFunctorToken());
       recipients.addAll(resolvedRecipients);
     }
     return recipients.stream().distinct().collect(Collectors.toList());

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/api/NotificationSettingsService.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/api/NotificationSettingsService.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 @OwnedBy(PL)
 public interface NotificationSettingsService {
   List<String> getNotificationRequestForUserGroups(List<NotificationRequest.UserGroup> notificationUserGroups,
-      NotificationChannelType notificationChannelType, String accountId);
+      NotificationChannelType notificationChannelType, String accountId, long expressionFunctorToken);
   List<String> getNotificationSettingsForGroups(
       List<String> userGroups, NotificationChannelType notificationChannelType, String accountId);
   Optional<NotificationSetting> getNotificationSetting(String accountId);

--- a/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
+++ b/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
@@ -34,15 +34,17 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   @Mock private NotificationSettingRepository notificationSettingRepository;
   @Mock private SmtpConfigClient smtpConfigClient;
   private NotificationSettingsServiceImpl notificationSettingsService;
-  private String slackWebhookurl = "https://hooks.slack.com/services/TL81600E8/B027JT97D5X/";
-  private String slackSecret1 = "<+secrets.getValue('SlackWebhookUrlSecret1')>";
-  private String slackSecret2 = "<+secrets.getValue('SlackWebhookUrlSecret2')>";
-  private String slackSecret3 = "<+secrets.getValue(\"SlackWebhookUrlSecret3\")>";
-  private String pagerDutySecret = "<+secrets.getValue('PagerDutyWebhookUrlSecret')>";
+  private final static String SLACK_WEBHOOK_URL = "https://hooks.slack.com/services/TL81600E8/B027JT97D5X/";
+  private final static String SLACK_SECRET_1 = "<+secrets.getValue('SlackWebhookUrlSecret1')>";
+  private final static String SLACK_SECRET_2 = "<+secrets.getValue('SlackWebhookUrlSecret2')>";
+  private final static String SLACK_SECRET_3 = "<+secrets.getValue(\"SlackWebhookUrlSecret3\")>";
+  private final static String PAGERDUTY_SECRET = "<+secrets.getValue('PagerDutyWebhookUrlSecret')>";
+  private long expressionFunctorToken;
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
+    expressionFunctorToken = HashGenerator.generateIntegerHash();
     notificationSettingsService = new NotificationSettingsServiceImpl(
         userGroupClient, userClient, notificationSettingRepository, smtpConfigClient);
   }
@@ -52,9 +54,8 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   @Category(UnitTests.class)
   public void testGetNotificationRequestForSecretExpressionSlackUserGroups() {
     List<String> notificationSettings = new ArrayList<>();
-    notificationSettings.add(slackSecret1);
-    notificationSettings.add(slackSecret2);
-    long expressionFunctorToken = HashGenerator.generateIntegerHash();
+    notificationSettings.add(SLACK_SECRET_1);
+    notificationSettings.add(SLACK_SECRET_2);
     List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
         NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken);
     String expectedUserGroup1 =
@@ -71,7 +72,6 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   public void testGetNotificationRequestForInvalidExpression() {
     List<String> notificationSettings = new ArrayList<>();
     notificationSettings.add("<+adbc>");
-    long expressionFunctorToken = HashGenerator.generateIntegerHash();
     assertThatThrownBy(()
                            -> notificationSettingsService.resolveUserGroups(
                                NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken))
@@ -84,11 +84,10 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   @Category(UnitTests.class)
   public void testGetNotificationRequestForPlainTextSlackUserGroups() {
     List<String> notificationSettings = new ArrayList<>();
-    notificationSettings.add(slackWebhookurl);
-    long expressionFunctorToken = HashGenerator.generateIntegerHash();
+    notificationSettings.add(SLACK_WEBHOOK_URL);
     List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
         NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken);
-    assertEquals(slackWebhookurl, resolvedUserGroups.get(0));
+    assertEquals(SLACK_WEBHOOK_URL, resolvedUserGroups.get(0));
   }
 
   @Test
@@ -96,8 +95,7 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   @Category(UnitTests.class)
   public void testGetNotificationRequestForSecretExpressionPagerDutyUserGroups() {
     List<String> notificationSettings = new ArrayList<>();
-    notificationSettings.add(pagerDutySecret);
-    long expressionFunctorToken = HashGenerator.generateIntegerHash();
+    notificationSettings.add(PAGERDUTY_SECRET);
     List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
         NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken);
     String expectedUserGroup =
@@ -109,7 +107,6 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   @Owner(developers = ADITHYA)
   @Category(UnitTests.class)
   public void testGetNotificationRequestForEmptyUserGroups() {
-    long expressionFunctorToken = HashGenerator.generateIntegerHash();
     List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
         NotificationChannelType.SLACK, new ArrayList<>(), expressionFunctorToken);
     assertTrue(resolvedUserGroups.isEmpty());
@@ -120,8 +117,7 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   @Category(UnitTests.class)
   public void testRegex() {
     List<String> notificationSettings = new ArrayList<>();
-    notificationSettings.add(slackSecret3);
-    long expressionFunctorToken = HashGenerator.generateIntegerHash();
+    notificationSettings.add(SLACK_SECRET_3);
     List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
         NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken);
     String expectedUserGroup1 =

--- a/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
+++ b/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
@@ -34,11 +34,11 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   @Mock private NotificationSettingRepository notificationSettingRepository;
   @Mock private SmtpConfigClient smtpConfigClient;
   private NotificationSettingsServiceImpl notificationSettingsService;
-  private final static String SLACK_WEBHOOK_URL = "https://hooks.slack.com/services/TL81600E8/B027JT97D5X/";
-  private final static String SLACK_SECRET_1 = "<+secrets.getValue('SlackWebhookUrlSecret1')>";
-  private final static String SLACK_SECRET_2 = "<+secrets.getValue('SlackWebhookUrlSecret2')>";
-  private final static String SLACK_SECRET_3 = "<+secrets.getValue(\"SlackWebhookUrlSecret3\")>";
-  private final static String PAGERDUTY_SECRET = "<+secrets.getValue('PagerDutyWebhookUrlSecret')>";
+  private static final String SLACK_WEBHOOK_URL = "https://hooks.slack.com/services/TL81600E8/B027JT97D5X/";
+  private static final String SLACK_SECRET_1 = "<+secrets.getValue('SlackWebhookUrlSecret1')>";
+  private static final String SLACK_SECRET_2 = "<+secrets.getValue('SlackWebhookUrlSecret2')>";
+  private static final String SLACK_SECRET_3 = "<+secrets.getValue(\"SlackWebhookUrlSecret3\")>";
+  private static final String PAGERDUTY_SECRET = "<+secrets.getValue('PagerDutyWebhookUrlSecret')>";
   private long expressionFunctorToken;
 
   @Before

--- a/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
+++ b/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
@@ -37,6 +37,7 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   private String slackWebhookurl = "https://hooks.slack.com/services/TL81600E8/B027JT97D5X/";
   private String slackSecret1 = "<+secrets.getValue('SlackWebhookUrlSecret1')>";
   private String slackSecret2 = "<+secrets.getValue('SlackWebhookUrlSecret2')>";
+  private String slackSecret3 = "<+secrets.getValue(\"SlackWebhookUrlSecret3\")>";
   private String pagerDutySecret = "<+secrets.getValue('PagerDutyWebhookUrlSecret')>";
 
   @Before
@@ -112,5 +113,19 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
     List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
         NotificationChannelType.SLACK, new ArrayList<>(), expressionFunctorToken);
     assertTrue(resolvedUserGroups.isEmpty());
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testRegex() {
+    List<String> notificationSettings = new ArrayList<>();
+    notificationSettings.add(slackSecret3);
+    long expressionFunctorToken = HashGenerator.generateIntegerHash();
+    List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
+        NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken);
+    String expectedUserGroup1 =
+        String.format("${ngSecretManager.obtain(\"SlackWebhookUrlSecret3\", %d)}", expressionFunctorToken);
+    assertEquals(expectedUserGroup1, resolvedUserGroups.get(0));
   }
 }

--- a/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
+++ b/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
@@ -3,17 +3,23 @@ package io.harness.notification.service;
 import static io.harness.annotations.dev.HarnessTeam.PL;
 import static io.harness.rule.OwnerRule.ADITHYA;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import io.harness.CategoryTest;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.category.element.UnitTests;
+import io.harness.data.algorithm.HashGenerator;
+import io.harness.exception.InvalidRequestException;
 import io.harness.notification.NotificationChannelType;
-import io.harness.notification.NotificationRequest;
 import io.harness.notification.remote.SmtpConfigClient;
 import io.harness.notification.repositories.NotificationSettingRepository;
 import io.harness.rule.Owner;
 import io.harness.user.remote.UserClient;
 import io.harness.usergroups.UserGroupClient;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,6 +34,10 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   @Mock private NotificationSettingRepository notificationSettingRepository;
   @Mock private SmtpConfigClient smtpConfigClient;
   private NotificationSettingsServiceImpl notificationSettingsService;
+  private String slackWebhookurl = "https://hooks.slack.com/services/TL81600E8/B027JT97D5X/";
+  private String slackSecret1 = "<+secrets.getValue('SlackWebhookUrlSecret1')>";
+  private String slackSecret2 = "<+secrets.getValue('SlackWebhookUrlSecret2')>";
+  private String pagerDutySecret = "<+secrets.getValue('PagerDutyWebhookUrlSecret')>";
 
   @Before
   public void setUp() {
@@ -39,10 +49,68 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   @Test
   @Owner(developers = ADITHYA)
   @Category(UnitTests.class)
-  public void testGetNotificationRequestForUserGroups() {
-    //        List<String> getNotificationRequestForUserGroups(List< NotificationRequest.UserGroup>
-    //        notificationUserGroups,
-    //                NotificationChannelType notificationChannelType, String accountId, long expressionFunctorToken)
-    NotificationRequest.UserGroup userGroup1 = NotificationRequest.UserGroup.newBuilder().build();
+  public void testGetNotificationRequestForSecretExpressionSlackUserGroups() {
+    List<String> notificationSettings = new ArrayList<>();
+    notificationSettings.add(slackSecret1);
+    notificationSettings.add(slackSecret2);
+    long expressionFunctorToken = HashGenerator.generateIntegerHash();
+    List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
+        NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken);
+    String expectedUserGroup1 =
+        String.format("${ngSecretManager.obtain(\"SlackWebhookUrlSecret1\", %d)}", expressionFunctorToken);
+    String expectedUserGroup2 =
+        String.format("${ngSecretManager.obtain(\"SlackWebhookUrlSecret2\", %d)}", expressionFunctorToken);
+    assertEquals(expectedUserGroup1, resolvedUserGroups.get(0));
+    assertEquals(expectedUserGroup2, resolvedUserGroups.get(1));
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testGetNotificationRequestForInvalidExpression() {
+    List<String> notificationSettings = new ArrayList<>();
+    notificationSettings.add("<+adbc>");
+    long expressionFunctorToken = HashGenerator.generateIntegerHash();
+    assertThatThrownBy(()
+                           -> notificationSettingsService.resolveUserGroups(
+                               NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken))
+        .isInstanceOf(InvalidRequestException.class)
+        .hasMessage("Expression provided is not valid");
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testGetNotificationRequestForPlainTextSlackUserGroups() {
+    List<String> notificationSettings = new ArrayList<>();
+    notificationSettings.add(slackWebhookurl);
+    long expressionFunctorToken = HashGenerator.generateIntegerHash();
+    List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
+        NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken);
+    assertEquals(slackWebhookurl, resolvedUserGroups.get(0));
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testGetNotificationRequestForSecretExpressionPagerDutyUserGroups() {
+    List<String> notificationSettings = new ArrayList<>();
+    notificationSettings.add(pagerDutySecret);
+    long expressionFunctorToken = HashGenerator.generateIntegerHash();
+    List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
+        NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken);
+    String expectedUserGroup =
+        String.format("${ngSecretManager.obtain(\"PagerDutyWebhookUrlSecret\", %d)}", expressionFunctorToken);
+    assertEquals(expectedUserGroup, resolvedUserGroups.get(0));
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testGetNotificationRequestForEmptyUserGroups() {
+    long expressionFunctorToken = HashGenerator.generateIntegerHash();
+    List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
+        NotificationChannelType.SLACK, new ArrayList<>(), expressionFunctorToken);
+    assertTrue(resolvedUserGroups.isEmpty());
   }
 }

--- a/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
+++ b/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
@@ -1,0 +1,48 @@
+package io.harness.notification.service;
+
+import static io.harness.annotations.dev.HarnessTeam.PL;
+import static io.harness.rule.OwnerRule.ADITHYA;
+
+import io.harness.CategoryTest;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.notification.NotificationChannelType;
+import io.harness.notification.NotificationRequest;
+import io.harness.notification.remote.SmtpConfigClient;
+import io.harness.notification.repositories.NotificationSettingRepository;
+import io.harness.rule.Owner;
+import io.harness.user.remote.UserClient;
+import io.harness.usergroups.UserGroupClient;
+
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@OwnedBy(PL)
+public class NotificationSettingsServiceImplTest extends CategoryTest {
+  @Mock private UserGroupClient userGroupClient;
+  @Mock private UserClient userClient;
+  @Mock private NotificationSettingRepository notificationSettingRepository;
+  @Mock private SmtpConfigClient smtpConfigClient;
+  private NotificationSettingsServiceImpl notificationSettingsService;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    notificationSettingsService = new NotificationSettingsServiceImpl(
+        userGroupClient, userClient, notificationSettingRepository, smtpConfigClient);
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testGetNotificationRequestForUserGroups() {
+    //        List<String> getNotificationRequestForUserGroups(List< NotificationRequest.UserGroup>
+    //        notificationUserGroups,
+    //                NotificationChannelType notificationChannelType, String accountId, long expressionFunctorToken)
+    NotificationRequest.UserGroup userGroup1 = NotificationRequest.UserGroup.newBuilder().build();
+  }
+}


### PR DESCRIPTION
## Describe your changes
Backend code changes to support secrets for userGroups

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [x] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/34314)
<!-- Reviewable:end -->
