### PR TITLE
Fix NPE, issue on wrong selector 

### DIFF
--- a/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
+++ b/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
@@ -890,6 +890,7 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
       DelegateHeartbeatResponseStreaming delegateHeartbeatResponse =
           JsonUtils.asObject(message, DelegateHeartbeatResponseStreaming.class);
       healthMonitorExecutor.submit(() -> processHeartbeat(delegateHeartbeatResponse));
+      return;
     }
 
     // Handle other messages in task executor thread-pool.

--- a/878-ng-common-utilities/src/main/java/io/harness/steps/StepUtils.java
+++ b/878-ng-common-utilities/src/main/java/io/harness/steps/StepUtils.java
@@ -84,6 +84,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -510,11 +511,15 @@ public class StepUtils {
 
   private static boolean hasDelegateSelectors(
       ParameterField<List<TaskSelectorYaml>> delegateSelectors, WithDelegateSelector withDelegateSelector) {
-    if (ParameterField.isNull(withDelegateSelector.fetchDelegateSelectors()) || isEmpty(delegateSelectors.getValue())) {
+    if (delegateSelectors == null || ParameterField.isNull(withDelegateSelector.fetchDelegateSelectors())
+        || isEmpty(delegateSelectors.getValue())) {
       return false;
     }
-    List<TaskSelectorYaml> selectorYamls =
-        delegateSelectors.getValue().stream().filter(s -> isNotEmpty(s.getDelegateSelectors())).collect(toList());
+    List<TaskSelectorYaml> selectorYamls = delegateSelectors.getValue()
+                                               .stream()
+                                               .filter(Objects::nonNull)
+                                               .filter(s -> isNotEmpty(s.getDelegateSelectors()))
+                                               .collect(toList());
     if (selectorYamls.isEmpty()) {
       return false;
     }


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/34812)
<!-- Reviewable:end -->
