### PR TITLE
[fix]: [PL-25546]: Added AccessControl check for SMTP

### DIFF
--- a/120-ng-manager/src/main/java/io/harness/ng/core/smtp/resources/SmtpNgResource.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/core/smtp/resources/SmtpNgResource.java
@@ -18,6 +18,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import io.harness.NGCommonEntityConstants;
 import io.harness.accesscontrol.AccountIdentifier;
 import io.harness.accesscontrol.acl.api.Resource;
+import io.harness.accesscontrol.acl.api.ResourceScope;
 import io.harness.accesscontrol.clients.AccessControlClient;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.connector.accesscontrol.ResourceTypes;
@@ -83,9 +84,10 @@ import lombok.extern.slf4j.Slf4j;
     })
 @OwnedBy(PL)
 public class SmtpNgResource {
-  @Inject private SmtpNgService smtpNgService;
+  private final SmtpNgService smtpNgService;
   private final AccessControlClient accessControlClient;
 
+  @Inject
   public SmtpNgResource(SmtpNgService smtpNgService, AccessControlClient accessControlClient) {
     this.smtpNgService = smtpNgService;
     this.accessControlClient = accessControlClient;
@@ -105,7 +107,8 @@ public class SmtpNgResource {
   save(@Valid @NotNull NgSmtpDTO variable,
       @Parameter(description = ACCOUNT_PARAM_MESSAGE, required = true) @NotNull @AccountIdentifier @QueryParam(
           NGCommonEntityConstants.ACCOUNT_KEY) String accountIdentifier) throws IOException {
-    accessControlClient.checkForAccessOrThrow(null, Resource.of(ResourceTypes.SMTP, null), EDIT_SMTP_PERMISSION);
+    accessControlClient.checkForAccessOrThrow(
+        ResourceScope.of(accountIdentifier, null, null), Resource.of(ResourceTypes.SMTP, null), EDIT_SMTP_PERMISSION);
     variable.setAccountId(accountIdentifier);
     NgSmtpDTO response = smtpNgService.saveSmtpSettings(variable);
     return ResponseDTO.newResponse(response);
@@ -144,7 +147,8 @@ public class SmtpNgResource {
   update(@Valid @NotNull NgSmtpDTO variable,
       @Parameter(description = ACCOUNT_PARAM_MESSAGE, required = true) @NotNull @AccountIdentifier @QueryParam(
           NGCommonEntityConstants.ACCOUNT_KEY) String accountIdentifier) throws IOException {
-    accessControlClient.checkForAccessOrThrow(null, Resource.of(ResourceTypes.SMTP, null), EDIT_SMTP_PERMISSION);
+    accessControlClient.checkForAccessOrThrow(
+        ResourceScope.of(accountIdentifier, null, null), Resource.of(ResourceTypes.SMTP, null), EDIT_SMTP_PERMISSION);
     variable.setAccountId(accountIdentifier);
     NgSmtpDTO response = smtpNgService.updateSmtpSettings(variable);
     return ResponseDTO.newResponse(response);
@@ -188,7 +192,8 @@ public class SmtpNgResource {
   delete(@Parameter(description = "Config identifier") @PathParam("identifier") String identifier,
       @Parameter(description = ACCOUNT_PARAM_MESSAGE, required = true) @NotNull @AccountIdentifier @QueryParam(
           NGCommonEntityConstants.ACCOUNT_KEY) String accountIdentifier) throws IOException {
-    accessControlClient.checkForAccessOrThrow(null, Resource.of(ResourceTypes.SMTP, null), DELETE_SMTP_PERMISSION);
+    accessControlClient.checkForAccessOrThrow(
+        ResourceScope.of(accountIdentifier, null, null), Resource.of(ResourceTypes.SMTP, null), DELETE_SMTP_PERMISSION);
     Boolean response = smtpNgService.deleteSmtpSettings(identifier);
     return ResponseDTO.newResponse(response);
   }
@@ -206,7 +211,8 @@ public class SmtpNgResource {
   @ExceptionMetered
   public ResponseDTO<NgSmtpDTO>
   get(@Parameter(description = ACCOUNT_PARAM_MESSAGE) @QueryParam("accountId") String accountId) throws IOException {
-    accessControlClient.checkForAccessOrThrow(null, Resource.of(ResourceTypes.SMTP, null), VIEW_SMTP_PERMISSION);
+    accessControlClient.checkForAccessOrThrow(
+        ResourceScope.of(accountId, null, null), Resource.of(ResourceTypes.SMTP, null), VIEW_SMTP_PERMISSION);
     NgSmtpDTO response = smtpNgService.getSmtpSettings(accountId);
     return ResponseDTO.newResponse(response);
   }

--- a/120-ng-manager/src/main/java/io/harness/ng/core/smtp/resources/SmtpNgResource.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/core/smtp/resources/SmtpNgResource.java
@@ -9,12 +9,18 @@ package io.harness.ng.core.smtp.resources;
 
 import static io.harness.NGCommonEntityConstants.ACCOUNT_PARAM_MESSAGE;
 import static io.harness.annotations.dev.HarnessTeam.PL;
+import static io.harness.connector.accesscontrol.SMTPAccessControlPermissions.DELETE_SMTP_PERMISSION;
+import static io.harness.connector.accesscontrol.SMTPAccessControlPermissions.EDIT_SMTP_PERMISSION;
+import static io.harness.connector.accesscontrol.SMTPAccessControlPermissions.VIEW_SMTP_PERMISSION;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 import io.harness.NGCommonEntityConstants;
 import io.harness.accesscontrol.AccountIdentifier;
+import io.harness.accesscontrol.acl.api.Resource;
+import io.harness.accesscontrol.clients.AccessControlClient;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.connector.accesscontrol.ResourceTypes;
 import io.harness.ng.core.dto.ErrorDTO;
 import io.harness.ng.core.dto.FailureDTO;
 import io.harness.ng.core.dto.NgSmtpDTO;
@@ -78,6 +84,12 @@ import lombok.extern.slf4j.Slf4j;
 @OwnedBy(PL)
 public class SmtpNgResource {
   @Inject private SmtpNgService smtpNgService;
+  private final AccessControlClient accessControlClient;
+
+  public SmtpNgResource(SmtpNgService smtpNgService, AccessControlClient accessControlClient) {
+    this.smtpNgService = smtpNgService;
+    this.accessControlClient = accessControlClient;
+  }
 
   @POST
   @ApiOperation(value = "Create SMTP config", nickname = "createSmtpConfig")
@@ -93,6 +105,7 @@ public class SmtpNgResource {
   save(@Valid @NotNull NgSmtpDTO variable,
       @Parameter(description = ACCOUNT_PARAM_MESSAGE, required = true) @NotNull @AccountIdentifier @QueryParam(
           NGCommonEntityConstants.ACCOUNT_KEY) String accountIdentifier) throws IOException {
+    accessControlClient.checkForAccessOrThrow(null, Resource.of(ResourceTypes.SMTP, null), EDIT_SMTP_PERMISSION);
     variable.setAccountId(accountIdentifier);
     NgSmtpDTO response = smtpNgService.saveSmtpSettings(variable);
     return ResponseDTO.newResponse(response);
@@ -131,6 +144,7 @@ public class SmtpNgResource {
   update(@Valid @NotNull NgSmtpDTO variable,
       @Parameter(description = ACCOUNT_PARAM_MESSAGE, required = true) @NotNull @AccountIdentifier @QueryParam(
           NGCommonEntityConstants.ACCOUNT_KEY) String accountIdentifier) throws IOException {
+    accessControlClient.checkForAccessOrThrow(null, Resource.of(ResourceTypes.SMTP, null), EDIT_SMTP_PERMISSION);
     variable.setAccountId(accountIdentifier);
     NgSmtpDTO response = smtpNgService.updateSmtpSettings(variable);
     return ResponseDTO.newResponse(response);
@@ -174,6 +188,7 @@ public class SmtpNgResource {
   delete(@Parameter(description = "Config identifier") @PathParam("identifier") String identifier,
       @Parameter(description = ACCOUNT_PARAM_MESSAGE, required = true) @NotNull @AccountIdentifier @QueryParam(
           NGCommonEntityConstants.ACCOUNT_KEY) String accountIdentifier) throws IOException {
+    accessControlClient.checkForAccessOrThrow(null, Resource.of(ResourceTypes.SMTP, null), DELETE_SMTP_PERMISSION);
     Boolean response = smtpNgService.deleteSmtpSettings(identifier);
     return ResponseDTO.newResponse(response);
   }
@@ -191,6 +206,7 @@ public class SmtpNgResource {
   @ExceptionMetered
   public ResponseDTO<NgSmtpDTO>
   get(@Parameter(description = ACCOUNT_PARAM_MESSAGE) @QueryParam("accountId") String accountId) throws IOException {
+    accessControlClient.checkForAccessOrThrow(null, Resource.of(ResourceTypes.SMTP, null), VIEW_SMTP_PERMISSION);
     NgSmtpDTO response = smtpNgService.getSmtpSettings(accountId);
     return ResponseDTO.newResponse(response);
   }

--- a/440-connector-nextgen/src/main/java/io/harness/connector/accesscontrol/SMTPAccessControlPermissions.java
+++ b/440-connector-nextgen/src/main/java/io/harness/connector/accesscontrol/SMTPAccessControlPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Harness Inc. All rights reserved.
+ * Copyright 2022 Harness Inc. All rights reserved.
  * Use of this source code is governed by the PolyForm Shield 1.0.0 license
  * that can be found in the licenses directory at the root of this repository, also available at
  * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
@@ -7,18 +7,16 @@
 
 package io.harness.connector.accesscontrol;
 
-import static io.harness.annotations.dev.HarnessTeam.DX;
+import static io.harness.annotations.dev.HarnessTeam.PL;
 
 import io.harness.annotations.dev.OwnedBy;
 
 import lombok.experimental.UtilityClass;
 
-@OwnedBy(DX)
+@OwnedBy(PL)
 @UtilityClass
-public class ResourceTypes {
-  public static final String CONNECTOR = "CONNECTOR";
-  public static final String SMTP = "SMTP";
-  public static final String ACCOUNT = "ACCOUNT";
-  public static final String ORGANIZATION = "ORGANIZATION";
-  public static final String PROJECT = "PROJECT";
+public class SMTPAccessControlPermissions {
+  public static final String VIEW_SMTP_PERMISSION = "core_smtp_view";
+  public static final String EDIT_SMTP_PERMISSION = "core_smtp_edit";
+  public static final String DELETE_SMTP_PERMISSION = "core_smtp_delete";
 }


### PR DESCRIPTION
## Describe your changes
[fix]: [PL-25546]: Added AccessControl check for SMTP

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>
