### PR TITLE
[fix]: [CDS-28853]: removing user from createmeta only for ng

### DIFF
--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/jira/JiraTaskNGHandler.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/jira/JiraTaskNGHandler.java
@@ -27,7 +27,6 @@ import com.google.inject.Singleton;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 @OwnedBy(CDC)

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/jira/JiraTaskNGHandler.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/jira/JiraTaskNGHandler.java
@@ -15,6 +15,8 @@ import io.harness.delegate.task.jira.mappers.JiraRequestResponseMapper;
 import io.harness.exception.InvalidArtifactServerException;
 import io.harness.exception.NestedExceptionUtils;
 import io.harness.jira.JiraClient;
+import io.harness.jira.JiraFieldNG;
+import io.harness.jira.JiraFieldTypeNG;
 import io.harness.jira.JiraIssueCreateMetadataNG;
 import io.harness.jira.JiraIssueNG;
 import io.harness.jira.JiraIssueUpdateMetadataNG;
@@ -22,7 +24,10 @@ import io.harness.jira.JiraProjectBasicNG;
 import io.harness.jira.JiraStatusNG;
 
 import com.google.inject.Singleton;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 @OwnedBy(CDC)
@@ -73,6 +78,18 @@ public class JiraTaskNGHandler {
     JiraClient jiraClient = getJiraClient(params);
     JiraIssueCreateMetadataNG createMetadata = jiraClient.getIssueCreateMetadata(params.getProjectKey(),
         params.getIssueType(), params.getExpand(), params.isFetchStatus(), params.isIgnoreComment());
+
+    // TECHDEBIT: we need to remove user type fields only from calls NG until we add support. After that we need to
+    // remove this block of code.
+    Set<JiraFieldNG> jiraUserFields = new HashSet<>();
+    createMetadata.getProjects().values().forEach(proj
+        -> proj.getIssueTypes().values().forEach(issueType -> issueType.getFields().values().stream().forEach(field -> {
+      if (field.getSchema().getType() == JiraFieldTypeNG.USER) {
+        jiraUserFields.add(field);
+      }
+    })));
+    jiraUserFields.forEach(field -> createMetadata.removeField(field.getName()));
+
     return JiraTaskNGResponse.builder().issueCreateMetadata(createMetadata).build();
   }
 

--- a/970-api-services-beans/src/main/java/io/harness/jira/JiraIssueUtilsNG.java
+++ b/970-api-services-beans/src/main/java/io/harness/jira/JiraIssueUtilsNG.java
@@ -86,12 +86,15 @@ public class JiraIssueUtilsNG {
 
     Map<String, String> finalFields = fields;
     if (checkRequiredFields) {
-      Set<String> requiredFieldsNotPresent = issueTypeFields.entrySet()
-                                                 .stream()
-                                                 .filter(e -> e.getValue().isRequired())
-                                                 .map(Map.Entry::getKey)
-                                                 .filter(f -> !finalFields.containsKey(f))
-                                                 .collect(Collectors.toSet());
+      Set<String> requiredFieldsNotPresent =
+          issueTypeFields.entrySet()
+              .stream()
+              // TECHDEBIT: remove the USER validation after support for user type fields
+              .filter(
+                  e -> e.getValue().isRequired() && !e.getValue().getSchema().getType().equals(JiraFieldTypeNG.USER))
+              .map(Map.Entry::getKey)
+              .filter(f -> !finalFields.containsKey(f))
+              .collect(Collectors.toSet());
       if (EmptyPredicate.isNotEmpty(requiredFieldsNotPresent)) {
         throw new JiraClientException(String.format("Some required fields for this jira issue type are missing: %s",
                                           String.join(", ", requiredFieldsNotPresent)),

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=75618
+build.number=75619
 build.patch=001
 delegate.version=22.06.12
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/35183)
<!-- Reviewable:end -->
