### PR TITLE
[fix]: [PL-26379]: The feature flag was coming as enabled even when it was disabled

### DIFF
--- a/400-rest/src/main/java/software/wings/resources/SSOResource.java
+++ b/400-rest/src/main/java/software/wings/resources/SSOResource.java
@@ -98,7 +98,7 @@ public class SSOResource {
       @FormDataParam("clientSecret") String clientSecret) {
     return new RestResponse<>(ssoService.uploadSamlConfiguration(accountId, uploadedInputStream, displayName,
         groupMembershipAttr, authorizationEnabled, logoutUrl, entityIdentifier, samlProviderType, clientId,
-        isEmpty(clientSecret) ? null : clientSecret.toCharArray()));
+        isEmpty(clientSecret) ? null : clientSecret.toCharArray(), false));
   }
 
   @POST
@@ -147,7 +147,7 @@ public class SSOResource {
       @FormDataParam("clientSecret") String clientSecret) {
     return new RestResponse<>(ssoService.updateSamlConfiguration(accountId, uploadedInputStream, displayName,
         groupMembershipAttr, authorizationEnabled, logoutUrl, entityIdentifier, samlProviderType, clientId,
-        isEmpty(clientSecret) ? null : clientSecret.toCharArray()));
+        isEmpty(clientSecret) ? null : clientSecret.toCharArray(), false));
   }
 
   @PUT

--- a/400-rest/src/main/java/software/wings/resources/SSOResourceNG.java
+++ b/400-rest/src/main/java/software/wings/resources/SSOResourceNG.java
@@ -140,7 +140,7 @@ public class SSOResourceNG {
     final String clientSecretRef = getCGSecretManagerRefForClientSecret(accountId, true, clientId, clientSecret);
     return new RestResponse<>(ssoService.uploadSamlConfiguration(accountId, uploadedInputStream, displayName,
         groupMembershipAttr, authorizationEnabled, logoutUrl, entityIdentifier, samlProviderType, clientId,
-        isEmpty(clientSecretRef) ? null : clientSecretRef.toCharArray()));
+        isEmpty(clientSecretRef) ? null : clientSecretRef.toCharArray(), true));
   }
 
   @PUT
@@ -158,7 +158,7 @@ public class SSOResourceNG {
     final String clientSecretRef = getCGSecretManagerRefForClientSecret(accountId, false, clientId, clientSecret);
     return new RestResponse<>(ssoService.updateSamlConfiguration(accountId, uploadedInputStream, displayName,
         groupMembershipAttr, authorizationEnabled, logoutUrl, entityIdentifier, samlProviderType, clientId,
-        isEmpty(clientSecretRef) ? null : clientSecretRef.toCharArray()));
+        isEmpty(clientSecretRef) ? null : clientSecretRef.toCharArray(), true));
   }
 
   @DELETE

