### PR TITLE
fix: [PIE-4234]: Delete triggers on Hard Delete Project

### DIFF
--- a/800-pipeline-service/src/main/java/io/harness/repositories/pipeline/PMSPipelineRepositoryCustomImpl.java
+++ b/800-pipeline-service/src/main/java/io/harness/repositories/pipeline/PMSPipelineRepositoryCustomImpl.java
@@ -323,7 +323,10 @@ public class PMSPipelineRepositoryCustomImpl implements PMSPipelineRepositoryCus
     Criteria criteria = PMSPipelineFilterHelper.getCriteriaForAllPipelinesInProject(accountId, orgId, projectId);
     Query query = new Query(criteria);
     try {
-      mongoTemplate.findAllAndRemove(query, PipelineEntity.class);
+      List<PipelineEntity> entities = mongoTemplate.findAllAndRemove(query, PipelineEntity.class);
+      entities.stream().forEach((deletedPipelineEntity) -> {
+        outboxService.save(new PipelineDeleteEvent(accountId, orgId, projectId, deletedPipelineEntity));
+      });
       return true;
     } catch (Exception e) {
       String errorMessage = PipelineCRUDErrorResponse.errorMessageForPipelinesNotDeleted(

--- a/800-pipeline-service/src/test/java/io/harness/repositories/pipeline/PMSPipelineRepositoryCustomImplTest.java
+++ b/800-pipeline-service/src/test/java/io/harness/repositories/pipeline/PMSPipelineRepositoryCustomImplTest.java
@@ -9,6 +9,7 @@ package io.harness.repositories.pipeline;
 
 import static io.harness.annotations.dev.HarnessTeam.PIPELINE;
 import static io.harness.rule.OwnerRule.NAMAN;
+import static io.harness.rule.OwnerRule.SRIDHAR;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -36,6 +37,8 @@ import io.harness.pms.pipeline.service.PipelineMetadataService;
 import io.harness.rule.Owner;
 import io.harness.springdata.TransactionHelper;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import lombok.Data;
@@ -389,6 +392,27 @@ public class PMSPipelineRepositoryCustomImplTest extends CategoryTest {
     doReturn(pipelineEntity).when(mongoTemplate).findAndRemove(any(), any());
     pipelineRepository.delete(accountIdentifier, orgIdentifier, projectIdentifier, pipelineId);
     verify(mongoTemplate, times(1)).findAndRemove(any(), any());
+    verify(outboxService, times(1)).save(any());
+  }
+
+  @Test
+  @Owner(developers = SRIDHAR)
+  @Category(UnitTests.class)
+  public void testDeleteAllPipelineInProject() {
+    Update update = new Update();
+    update.set(PipelineEntityKeys.deleted, true);
+    PipelineEntity pipelineEntity = PipelineEntity.builder()
+                                        .accountId(accountIdentifier)
+                                        .orgIdentifier(orgIdentifier)
+                                        .projectIdentifier(projectIdentifier)
+                                        .identifier(pipelineId)
+                                        .yaml(pipelineYaml)
+                                        .deleted(true)
+                                        .build();
+    List<PipelineEntity> entityList = Arrays.asList(pipelineEntity);
+    doReturn(entityList).when(mongoTemplate).findAllAndRemove(any(), (Class<PipelineEntity>) any());
+    pipelineRepository.deleteAllPipelinesInAProject(accountIdentifier, orgIdentifier, projectIdentifier);
+    verify(mongoTemplate, times(1)).findAllAndRemove(any(), (Class<PipelineEntity>) any());
     verify(outboxService, times(1)).save(any());
   }
 


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions