### PR TITLE
[fix]:[PL-26131]: Remove variable sendNotificationViaDelegate option for notification channels

### DIFF
--- a/platform-service/build.properties
+++ b/platform-service/build.properties
@@ -1,4 +1,4 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=75900
+build.number=75901
 build.patch=000

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/MSTeamsServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/MSTeamsServiceImpl.java
@@ -167,7 +167,7 @@ public class MSTeamsServiceImpl implements ChannelService {
     }
     String message = messageOpt.get();
     NotificationProcessingResponse processingResponse = null;
-    if (notificationSettingsService.getSendNotificationViaDelegate(accountId)) {
+    if (notificationSettingsService.checkIfWebhookIsSecret(microsoftTeamsWebhookUrls)) {
       DelegateTaskRequest delegateTaskRequest =
           DelegateTaskRequest.builder()
               .accountId(accountId)

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/MailServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/MailServiceImpl.java
@@ -138,7 +138,7 @@ public class MailServiceImpl implements ChannelService {
       List<String> emailIds, String subject, String body, String notificationId, String accountId) {
     NotificationProcessingResponse notificationProcessingResponse;
     SmtpConfigResponse smtpConfigResponse = notificationSettingsService.getSmtpConfigResponse(accountId);
-    if (notificationSettingsService.getSendNotificationViaDelegate(accountId) && Objects.nonNull(smtpConfigResponse)) {
+    if (Objects.nonNull(smtpConfigResponse)) {
       DelegateTaskRequest delegateTaskRequest =
           DelegateTaskRequest.builder()
               .accountId(accountId)

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/NotificationSettingsServiceImpl.java
@@ -59,6 +59,8 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
   private static final Pattern VALID_EXPRESSION_PATTERN =
       Pattern.compile("\\<\\+secrets.getValue\\((\\\"|\\')\\w*[\\.]?\\w*(\\\"|\\')\\)>");
   private static final String INVALID_EXPRESSION_EXCEPTION = "Expression provided is not valid";
+  private static final Pattern SECRET_EXPRESSION =
+      Pattern.compile("\\$\\{ngSecretManager\\.obtain\\(\\\"\\w*[\\.]?\\w*\\\"\\, ([+-]?\\d*|0)\\)\\}");
 
   private List<UserGroupDTO> getUserGroups(List<String> userGroupIds) {
     if (isEmpty(userGroupIds)) {
@@ -198,6 +200,16 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
       log.error("Rest call for getting smtp config failed: ", ex);
     }
     return smtpConfigResponse;
+  }
+
+  @Override
+  public boolean checkIfWebhookIsSecret(List<String> webhooks) {
+    for (String webhook : webhooks) {
+      if (SECRET_EXPRESSION.matcher(webhook).matches()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/PagerDutyServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/PagerDutyServiceImpl.java
@@ -164,7 +164,7 @@ public class PagerDutyServiceImpl implements ChannelService {
     }
 
     NotificationProcessingResponse processingResponse = null;
-    if (notificationSettingsService.getSendNotificationViaDelegate(accountId)) {
+    if (notificationSettingsService.checkIfWebhookIsSecret(pagerDutyKeys)) {
       DelegateTaskRequest delegateTaskRequest = DelegateTaskRequest.builder()
                                                     .accountId(accountId)
                                                     .taskType("NOTIFY_PAGERDUTY")

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/SlackServiceImpl.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/SlackServiceImpl.java
@@ -129,7 +129,7 @@ public class SlackServiceImpl implements ChannelService {
     StrSubstitutor strSubstitutor = new StrSubstitutor(templateData);
     String message = strSubstitutor.replace(template);
     NotificationProcessingResponse processingResponse = null;
-    if (notificationSettingsService.getSendNotificationViaDelegate(accountId)) {
+    if (notificationSettingsService.checkIfWebhookIsSecret(slackWebhookUrls)) {
       DelegateTaskRequest delegateTaskRequest = DelegateTaskRequest.builder()
                                                     .accountId(accountId)
                                                     .taskType("NOTIFY_SLACK")

--- a/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/api/NotificationSettingsService.java
+++ b/platform-service/modules/notification-service/src/main/java/io/harness/notification/service/api/NotificationSettingsService.java
@@ -32,4 +32,6 @@ public interface NotificationSettingsService {
   NotificationSetting setSmtpConfig(String accountId, SmtpConfig smtpConfig);
 
   SmtpConfigResponse getSmtpConfigResponse(String accountId);
+
+  boolean checkIfWebhookIsSecret(List<String> webhooks);
 }

--- a/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/MSTeamsServiceImplTest.java
+++ b/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/MSTeamsServiceImplTest.java
@@ -151,7 +151,7 @@ public class MSTeamsServiceImplTest extends CategoryTest {
                                              .build())
                               .build();
     notificationExpectedResponse =
-        NotificationProcessingResponse.builder().result(Arrays.asList(true)).shouldRetry(false).build();
+        NotificationProcessingResponse.builder().result(Arrays.asList(true, false)).shouldRetry(false).build();
     when(notificationTemplateService.getTemplateAsString(eq(msTeamsTemplateName), any()))
         .thenReturn(Optional.of("this is test notification"));
     when(notificationSettingsService.getSendNotificationViaDelegate(eq(accountId))).thenReturn(true);
@@ -207,7 +207,7 @@ public class MSTeamsServiceImplTest extends CategoryTest {
                                              .build())
                               .build();
     notificationExpectedResponse =
-        NotificationProcessingResponse.builder().result(Arrays.asList(true)).shouldRetry(false).build();
+        NotificationProcessingResponse.builder().result(Arrays.asList(true, false)).shouldRetry(false).build();
     when(notificationTemplateService.getTemplateAsString(eq(msTeamsTemplateName), any()))
         .thenReturn(Optional.of("this is test notification"));
     when(notificationSettingsService.getSendNotificationViaDelegate(eq(accountId))).thenReturn(true);
@@ -259,7 +259,7 @@ public class MSTeamsServiceImplTest extends CategoryTest {
                                              .build())
                               .build();
     notificationExpectedResponse =
-        NotificationProcessingResponse.builder().result(Arrays.asList(true, true)).shouldRetry(false).build();
+        NotificationProcessingResponse.builder().result(Arrays.asList(true, false)).shouldRetry(false).build();
     when(notificationTemplateService.getTemplateAsString(eq(msTeamsTemplateName), any()))
         .thenReturn(Optional.of("this is test notification"));
     when(notificationSettingsService.getSendNotificationViaDelegate(eq(accountId))).thenReturn(true);

--- a/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
+++ b/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
@@ -11,6 +11,7 @@ import static io.harness.annotations.dev.HarnessTeam.PL;
 import static io.harness.rule.OwnerRule.ADITHYA;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -48,12 +49,25 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   private static final String SLACK_ORG_SECRET = "<+secrets.getValue('org.SlackWebhookUrlSecret')>";
   private static final String SLACK_ACCOUNT_SECRET = "<+secrets.getValue('account.SlackWebhookUrlSecret')>";
   private static final String PAGERDUTY_SECRET = "<+secrets.getValue('PagerDutyWebhookUrlSecret')>";
-  private long expressionFunctorToken;
+  private static final long EXPRESSION_FUNCTOR_TOKEN_1 = HashGenerator.generateIntegerHash();
+  private static final String RESOLVED_SLACK_SECRET_1 =
+      String.format("${ngSecretManager.obtain(\"SlackWebhookUrlSecret1\", %d)}", EXPRESSION_FUNCTOR_TOKEN_1);
+  private static final String RESOLVED_SLACK_SECRET_2 =
+      String.format("${ngSecretManager.obtain(\"SlackWebhookUrlSecret2\", %d)}", EXPRESSION_FUNCTOR_TOKEN_1);
+  private static final String RESOLVED_SLACK_SECRET_3 =
+      String.format("${ngSecretManager.obtain(\"SlackWebhookUrlSecret3\", %d)}", EXPRESSION_FUNCTOR_TOKEN_1);
+  private static final String RESOLVED_PAGER_DUTY_SECRET =
+      String.format("${ngSecretManager.obtain(\"PagerDutyWebhookUrlSecret\", %d)}", EXPRESSION_FUNCTOR_TOKEN_1);
+  private static final String RESOLVED_SLACK_ORG_SECRET =
+      String.format("${ngSecretManager.obtain(\"org.SlackWebhookUrlSecret\", %d)}", EXPRESSION_FUNCTOR_TOKEN_1);
+  private static final String RESOLVED_SLACK_ACCOUNT_SECRET =
+      String.format("${ngSecretManager.obtain(\"account.SlackWebhookUrlSecret\", %d)}", EXPRESSION_FUNCTOR_TOKEN_1);
+  private static final String RESOLVED_SLACK_SECRET_WITH_FUNCTOR_ZERO =
+      "${ngSecretManager.obtain(\"SlackWebhookUrlSecret1\", 0)}";
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    expressionFunctorToken = HashGenerator.generateIntegerHash();
     notificationSettingsService = new NotificationSettingsServiceImpl(
         userGroupClient, userClient, notificationSettingRepository, smtpConfigClient);
   }
@@ -66,13 +80,9 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
     notificationSettings.add(SLACK_SECRET_1);
     notificationSettings.add(SLACK_SECRET_2);
     List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
-        NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken);
-    String expectedUserGroup1 =
-        String.format("${ngSecretManager.obtain(\"SlackWebhookUrlSecret1\", %d)}", expressionFunctorToken);
-    String expectedUserGroup2 =
-        String.format("${ngSecretManager.obtain(\"SlackWebhookUrlSecret2\", %d)}", expressionFunctorToken);
-    assertEquals(expectedUserGroup1, resolvedUserGroups.get(0));
-    assertEquals(expectedUserGroup2, resolvedUserGroups.get(1));
+        NotificationChannelType.SLACK, notificationSettings, EXPRESSION_FUNCTOR_TOKEN_1);
+    assertEquals(RESOLVED_SLACK_SECRET_1, resolvedUserGroups.get(0));
+    assertEquals(RESOLVED_SLACK_SECRET_2, resolvedUserGroups.get(1));
   }
 
   @Test
@@ -83,13 +93,9 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
     notificationSettings.add(SLACK_ORG_SECRET);
     notificationSettings.add(SLACK_ACCOUNT_SECRET);
     List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
-        NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken);
-    String expectedUserGroup1 =
-        String.format("${ngSecretManager.obtain(\"org.SlackWebhookUrlSecret\", %d)}", expressionFunctorToken);
-    String expectedUserGroup2 =
-        String.format("${ngSecretManager.obtain(\"account.SlackWebhookUrlSecret\", %d)}", expressionFunctorToken);
-    assertEquals(expectedUserGroup1, resolvedUserGroups.get(0));
-    assertEquals(expectedUserGroup2, resolvedUserGroups.get(1));
+        NotificationChannelType.SLACK, notificationSettings, EXPRESSION_FUNCTOR_TOKEN_1);
+    assertEquals(RESOLVED_SLACK_ORG_SECRET, resolvedUserGroups.get(0));
+    assertEquals(RESOLVED_SLACK_ACCOUNT_SECRET, resolvedUserGroups.get(1));
   }
 
   @Test
@@ -100,7 +106,7 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
     notificationSettings.add("<+adbc>");
     assertThatThrownBy(()
                            -> notificationSettingsService.resolveUserGroups(
-                               NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken))
+                               NotificationChannelType.SLACK, notificationSettings, EXPRESSION_FUNCTOR_TOKEN_1))
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage("Expression provided is not valid");
   }
@@ -112,7 +118,7 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
     List<String> notificationSettings = new ArrayList<>();
     notificationSettings.add(SLACK_WEBHOOK_URL);
     List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
-        NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken);
+        NotificationChannelType.SLACK, notificationSettings, EXPRESSION_FUNCTOR_TOKEN_1);
     assertEquals(SLACK_WEBHOOK_URL, resolvedUserGroups.get(0));
   }
 
@@ -123,10 +129,8 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
     List<String> notificationSettings = new ArrayList<>();
     notificationSettings.add(PAGERDUTY_SECRET);
     List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
-        NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken);
-    String expectedUserGroup =
-        String.format("${ngSecretManager.obtain(\"PagerDutyWebhookUrlSecret\", %d)}", expressionFunctorToken);
-    assertEquals(expectedUserGroup, resolvedUserGroups.get(0));
+        NotificationChannelType.SLACK, notificationSettings, EXPRESSION_FUNCTOR_TOKEN_1);
+    assertEquals(RESOLVED_PAGER_DUTY_SECRET, resolvedUserGroups.get(0));
   }
 
   @Test
@@ -134,7 +138,7 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   @Category(UnitTests.class)
   public void testGetNotificationRequestForEmptyUserGroups() {
     List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
-        NotificationChannelType.SLACK, new ArrayList<>(), expressionFunctorToken);
+        NotificationChannelType.SLACK, new ArrayList<>(), EXPRESSION_FUNCTOR_TOKEN_1);
     assertTrue(resolvedUserGroups.isEmpty());
   }
 
@@ -145,9 +149,40 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
     List<String> notificationSettings = new ArrayList<>();
     notificationSettings.add(SLACK_SECRET_3);
     List<String> resolvedUserGroups = notificationSettingsService.resolveUserGroups(
-        NotificationChannelType.SLACK, notificationSettings, expressionFunctorToken);
-    String expectedUserGroup1 =
-        String.format("${ngSecretManager.obtain(\"SlackWebhookUrlSecret3\", %d)}", expressionFunctorToken);
-    assertEquals(expectedUserGroup1, resolvedUserGroups.get(0));
+        NotificationChannelType.SLACK, notificationSettings, EXPRESSION_FUNCTOR_TOKEN_1);
+    assertEquals(RESOLVED_SLACK_SECRET_3, resolvedUserGroups.get(0));
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testSlackWebhookSecret() {
+    List<String> notificationSettings = new ArrayList<>();
+    notificationSettings.add(RESOLVED_SLACK_SECRET_1);
+    notificationSettings.add(RESOLVED_SLACK_SECRET_1);
+    notificationSettings.add(RESOLVED_SLACK_SECRET_WITH_FUNCTOR_ZERO);
+    boolean isSecret = notificationSettingsService.checkIfWebhookIsSecret(notificationSettings);
+    assertTrue(isSecret);
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testSlackWebhookNonSecret() {
+    List<String> notificationSettings = new ArrayList<>();
+    notificationSettings.add(SLACK_WEBHOOK_URL);
+    boolean isSecret = notificationSettingsService.checkIfWebhookIsSecret(notificationSettings);
+    assertFalse(isSecret);
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testSlackWebhookSecretAndNonSecret() {
+    List<String> notificationSettings = new ArrayList<>();
+    notificationSettings.add(SLACK_WEBHOOK_URL);
+    notificationSettings.add(RESOLVED_SLACK_SECRET_1);
+    boolean isSecret = notificationSettingsService.checkIfWebhookIsSecret(notificationSettings);
+    assertTrue(isSecret);
   }
 }

--- a/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
+++ b/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/NotificationSettingsServiceImplTest.java
@@ -159,7 +159,7 @@ public class NotificationSettingsServiceImplTest extends CategoryTest {
   public void testSlackWebhookSecret() {
     List<String> notificationSettings = new ArrayList<>();
     notificationSettings.add(RESOLVED_SLACK_SECRET_1);
-    notificationSettings.add(RESOLVED_SLACK_SECRET_1);
+    notificationSettings.add(RESOLVED_SLACK_SECRET_2);
     notificationSettings.add(RESOLVED_SLACK_SECRET_WITH_FUNCTOR_ZERO);
     boolean isSecret = notificationSettingsService.checkIfWebhookIsSecret(notificationSettings);
     assertTrue(isSecret);

--- a/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/PagerDutyServiceImplTest.java
+++ b/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/PagerDutyServiceImplTest.java
@@ -159,7 +159,7 @@ public class PagerDutyServiceImplTest extends CategoryTest {
                                                 .build())
                               .build();
     notificationExpectedResponse =
-        NotificationProcessingResponse.builder().result(Arrays.asList(true)).shouldRetry(false).build();
+        NotificationProcessingResponse.builder().result(Arrays.asList(true, false)).shouldRetry(false).build();
     when(notificationTemplateService.getTemplateAsString(eq(pdTemplateName), any()))
         .thenReturn(Optional.of("this is test notification"));
     when(notificationSettingsService.getSendNotificationViaDelegate(eq(accountId))).thenReturn(true);
@@ -212,7 +212,7 @@ public class PagerDutyServiceImplTest extends CategoryTest {
                                                 .build())
                               .build();
     notificationExpectedResponse =
-        NotificationProcessingResponse.builder().result(Arrays.asList(true, true)).shouldRetry(false).build();
+        NotificationProcessingResponse.builder().result(Arrays.asList(true, false)).shouldRetry(false).build();
     when(notificationTemplateService.getTemplateAsString(eq(pdTemplateName), any()))
         .thenReturn(Optional.of("this is test notification"));
     when(notificationSettingsService.getSendNotificationViaDelegate(eq(accountId))).thenReturn(true);
@@ -269,7 +269,7 @@ public class PagerDutyServiceImplTest extends CategoryTest {
                                                 .build())
                               .build();
     notificationExpectedResponse =
-        NotificationProcessingResponse.builder().result(Arrays.asList(true)).shouldRetry(false).build();
+        NotificationProcessingResponse.builder().result(Arrays.asList(true, false)).shouldRetry(false).build();
     when(notificationTemplateService.getTemplateAsString(eq(pdTemplateName), any()))
         .thenReturn(Optional.of("this is test notification"));
     when(notificationSettingsService.getSendNotificationViaDelegate(eq(accountId))).thenReturn(true);

--- a/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/SlackServiceImplTest.java
+++ b/platform-service/modules/notification-service/src/test/java/io/harness/notification/service/SlackServiceImplTest.java
@@ -161,7 +161,7 @@ public class SlackServiceImplTest extends CategoryTest {
                                             .build())
                               .build();
     notificationExpectedResponse =
-        NotificationProcessingResponse.builder().result(Arrays.asList(true)).shouldRetry(false).build();
+        NotificationProcessingResponse.builder().result(Arrays.asList(true, false)).shouldRetry(false).build();
     when(notificationTemplateService.getTemplateAsString(eq(slackTemplateName), any()))
         .thenReturn(Optional.of("this is test notification"));
     when(notificationSettingsService.getSendNotificationViaDelegate(eq(accountId))).thenReturn(true);
@@ -213,7 +213,7 @@ public class SlackServiceImplTest extends CategoryTest {
                                             .build())
                               .build();
     notificationExpectedResponse =
-        NotificationProcessingResponse.builder().result(Arrays.asList(true, true)).shouldRetry(false).build();
+        NotificationProcessingResponse.builder().result(Arrays.asList(true, false)).shouldRetry(false).build();
     when(notificationTemplateService.getTemplateAsString(eq(slackTemplateName), any()))
         .thenReturn(Optional.of("this is test notification"));
     when(notificationSettingsService.getSendNotificationViaDelegate(eq(accountId))).thenReturn(true);
@@ -259,7 +259,7 @@ public class SlackServiceImplTest extends CategoryTest {
                                             .build())
                               .build();
     notificationExpectedResponse =
-        NotificationProcessingResponse.builder().result(Arrays.asList(true)).shouldRetry(false).build();
+        NotificationProcessingResponse.builder().result(Arrays.asList(true, false)).shouldRetry(false).build();
     when(notificationTemplateService.getTemplateAsString(eq(slackTemplateName), any()))
         .thenReturn(Optional.of("this is test notification"));
     when(notificationSettingsService.getSendNotificationViaDelegate(eq(accountId))).thenReturn(true);


### PR DESCRIPTION
## Describe your changes
Code changes to remove the setting sendNotificationViaDelegate

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [x] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/34788)
<!-- Reviewable:end -->