--- a/400-rest/src/main/java/software/wings/service/impl/SSOSettingServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/SSOSettingServiceImpl.java
@@ -143,6 +143,18 @@ public class SSOSettingServiceImpl implements SSOSettingService {
   @Override
   @RestrictedApi(SamlFeature.class)
   public SamlSettings saveSamlSettings(@GetAccountId(SamlSettingsAccountIdExtractor.class) SamlSettings settings) {
+    return saveSSOSettingsInternal(settings);
+  }
+
+  // This function is meant to be called for ng sso settings, as the license check is already done in NG Service
+  @Override
+  public SamlSettings saveSamlSettingsWithoutCGLicenseCheck(
+      @GetAccountId(SamlSettingsAccountIdExtractor.class) SamlSettings settings) {
+    return saveSSOSettingsInternal(settings);
+  }
+
+  private SamlSettings saveSSOSettingsInternal(
+      @GetAccountId(SamlSettingsAccountIdExtractor.class) SamlSettings settings) {
     SamlSettings queriedSettings = getSamlSettingsByAccountId(settings.getAccountId());
     SamlSettings savedSettings;
     if (queriedSettings != null) {

--- a/400-rest/src/main/java/software/wings/service/intfc/SSOService.java
+++ b/400-rest/src/main/java/software/wings/service/intfc/SSOService.java
@@ -34,15 +34,15 @@ import org.hibernate.validator.constraints.NotBlank;
 @OwnedBy(HarnessTeam.PL)
 @TargetModule(HarnessModule._950_NG_AUTHENTICATION_SERVICE)
 public interface SSOService {
-  SSOConfig uploadOauthConfiguration(String accountId, String filter, Set<OauthProviderType> allowedProviders);
+  SSOConfig uploadSamlConfiguration(String accountId, InputStream inputStream, String displayName,
+                                    String groupMembershipAttr, Boolean authorizationEnabled, String logoutUrl, String entityIdentifier,
+                                    String samlProviderType, String clientId, char[] clientSecret, boolean isNGSSO);
 
-  SSOConfig uploadSamlConfiguration(@NotNull String accountId, @NotNull InputStream inputStream,
-      @NotNull String displayName, String groupMembershipAttr, @NotNull Boolean authorizationEnabled, String logoutUrl,
-      String entityIdentifier, String samlProviderType, String clientId, char[] clientSecret);
+  SSOConfig uploadOauthConfiguration(String accountId, String filter, Set<OauthProviderType> allowedProviders);
 
   SSOConfig updateSamlConfiguration(@NotNull String accountId, InputStream inputStream, String displayName,
       String groupMembershipAttr, @NotNull Boolean authorizationEnabled, String logoutUrl, String entityIdentifier,
-      String samlProviderType, String clientId, char[] clientSecret);
+      String samlProviderType, String clientId, char[] clientSecret, boolean isNGSSO);
 
   SSOConfig updateLogoutUrlSamlSettings(@NotNull String accountId, @NotNull String logoutUrl);
 

--- a/400-rest/src/main/java/software/wings/service/intfc/SSOService.java
+++ b/400-rest/src/main/java/software/wings/service/intfc/SSOService.java
@@ -35,8 +35,8 @@ import org.hibernate.validator.constraints.NotBlank;
 @TargetModule(HarnessModule._950_NG_AUTHENTICATION_SERVICE)
 public interface SSOService {
   SSOConfig uploadSamlConfiguration(String accountId, InputStream inputStream, String displayName,
-                                    String groupMembershipAttr, Boolean authorizationEnabled, String logoutUrl, String entityIdentifier,
-                                    String samlProviderType, String clientId, char[] clientSecret, boolean isNGSSO);
+      String groupMembershipAttr, Boolean authorizationEnabled, String logoutUrl, String entityIdentifier,
+      String samlProviderType, String clientId, char[] clientSecret, boolean isNGSSO);
 
   SSOConfig uploadOauthConfiguration(String accountId, String filter, Set<OauthProviderType> allowedProviders);
 

--- a/400-rest/src/main/java/software/wings/service/intfc/SSOSettingService.java
+++ b/400-rest/src/main/java/software/wings/service/intfc/SSOSettingService.java
@@ -44,7 +44,8 @@ public interface SSOSettingService extends OwnedByAccount {
   @ValidationGroups(Create.class) SamlSettings saveSamlSettings(@Valid SamlSettings settings);
 
   // This function is meant to be called for ng sso settings, as the license check is already done in NG Service
-  SamlSettings saveSamlSettingsWithoutCGLicenseCheck(@GetAccountId(SamlSettingsAccountIdExtractor.class) SamlSettings settings);
+  SamlSettings saveSamlSettingsWithoutCGLicenseCheck(
+      @GetAccountId(SamlSettingsAccountIdExtractor.class) SamlSettings settings);
 
   OauthSettings saveOauthSettings(OauthSettings settings);
 

--- a/400-rest/src/main/java/software/wings/service/intfc/SSOSettingService.java
+++ b/400-rest/src/main/java/software/wings/service/intfc/SSOSettingService.java
@@ -19,6 +19,8 @@ import software.wings.beans.sso.LdapSettings;
 import software.wings.beans.sso.OauthSettings;
 import software.wings.beans.sso.SSOSettings;
 import software.wings.beans.sso.SamlSettings;
+import software.wings.features.api.GetAccountId;
+import software.wings.features.extractors.SamlSettingsAccountIdExtractor;
 import software.wings.service.intfc.ownership.OwnedByAccount;
 
 import java.util.Iterator;
@@ -40,6 +42,9 @@ public interface SSOSettingService extends OwnedByAccount {
   OauthSettings getOauthSettingsByAccountId(String accountId);
 
   @ValidationGroups(Create.class) SamlSettings saveSamlSettings(@Valid SamlSettings settings);
+
+  // This function is meant to be called for ng sso settings, as the license check is already done in NG Service
+  SamlSettings saveSamlSettingsWithoutCGLicenseCheck(@GetAccountId(SamlSettingsAccountIdExtractor.class) SamlSettings settings);
 
   OauthSettings saveOauthSettings(OauthSettings settings);
 

--- a/400-rest/src/test/java/software/wings/service/SSOServiceTest.java
+++ b/400-rest/src/test/java/software/wings/service/SSOServiceTest.java
@@ -136,9 +136,9 @@ public class SSOServiceTest extends WingsBaseTest {
     mockSamlSettings.setDisplayName("Okta");
     when(SSO_SETTING_SERVICE.getSamlSettingsByAccountId(anyString())).thenReturn(mockSamlSettings);
 
-    SSOConfig settings =
-        ssoService.uploadSamlConfiguration(account.getUuid(), getClass().getResourceAsStream("/okta-IDP-metadata.xml"),
-            "Okta", "group", true, logoutUrl, "app.harness.io", SAMLProviderType.OKTA.name(), anyString(), any());
+    SSOConfig settings = ssoService.uploadSamlConfiguration(account.getUuid(),
+        getClass().getResourceAsStream("/okta-IDP-metadata.xml"), "Okta", "group", true, logoutUrl, "app.harness.io",
+        SAMLProviderType.OKTA.name(), anyString(), any(), false);
     String idpRedirectUrl = ((SamlSettings) settings.getSsoSettings().get(0)).getUrl();
     assertThat(idpRedirectUrl)
         .isEqualTo("https://dev-274703.oktapreview.com/app/harnessiodev274703_testapp_1/exkefa5xlgHhrU1Mc0h7/sso/saml");
@@ -146,7 +146,7 @@ public class SSOServiceTest extends WingsBaseTest {
 
     try {
       ssoService.uploadSamlConfiguration(account.getUuid(), getClass().getResourceAsStream("/SamlResponse.txt"), "Okta",
-          "group", true, logoutUrl, "app.harness.io", SAMLProviderType.OKTA.name(), anyString(), any());
+          "group", true, logoutUrl, "app.harness.io", SAMLProviderType.OKTA.name(), anyString(), any(), false);
       failBecauseExceptionWasNotThrown(WingsException.class);
     } catch (WingsException e) {
       assertThat(e.getMessage()).isEqualTo(ErrorCode.INVALID_SAML_CONFIGURATION.name());

--- a/400-rest/src/test/java/software/wings/service/impl/SSOServiceImplTest.java
+++ b/400-rest/src/test/java/software/wings/service/impl/SSOServiceImplTest.java
@@ -170,7 +170,7 @@ public class SSOServiceImplTest extends WingsBaseTest {
 
     // Upload SAML config and enable
     ssoService.uploadSamlConfiguration(accountId, new ByteArrayInputStream("test data".getBytes()), "test", "", false,
-        "", "", SAMLProviderType.ONELOGIN.name(), anyString(), any());
+        "", "", SAMLProviderType.ONELOGIN.name(), anyString(), any(), false);
     ssoService.setAuthenticationMechanism(accountId, SAML);
     account = accountService.get(account.getUuid());
     assertThat(account.getAuthenticationMechanism()).isEqualTo(SAML);
@@ -206,7 +206,7 @@ public class SSOServiceImplTest extends WingsBaseTest {
 
     // Upload SAML config and enable
     ssoService.uploadSamlConfiguration(accountId, new ByteArrayInputStream("test data".getBytes()), "test", "", false,
-        "", "", SAMLProviderType.ONELOGIN.name(), anyString(), any());
+        "", "", SAMLProviderType.ONELOGIN.name(), anyString(), any(), false);
     ssoService.setAuthenticationMechanism(accountId, SAML);
     account = accountService.get(account.getUuid());
     assertThat(account.getAuthenticationMechanism()).isEqualTo(SAML);

--- a/940-feature-flag/src/main/java/io/harness/ff/FeatureFlagServiceImpl.java
+++ b/940-feature-flag/src/main/java/io/harness/ff/FeatureFlagServiceImpl.java
@@ -206,7 +206,7 @@ public class FeatureFlagServiceImpl implements FeatureFlagService {
   }
 
   @Override
-  public boolean isEnabled(@NonNull FeatureName featureName, String accountId) {
+  public boolean  isEnabled(@NonNull FeatureName featureName, String accountId) {
     switch (featureFlagConfig.getFeatureFlagSystem()) {
       case CF:
         return cfFeatureFlagEvaluation(featureName, accountId);
@@ -252,7 +252,7 @@ public class FeatureFlagServiceImpl implements FeatureFlagService {
             return featureValue;
           }
           featureValue = featureFlag.getAccountIds().contains(accountId);
-          return featureValue;
+          return featureValue && featureFlag.isEnabled();
         }
       } finally {
         cfMigrationService.verifyBehaviorWithCF(featureName, featureValue, accountId);

--- a/940-feature-flag/src/test/java/io/harness/ff/FeatureFlagServiceTest.java
+++ b/940-feature-flag/src/test/java/io/harness/ff/FeatureFlagServiceTest.java
@@ -100,10 +100,10 @@ public class FeatureFlagServiceTest extends FeatureFlagTestBase {
   public void testIsEnabled_WhenAccountIdIsGivenAndFeatureFlagIsOff() {
     String accountId = "accountId";
     FeatureFlag featureFlag = FeatureFlag.builder()
-            .name(SEARCH_REQUEST.name())
-            .enabled(false)
-            .accountIds(new HashSet<>(Arrays.asList(accountId)))
-            .build();
+                                  .name(SEARCH_REQUEST.name())
+                                  .enabled(false)
+                                  .accountIds(new HashSet<>(Arrays.asList(accountId)))
+                                  .build();
     persistence.save(featureFlag);
     boolean featureFlagEnabled = featureFlagService.isEnabled(SEARCH_REQUEST, accountId);
     assertThat(featureFlagEnabled).isFalse();

--- a/940-feature-flag/src/test/java/io/harness/ff/FeatureFlagServiceTest.java
+++ b/940-feature-flag/src/test/java/io/harness/ff/FeatureFlagServiceTest.java
@@ -10,10 +10,7 @@ package io.harness.ff;
 import static io.harness.beans.FeatureName.CV_DEMO;
 import static io.harness.beans.FeatureName.GLOBAL_DISABLE_HEALTH_CHECK;
 import static io.harness.beans.FeatureName.SEARCH_REQUEST;
-import static io.harness.rule.OwnerRule.NANDAN;
-import static io.harness.rule.OwnerRule.PHOENIKX;
-import static io.harness.rule.OwnerRule.UTKARSH;
-import static io.harness.rule.OwnerRule.VIKAS;
+import static io.harness.rule.OwnerRule.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,11 +26,7 @@ import io.harness.rule.Owner;
 
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import org.junit.Before;
@@ -84,6 +77,36 @@ public class FeatureFlagServiceTest extends FeatureFlagTestBase {
     persistence.save(featureFlag);
     boolean featureFlagEnabled = featureFlagService.isEnabled(SEARCH_REQUEST, null);
     assertThat(featureFlagEnabled).isTrue();
+  }
+
+  @Test
+  @Owner(developers = DEEPAK)
+  @Category(UnitTests.class)
+  public void testIsEnabled_WhenAccountIdIsGiven() {
+    String accountId = "accountId";
+    FeatureFlag featureFlag = FeatureFlag.builder()
+                                  .name(SEARCH_REQUEST.name())
+                                  .enabled(true)
+                                  .accountIds(new HashSet<>(Arrays.asList(accountId)))
+                                  .build();
+    persistence.save(featureFlag);
+    boolean featureFlagEnabled = featureFlagService.isEnabled(SEARCH_REQUEST, accountId);
+    assertThat(featureFlagEnabled).isTrue();
+  }
+
+  @Test
+  @Owner(developers = DEEPAK)
+  @Category(UnitTests.class)
+  public void testIsEnabled_WhenAccountIdIsGivenAndFeatureFlagIsOff() {
+    String accountId = "accountId";
+    FeatureFlag featureFlag = FeatureFlag.builder()
+            .name(SEARCH_REQUEST.name())
+            .enabled(false)
+            .accountIds(new HashSet<>(Arrays.asList(accountId)))
+            .build();
+    persistence.save(featureFlag);
+    boolean featureFlagEnabled = featureFlagService.isEnabled(SEARCH_REQUEST, accountId);
+    assertThat(featureFlagEnabled).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions