### PR TITLE
fix: [PL-23938]: return 400 in case of upsert entity failure

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/yaml/service/YamlServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/yaml/service/YamlServiceImpl.java
@@ -1097,8 +1097,8 @@ public class YamlServiceImpl<Y extends BaseYaml, B extends Base> implements Yaml
                       return prepareSuccessfulYAMLOperationResponse(processedChangeList, changeList);
                     } catch (YamlProcessingException ex) {
                       log.warn(format("Unable to process uploaded zip file for account %s, error: %s", accountId, ex));
-                      return prepareFailedYAMLOperationResponse(ex.getMessage(), ex.getFailedYamlFileChangeMap(),
-                          ex.getChangeContextList(), ex.getChangeList());
+                      return prepareFailedYAMLOperationResponse(ExceptionUtils.getMessage(ex),
+                          ex.getFailedYamlFileChangeMap(), ex.getChangeContextList(), ex.getChangeList());
                     }
                   });
           return future.get(30, TimeUnit.SECONDS);
@@ -1192,16 +1192,8 @@ public class YamlServiceImpl<Y extends BaseYaml, B extends Base> implements Yaml
       }
     } catch (YamlProcessingException ex) {
       log.warn(format("Unable to process yaml file for account %s, error: %s", accountId, ex));
-      if (ex != null && !isEmpty(ex.getFailedYamlFileChangeMap())) {
-        final Map.Entry<String, ChangeWithErrorMsg> entry =
-            ex.getFailedYamlFileChangeMap().entrySet().iterator().next();
-        final ChangeWithErrorMsg changeWithErrorMsg = entry.getValue();
-        return FileOperationStatus.builder()
-            .status(FileOperationStatus.Status.FAILED)
-            .errorMssg(changeWithErrorMsg.getErrorMsg())
-            .yamlFilePath(changeWithErrorMsg.getChange().getFilePath())
-            .build();
-      }
+      throw new InvalidRequestException(String.format("Failed in processing file: [%s] with error: [%s]", yamlFilePath,
+          ex.getFailedYamlFileChangeMap().get(yamlFilePath).getErrorMsg()));
     }
     return null;
   }


### PR DESCRIPTION
## Describe your changes
Made changes to upsert-entity api

<img width="929" alt="Screenshot 2022-06-22 at 1 31 13 PM" src="https://user-images.githubusercontent.com/57988751/174976514-6667014b-fdd6-4156-9ab1-6505264753b9.png">


## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/34561)
<!-- Reviewable:end -->
