### PR TITLE
fix: [CDS-38447]:  add access check on template and pipeline refresh apis

### DIFF
--- a/800-pipeline-service/src/main/java/io/harness/pms/template/PipelineRefreshResource.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/template/PipelineRefreshResource.java
@@ -13,11 +13,15 @@ import io.harness.NGCommonEntityConstants;
 import io.harness.accesscontrol.AccountIdentifier;
 import io.harness.accesscontrol.OrgIdentifier;
 import io.harness.accesscontrol.ProjectIdentifier;
+import io.harness.accesscontrol.acl.api.Resource;
+import io.harness.accesscontrol.acl.api.ResourceScope;
+import io.harness.accesscontrol.clients.AccessControlClient;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.gitsync.interceptor.GitEntityFindInfoDTO;
 import io.harness.ng.core.dto.ErrorDTO;
 import io.harness.ng.core.dto.FailureDTO;
 import io.harness.ng.core.dto.ResponseDTO;
+import io.harness.pms.rbac.PipelineRbacPermissions;
 import io.harness.pms.template.service.PipelineRefreshService;
 import io.harness.security.annotations.NextGenManagerAuth;
 import io.harness.template.beans.refresh.ValidateTemplateInputsResponseDTO;
@@ -79,6 +83,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PipelineRefreshResource {
   private final PipelineRefreshService pipelineRefreshService;
+  private final AccessControlClient accessControlClient;
 
   @POST
   @ApiOperation(
@@ -93,6 +98,8 @@ public class PipelineRefreshResource {
           NGCommonEntityConstants.PROJECT_KEY) @ProjectIdentifier String projectId,
       @QueryParam(NGCommonEntityConstants.IDENTIFIER_KEY) String pipelineIdentifier,
       @BeanParam GitEntityFindInfoDTO gitEntityBasicInfo) {
+    accessControlClient.checkForAccessOrThrow(ResourceScope.of(accountId, orgId, projectId),
+        Resource.of("PIPELINE", pipelineIdentifier), PipelineRbacPermissions.PIPELINE_CREATE_AND_EDIT);
     return ResponseDTO.newResponse(
         pipelineRefreshService.refreshTemplateInputsInPipeline(accountId, orgId, projectId, pipelineIdentifier));
   }
@@ -143,6 +150,8 @@ public class PipelineRefreshResource {
           NGCommonEntityConstants.PROJECT_KEY) @ProjectIdentifier String projectId,
       @QueryParam(NGCommonEntityConstants.IDENTIFIER_KEY) String pipelineIdentifier,
       @BeanParam GitEntityFindInfoDTO gitEntityBasicInfo) {
+    accessControlClient.checkForAccessOrThrow(ResourceScope.of(accountId, orgId, projectId),
+        Resource.of("PIPELINE", pipelineIdentifier), PipelineRbacPermissions.PIPELINE_EXECUTE);
     return ResponseDTO.newResponse(pipelineRefreshService.recursivelyRefreshAllTemplateInputsInPipeline(
         accountId, orgId, projectId, pipelineIdentifier));
   }

--- a/840-template-service/src/main/java/io/harness/template/services/TemplateRefreshServiceImpl.java
+++ b/840-template-service/src/main/java/io/harness/template/services/TemplateRefreshServiceImpl.java
@@ -8,11 +8,16 @@
 package io.harness.template.services;
 
 import static io.harness.annotations.dev.HarnessTeam.CDC;
+import static io.harness.template.resources.NGTemplateResource.TEMPLATE;
 
+import io.harness.accesscontrol.acl.api.Resource;
+import io.harness.accesscontrol.acl.api.ResourceScope;
+import io.harness.accesscontrol.clients.AccessControlClient;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.data.structure.EmptyPredicate;
 import io.harness.exception.InvalidRequestException;
 import io.harness.git.model.ChangeType;
+import io.harness.template.beans.PermissionTypes;
 import io.harness.template.beans.refresh.ErrorNodeSummary;
 import io.harness.template.beans.refresh.TemplateInfo;
 import io.harness.template.beans.refresh.ValidateTemplateInputsResponseDTO;
@@ -41,6 +46,8 @@ public class TemplateRefreshServiceImpl implements TemplateRefreshService {
   private TemplateInputsRefreshHelper templateInputsRefreshHelper;
   private NGTemplateService templateService;
   private TemplateInputsValidator templateInputsValidator;
+
+  private AccessControlClient accessControlClient;
 
   @Override
   public void refreshAndUpdateTemplate(
@@ -147,6 +154,8 @@ public class TemplateRefreshServiceImpl implements TemplateRefreshService {
 
       TemplateInfo templateInfo = top.getTemplateInfo();
       if (!visitedTemplateSet.contains(templateInfo)) {
+        accessControlClient.checkForAccessOrThrow(ResourceScope.of(accountId, orgId, projectId),
+            Resource.of(TEMPLATE, templateInfo.getTemplateIdentifier()), PermissionTypes.TEMPLATE_EDIT_PERMISSION);
         refreshAndUpdateTemplate(
             accountId, orgId, projectId, templateInfo.getTemplateIdentifier(), templateInfo.getVersionLabel());
         visitedTemplateSet.add(templateInfo);


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>
