### PR TITLE
[fix]: [CDS-38679]: fixing race condition

### DIFF
--- a/960-persistence/src/main/java/io/harness/persistence/HPersistence.java
+++ b/960-persistence/src/main/java/io/harness/persistence/HPersistence.java
@@ -83,8 +83,7 @@ public interface HPersistence extends HealthMonitor {
    */
 
   default AdvancedDatastore getDatastore(Class cls) {
-    Map<Class, Store> classStores = new HashMap<>(getClassStores());
-    return getDatastore(classStores.computeIfAbsent(cls, klass -> {
+    return getDatastore(getClassStores().computeIfAbsent(cls, klass -> {
       return Arrays.stream(cls.getDeclaredAnnotations())
           .filter(annotation -> annotation.annotationType().equals(StoreIn.class))
           .map(annotation -> ((StoreIn) annotation).value())

--- a/960-persistence/src/main/java/io/harness/persistence/HPersistence.java
+++ b/960-persistence/src/main/java/io/harness/persistence/HPersistence.java
@@ -83,7 +83,8 @@ public interface HPersistence extends HealthMonitor {
    */
 
   default AdvancedDatastore getDatastore(Class cls) {
-    return getDatastore(getClassStores().computeIfAbsent(cls, klass -> {
+    Map<Class, Store> classStores = new HashMap<>(getClassStores());
+    return getDatastore(classStores.computeIfAbsent(cls, klass -> {
       return Arrays.stream(cls.getDeclaredAnnotations())
           .filter(annotation -> annotation.annotationType().equals(StoreIn.class))
           .map(annotation -> ((StoreIn) annotation).value())

--- a/960-persistence/src/main/java/io/harness/queue/QueueListener.java
+++ b/960-persistence/src/main/java/io/harness/queue/QueueListener.java
@@ -63,17 +63,8 @@ public abstract class QueueListener<T extends Queuable> implements Runnable {
           sleep(ofSeconds(1));
         }
 
-        if (threadName.contains("DelayEvent")) {
-          log.info("modox reached here inside do");
-          int a = 1;
-        }
-
         if (!execute()) {
-          log.info("modox reached here break");
           break;
-        }
-        if (threadName.contains("DelayEvent")) {
-          int a = 1;
         }
 
       } while (!runOnce && !shouldStop.get());

--- a/960-persistence/src/main/java/io/harness/queue/QueueListener.java
+++ b/960-persistence/src/main/java/io/harness/queue/QueueListener.java
@@ -57,16 +57,30 @@ public abstract class QueueListener<T extends Queuable> implements Runnable {
     log.debug("Setting thread name to {}", threadName);
     Thread.currentThread().setName(threadName);
 
-    do {
-      while (getMaintenanceFlag() || (primaryOnly && queueController.isNotPrimary())) {
-        sleep(ofSeconds(1));
-      }
+    try {
+      do {
+        while (getMaintenanceFlag() || (primaryOnly && queueController.isNotPrimary())) {
+          sleep(ofSeconds(1));
+        }
 
-      if (!execute()) {
-        break;
-      }
+        if (threadName.contains("DelayEvent")) {
+          log.info("modox reached here inside do");
+          int a = 1;
+        }
 
-    } while (!runOnce && !shouldStop.get());
+        if (!execute()) {
+          log.info("modox reached here break");
+          break;
+        }
+        if (threadName.contains("DelayEvent")) {
+          int a = 1;
+        }
+
+      } while (!runOnce && !shouldStop.get());
+    } catch (Throwable e) {
+      log.error("Unexpected error on listener at thread: [{}]", threadName, e);
+      throw e;
+    }
   }
 
   public boolean execute() {


### PR DESCRIPTION
## Describe your changes

- Fixing racing condition when acessing datastores
- Adding observability on errors before thread dies

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/35075)
<!-- Reviewable:end -->
