### PR TITLE
feat: [CDS-39279]: Can have extra fields in runtime yaml which are no…

### DIFF
--- a/125-cd-nextgen/src/main/java/io/harness/cdng/creator/plan/stage/DeploymentStageConfig.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/creator/plan/stage/DeploymentStageConfig.java
@@ -108,6 +108,9 @@ public class DeploymentStageConfig implements StageInfoConfig, Visitable {
     if (environment != null) {
       children.add(VisitableChild.builder().value(environment).fieldName("environment").build());
     }
+    if (environmentGroup != null) {
+      children.add(VisitableChild.builder().value(environmentGroup).fieldName("environmentGroup").build());
+    }
     return VisitableChildren.builder().visitableChildList(children).build();
   }
 }

--- a/800-pipeline-service/src/main/java/io/harness/pms/ngpipeline/inputset/helpers/InputSetErrorsHelper.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/ngpipeline/inputset/helpers/InputSetErrorsHelper.java
@@ -144,9 +144,9 @@ public class InputSetErrorsHelper {
         subMap.keySet().forEach(inputSetFQNs::remove);
       }
     });
-    inputSetFQNs.forEach(fqn -> errorMap.put(fqn, "Field not a runtime input"));
 
-    if (inputSetFQNs.size() > 0) {
+    // Fqn which does not exist in pipeline, do not have to be added in error map.
+    if (inputSetFQNs.size() > 0)   {
       YamlConfig pipelineConfig = new YamlConfig(pipelineYaml);
       for (FQN fqn : inputSetFQNs) {
         if (pipelineConfig.getFqnToValueMap().get(fqn) == null) {

--- a/800-pipeline-service/src/main/java/io/harness/pms/ngpipeline/inputset/helpers/InputSetSanitizer.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/ngpipeline/inputset/helpers/InputSetSanitizer.java
@@ -54,7 +54,7 @@ public class InputSetSanitizer {
     YamlConfig inputSetConfig = new YamlConfig(filteredInputSetYaml);
 
     Set<FQN> invalidFQNsInInputSet =
-        InputSetErrorsHelper.getInvalidFQNsInInputSet(templateYaml, filteredInputSetYaml).keySet();
+        InputSetErrorsHelper.getInvalidFQNsInInputSet(templateYaml, filteredInputSetYaml, pipelineYaml).keySet();
 
     Map<FQN, Object> filtered = inputSetConfig.getFqnToValueMap()
                                     .entrySet()

--- a/800-pipeline-service/src/main/java/io/harness/pms/plan/execution/ExecutionHelper.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/plan/execution/ExecutionHelper.java
@@ -240,7 +240,7 @@ public class ExecutionHelper {
       pipelineYaml = pipelineEntity.getYaml();
     } else {
       Map<FQN, String> invalidFQNsInInputSet = InputSetErrorsHelper.getInvalidFQNsInInputSet(
-          InputSetTemplateHelper.createTemplateFromPipeline(pipelineEntity.getYaml()), mergedRuntimeInputYaml);
+          InputSetTemplateHelper.createTemplateFromPipeline(pipelineEntity.getYaml()), mergedRuntimeInputYaml,pipelineEntity.getYaml());
       if (EmptyPredicate.isNotEmpty(invalidFQNsInInputSet)) {
         throw new InvalidRequestException("Some fields are not valid: "
             + invalidFQNsInInputSet.entrySet()

--- a/800-pipeline-service/src/main/java/io/harness/pms/plan/execution/ExecutionHelper.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/plan/execution/ExecutionHelper.java
@@ -240,7 +240,8 @@ public class ExecutionHelper {
       pipelineYaml = pipelineEntity.getYaml();
     } else {
       Map<FQN, String> invalidFQNsInInputSet = InputSetErrorsHelper.getInvalidFQNsInInputSet(
-          InputSetTemplateHelper.createTemplateFromPipeline(pipelineEntity.getYaml()), mergedRuntimeInputYaml,pipelineEntity.getYaml());
+          InputSetTemplateHelper.createTemplateFromPipeline(pipelineEntity.getYaml()), mergedRuntimeInputYaml,
+          pipelineEntity.getYaml());
       if (EmptyPredicate.isNotEmpty(invalidFQNsInInputSet)) {
         throw new InvalidRequestException("Some fields are not valid: "
             + invalidFQNsInInputSet.entrySet()

--- a/800-pipeline-service/src/test/java/io/harness/pms/ngpipeline/inputset/helpers/InputSetErrorsHelperTest.java
+++ b/800-pipeline-service/src/test/java/io/harness/pms/ngpipeline/inputset/helpers/InputSetErrorsHelperTest.java
@@ -172,13 +172,13 @@ public class InputSetErrorsHelperTest extends CategoryTest {
     String inputSet = "runtimeInput1.yml";
     String inputSetYaml = readFile(inputSet);
 
-    Set<FQN> invalidFQNs = InputSetErrorsHelper.getInvalidFQNsInInputSet(templateYaml, inputSetYaml).keySet();
+    Set<FQN> invalidFQNs = InputSetErrorsHelper.getInvalidFQNsInInputSet(templateYaml, inputSetYaml, yaml).keySet();
     assertThat(invalidFQNs).isEmpty();
 
     String inputSetWrong = "runtimeInputWrong1.yml";
     String inputSetYamlWrong = readFile(inputSetWrong);
 
-    invalidFQNs = InputSetErrorsHelper.getInvalidFQNsInInputSet(templateYaml, inputSetYamlWrong).keySet();
+    invalidFQNs = InputSetErrorsHelper.getInvalidFQNsInInputSet(templateYaml, inputSetYamlWrong, yaml).keySet();
     assertThat(invalidFQNs.size()).isEqualTo(2);
     String invalidFQN1 =
         "pipeline.stages.stage[identifier:qaStage].spec.execution.steps.step[identifier:httpStep1].spec.method.";
@@ -203,12 +203,12 @@ public class InputSetErrorsHelperTest extends CategoryTest {
     String fullYaml = readFile(fullYamlFile);
     assertThat(mergedYaml).isEqualTo(fullYaml);
 
-    Map<FQN, String> noInvalidFQNsInInputSet = getInvalidFQNsInInputSet(template, runtimeInput);
+    Map<FQN, String> noInvalidFQNsInInputSet = getInvalidFQNsInInputSet(template, runtimeInput, yaml);
     assertThat(noInvalidFQNsInInputSet).isEmpty();
 
     String runtimeInputFileWrong = "paths-with-validators-runtime-input-wrong.yaml";
     String runtimeInputWrong = readFile(runtimeInputFileWrong);
-    Map<FQN, String> invalidFQNsInInputSet = getInvalidFQNsInInputSet(template, runtimeInputWrong);
+    Map<FQN, String> invalidFQNsInInputSet = getInvalidFQNsInInputSet(template, runtimeInputWrong, yaml);
     assertThat(invalidFQNsInInputSet.size()).isEqualTo(2);
     List<String> invalidFQNStrings =
         invalidFQNsInInputSet.keySet().stream().map(FQN::display).collect(Collectors.toList());

--- a/800-pipeline-service/src/test/java/io/harness/pms/ngpipeline/inputset/helpers/InputSetErrorsHelperTest.java
+++ b/800-pipeline-service/src/test/java/io/harness/pms/ngpipeline/inputset/helpers/InputSetErrorsHelperTest.java
@@ -219,4 +219,27 @@ public class InputSetErrorsHelperTest extends CategoryTest {
     assertThat(invalidFQNStrings.contains(invalidFQN1)).isTrue();
     assertThat(invalidFQNStrings.contains(invalidFQN2)).isTrue();
   }
+
+  @Test
+  @Owner(developers = NAMAN)
+  @Category(UnitTests.class)
+  public void testExtraFqnOnRuntimeTemplate() {
+    String filename = "pipeline-extensive.yml";
+    String yaml = readFile(filename);
+    String templateYaml = createTemplateFromPipeline(yaml);
+
+    String inputSet = "invalidRuntimeInputWithExtraValues.yml";
+    String inputSetYaml = readFile(inputSet);
+
+    Set<FQN> invalidFQNs = InputSetErrorsHelper.getInvalidFQNsInInputSet(templateYaml, inputSetYaml, yaml).keySet();
+    assertThat(invalidFQNs.size()).isEqualTo(1);
+    assertThat(invalidFQNs.iterator().next().getExpressionFqn())
+        .isEqualTo("pipeline.stages.qaStage.spec.execution.steps.httpStep1.spec.method");
+
+    String inputSetWrong = "validRuntimeInputWithExtraValues.yml";
+    String inputSetYamlWrong = readFile(inputSetWrong);
+
+    invalidFQNs = InputSetErrorsHelper.getInvalidFQNsInInputSet(templateYaml, inputSetYamlWrong, yaml).keySet();
+    assertThat(invalidFQNs.size()).isEqualTo(0);
+  }
 }

--- a/800-pipeline-service/src/test/java/io/harness/pms/plan/execution/ExecutionHelperTest.java
+++ b/800-pipeline-service/src/test/java/io/harness/pms/plan/execution/ExecutionHelperTest.java
@@ -15,6 +15,7 @@ import static io.harness.rule.OwnerRule.PRASHANTSHARMA;
 import static io.harness.rule.OwnerRule.UTKARSH_CHOUBEY;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -80,7 +81,6 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 @OwnedBy(PIPELINE)
 @PrepareForTest({PlanExecutionUtils.class, UUIDGenerator.class})
@@ -510,7 +510,7 @@ public class ExecutionHelperTest extends CategoryTest {
   @Owner(developers = NAMAN)
   @Category(UnitTests.class)
   public void testGetPipelineYamlAndValidate() {
-    String wrongRuntimeInputYaml = "pipeline:\n"
+    String runtimeYamlWithExtraField = "pipeline:\n"
         + "  stages:\n"
         + "  - stage:\n"
         + "      identifier: s1\n"
@@ -519,9 +519,11 @@ public class ExecutionHelperTest extends CategoryTest {
         + "      identifier: s2\n"
         + "      name: s2\n"
         + "      description: desc\n";
-    assertThatThrownBy(
-        () -> executionHelper.getPipelineYamlAndValidate(wrongRuntimeInputYaml, pipelineEntity).getMergedPipelineYaml())
-        .isInstanceOf(InvalidRequestException.class);
+
+    assertThatCode(()
+                       -> executionHelper.getPipelineYamlAndValidate(runtimeYamlWithExtraField, pipelineEntity)
+                              .getMergedPipelineYaml())
+        .doesNotThrowAnyException();
   }
 
   @Test

--- a/800-pipeline-service/src/test/java/io/harness/pms/plan/execution/ExecutionHelperTest.java
+++ b/800-pipeline-service/src/test/java/io/harness/pms/plan/execution/ExecutionHelperTest.java
@@ -81,6 +81,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 
 @OwnedBy(PIPELINE)
 @PrepareForTest({PlanExecutionUtils.class, UUIDGenerator.class})

--- a/800-pipeline-service/src/test/resources/invalidRuntimeInputWithExtraValues.yml
+++ b/800-pipeline-service/src/test/resources/invalidRuntimeInputWithExtraValues.yml
@@ -1,0 +1,104 @@
+pipeline:
+  identifier: "Test_Pipline11"
+  variables:
+  - name: "port2"
+    value: 8080
+  stages:
+  - stage:
+      identifier: "qaStage"
+      spec:
+        execution:
+          steps:
+          - step:
+              identifier: "httpStep1"
+              spec:
+                method: GET
+                url: www.google.com
+          - parallel:
+            - step:
+                identifier: "httpStep2"
+                spec:
+                  method: POST
+          - step:
+              identifier: "httpStep11"
+              spec:
+                socketTimeoutMillis: 60000
+        service:
+          identifier: "manager"
+          serviceDefinition:
+            spec:
+              manifests:
+              - manifest:
+                  identifier: "qaOverride"
+                  spec:
+                    store:
+                      connectorRef: my_git_connector
+                      gitFetchType: Branch
+                      branch: master
+                      paths:
+                      - test/baseValues.yaml
+                      - test/qa/values_1.yaml
+        infrastructure:
+          infrastructureDefinition:
+            spec:
+              namespace: default
+  - parallel:
+    - stage:
+        identifier: "qaStage2"
+        spec:
+          execution:
+            steps:
+            - step:
+                identifier: "httpStep4"
+                spec:
+                  method: GET
+          service:
+            identifier: "manager"
+            serviceDefinition:
+              spec:
+                manifests:
+                - manifest:
+                    identifier: "baseValues"
+                    spec:
+                      store:
+                        spec:
+                          connectorRef: defaultConn
+    - stage:
+        identifier: "qaStage3"
+        spec:
+          execution:
+            steps:
+            - step:
+                identifier: "httpStep5"
+                spec:
+                  method: GET
+          service:
+            identifier: "manager"
+            serviceDefinition:
+              spec:
+                manifests:
+                - manifest:
+                    identifier: baseValues
+                    type: K8sManifest
+                    spec:
+                      store:
+                        type: Git
+                        spec:
+                          connectorRef: my_git_connector
+                          gitFetchType: Branch
+                          branch: master
+                          paths:
+                          - test/spec
+                - manifest:
+                    identifier: qaOverride
+                    type: Values
+                    spec:
+                      store:
+                        type: Git
+                        spec:
+                          connectorRef: my_git_connector
+                          gitFetchType: Branch
+                          branch: master
+                          paths:
+                          - test/baseValues.yaml
+                          - test/qa/values_1.yaml

--- a/800-pipeline-service/src/test/resources/validRuntimeInputWithExtraValues.yml
+++ b/800-pipeline-service/src/test/resources/validRuntimeInputWithExtraValues.yml
@@ -1,0 +1,104 @@
+pipeline:
+  identifier: "Test_Pipline11"
+  variables:
+  - name: "port2"
+    value: 8080
+  stages:
+  - stage:
+      identifier: "qaStage"
+      spec:
+        execution:
+          steps:
+          - step:
+              identifier: "httpStep1"
+              spec:
+                extramethodField: GET
+                url: www.google.com
+          - parallel:
+            - step:
+                identifier: "httpStep2"
+                spec:
+                  method: POST
+          - step:
+              identifier: "httpStep11"
+              spec:
+                socketTimeoutMillis: 60000
+        service:
+          identifier: "manager"
+          serviceDefinition:
+            spec:
+              manifests:
+              - manifest:
+                  identifier: "qaOverride"
+                  spec:
+                    store:
+                      connectorRef: my_git_connector
+                      gitFetchType: Branch
+                      branch: master
+                      paths:
+                      - test/baseValues.yaml
+                      - test/qa/values_1.yaml
+        infrastructure:
+          infrastructureDefinition:
+            spec:
+              namespace: default
+  - parallel:
+    - stage:
+        identifier: "qaStage2"
+        spec:
+          execution:
+            steps:
+            - step:
+                identifier: "httpStep4"
+                spec:
+                  method: GET
+          service:
+            identifier: "manager"
+            serviceDefinition:
+              spec:
+                manifests:
+                - manifest:
+                    identifier: "baseValues"
+                    spec:
+                      store:
+                        spec:
+                          connectorRef: defaultConn
+    - stage:
+        identifier: "qaStage3"
+        spec:
+          execution:
+            steps:
+            - step:
+                identifier: "httpStep5"
+                spec:
+                  method: GET
+          service:
+            identifier: "manager"
+            serviceDefinition:
+              spec:
+                manifests:
+                - manifest:
+                    identifier: baseValues
+                    type: K8sManifest
+                    spec:
+                      store:
+                        type: Git
+                        spec:
+                          connectorRef: my_git_connector
+                          gitFetchType: Branch
+                          branch: master
+                          paths:
+                          - test/spec
+                - manifest:
+                    identifier: qaOverride
+                    type: Values
+                    spec:
+                      store:
+                        type: Git
+                        spec:
+                          connectorRef: my_git_connector
+                          gitFetchType: Branch
+                          branch: master
+                          paths:
+                          - test/baseValues.yaml
+                          - test/qa/values_1.yaml


### PR DESCRIPTION
…t present in pipeline yaml

## With these changes, runtime yaml can have fields which are not present in pipeline yaml. This was required for v2 impl of service-env when serviceRef will be a runtime time input which itself contains runtime values

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/34777)
<!-- Reviewable:end -->
