### PR TITLE
[fix]: [PIE-4087]: Input Set Error explanation needs to be correct when yaml file is invalid

### DIFF
--- a/800-pipeline-service/src/main/java/io/harness/pms/ngpipeline/inputset/resources/InputSetResourcePMS.java
+++ b/800-pipeline-service/src/main/java/io/harness/pms/ngpipeline/inputset/resources/InputSetResourcePMS.java
@@ -285,7 +285,7 @@ public class InputSetResourcePMS {
     InputSetErrorWrapperDTOPMS errorWrapperDTO = validateAndMergeHelper.validateInputSet(
         accountId, orgIdentifier, projectIdentifier, pipelineIdentifier, yaml, pipelineBranch, pipelineRepoID);
     if (errorWrapperDTO != null) {
-      throw new InvalidInputSetException("Exception in creating the Input Set", errorWrapperDTO);
+      throw new InvalidInputSetException("Some fields in the Input Set are invalid.", errorWrapperDTO);
     }
 
     InputSetEntity createdEntity = pmsInputSetService.create(entity);
@@ -333,7 +333,7 @@ public class InputSetResourcePMS {
           OverlayInputSetErrorWrapperDTOPMS.builder().invalidReferences(invalidReferences).build();
 
       throw new InvalidOverlayInputSetException(
-          "Exception in creating the Overlay Input Set", overlayInputSetErrorWrapperDTOPMS);
+          "Some fields in the Overlay Input Set are invalid.", overlayInputSetErrorWrapperDTOPMS);
     }
 
     InputSetEntity createdEntity = pmsInputSetService.create(entity);
@@ -388,7 +388,7 @@ public class InputSetResourcePMS {
     InputSetErrorWrapperDTOPMS errorWrapperDTO = validateAndMergeHelper.validateInputSet(
         accountId, orgIdentifier, projectIdentifier, pipelineIdentifier, yaml, pipelineBranch, pipelineRepoID);
     if (errorWrapperDTO != null) {
-      throw new InvalidInputSetException("Exception in updating the Input Set", errorWrapperDTO);
+      throw new InvalidInputSetException("Some fields in the Input Set are invalid.", errorWrapperDTO);
     }
 
     InputSetEntity entity = PMSInputSetElementMapper.toInputSetEntity(
@@ -443,7 +443,7 @@ public class InputSetResourcePMS {
           OverlayInputSetErrorWrapperDTOPMS.builder().invalidReferences(invalidReferences).build();
 
       throw new InvalidOverlayInputSetException(
-          "Exception in updating the Overlay Input Set", overlayInputSetErrorWrapperDTOPMS);
+          "Some fields in the Overlay Input Set are invalid.", overlayInputSetErrorWrapperDTOPMS);
     }
 
     InputSetEntity updatedEntity = pmsInputSetService.update(entityWithVersion, ChangeType.MODIFY);


### PR DESCRIPTION
Top level error message needs to be more descriptive, and not have the word "exception". The error message needs to convey that the YAML is actually invalid. Note: this error message is just a top level message for the full error response.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/34822)
<!-- Reviewable:end -->
