### PR TITLE
bug: [CI-4646]: Blocking /etc to be used as shared path

### DIFF
--- a/320-ci-execution/src/main/java/io/harness/ci/integrationstage/K8InitializeStepInfoBuilder.java
+++ b/320-ci-execution/src/main/java/io/harness/ci/integrationstage/K8InitializeStepInfoBuilder.java
@@ -18,6 +18,7 @@ import static io.harness.common.CIExecutionConstants.ADDON_VOLUME;
 import static io.harness.common.CIExecutionConstants.ADDON_VOL_MOUNT_PATH;
 import static io.harness.common.CIExecutionConstants.DEFAULT_CONTAINER_CPU_POV;
 import static io.harness.common.CIExecutionConstants.DEFAULT_CONTAINER_MEM_POV;
+import static io.harness.common.CIExecutionConstants.ETC_DIR;
 import static io.harness.common.CIExecutionConstants.PORT_STARTING_RANGE;
 import static io.harness.common.CIExecutionConstants.PVC_DEFAULT_STORAGE_CLASS;
 import static io.harness.common.CIExecutionConstants.SHARED_VOLUME_PREFIX;
@@ -260,8 +261,8 @@ public class K8InitializeStepInfoBuilder implements InitializeStepInfoBuilder {
         }
 
         String volumeName = format("%s%d", SHARED_VOLUME_PREFIX, index);
-        if (path.equals(STEP_MOUNT_PATH) || path.equals(ADDON_VOL_MOUNT_PATH)) {
-          throw new InvalidRequestException(format("Shared path: %s is a reserved keyword ", path));
+        if (path.equals(STEP_MOUNT_PATH) || path.equals(ADDON_VOL_MOUNT_PATH) || path.equals(ETC_DIR)) {
+          throw new InvalidRequestException(format("Shared path: %s is a reserved keyword", path));
         }
         volumeToMountPath.put(volumeName, path);
         index++;

--- a/320-ci-execution/src/main/java/io/harness/common/CIExecutionConstants.java
+++ b/320-ci-execution/src/main/java/io/harness/common/CIExecutionConstants.java
@@ -34,6 +34,7 @@ public class CIExecutionConstants {
   public static final String STEP_MOUNT_PATH = "/harness";
   public static final String OSX_STEP_MOUNT_PATH = "/tmp/harness";
   public static final String STEP_WORK_DIR = STEP_MOUNT_PATH;
+  public static final String ETC_DIR = "/etc";
 
   public static final int POD_MAX_WAIT_UNTIL_READY_SECS = 8 * 60;
 


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions