### PR TITLE
[fix]: [PL-26379]: The feature flag was coming as enabled even when it was disabled 

### DIFF
--- a/940-feature-flag/src/main/java/io/harness/ff/FeatureFlagServiceImpl.java
+++ b/940-feature-flag/src/main/java/io/harness/ff/FeatureFlagServiceImpl.java
@@ -206,7 +206,7 @@ public class FeatureFlagServiceImpl implements FeatureFlagService {
   }
 
   @Override
-  public boolean  isEnabled(@NonNull FeatureName featureName, String accountId) {
+  public boolean isEnabled(@NonNull FeatureName featureName, String accountId) {
     switch (featureFlagConfig.getFeatureFlagSystem()) {
       case CF:
         return cfFeatureFlagEvaluation(featureName, accountId);
@@ -252,7 +252,10 @@ public class FeatureFlagServiceImpl implements FeatureFlagService {
             return featureValue;
           }
           featureValue = featureFlag.getAccountIds().contains(accountId);
-          return featureValue && featureFlag.isEnabled();
+          if (!featureFlag.isEnabled()) {
+            return false;
+          }
+          return featureValue;
         }
       } finally {
         cfMigrationService.verifyBehaviorWithCF(featureName, featureValue, accountId);

--- a/940-feature-flag/src/main/java/io/harness/ff/FeatureFlagServiceImpl.java
+++ b/940-feature-flag/src/main/java/io/harness/ff/FeatureFlagServiceImpl.java
@@ -206,7 +206,7 @@ public class FeatureFlagServiceImpl implements FeatureFlagService {
   }
 
   @Override
-  public boolean isEnabled(@NonNull FeatureName featureName, String accountId) {
+  public boolean  isEnabled(@NonNull FeatureName featureName, String accountId) {
     switch (featureFlagConfig.getFeatureFlagSystem()) {
       case CF:
         return cfFeatureFlagEvaluation(featureName, accountId);
@@ -252,7 +252,7 @@ public class FeatureFlagServiceImpl implements FeatureFlagService {
             return featureValue;
           }
           featureValue = featureFlag.getAccountIds().contains(accountId);
-          return featureValue;
+          return featureValue && featureFlag.isEnabled();
         }
       } finally {
         cfMigrationService.verifyBehaviorWithCF(featureName, featureValue, accountId);

--- a/940-feature-flag/src/test/java/io/harness/ff/FeatureFlagServiceTest.java
+++ b/940-feature-flag/src/test/java/io/harness/ff/FeatureFlagServiceTest.java
@@ -10,10 +10,7 @@ package io.harness.ff;
 import static io.harness.beans.FeatureName.CV_DEMO;
 import static io.harness.beans.FeatureName.GLOBAL_DISABLE_HEALTH_CHECK;
 import static io.harness.beans.FeatureName.SEARCH_REQUEST;
-import static io.harness.rule.OwnerRule.NANDAN;
-import static io.harness.rule.OwnerRule.PHOENIKX;
-import static io.harness.rule.OwnerRule.UTKARSH;
-import static io.harness.rule.OwnerRule.VIKAS;
+import static io.harness.rule.OwnerRule.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,11 +26,7 @@ import io.harness.rule.Owner;
 
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import org.junit.Before;
@@ -84,6 +77,36 @@ public class FeatureFlagServiceTest extends FeatureFlagTestBase {
     persistence.save(featureFlag);
     boolean featureFlagEnabled = featureFlagService.isEnabled(SEARCH_REQUEST, null);
     assertThat(featureFlagEnabled).isTrue();
+  }
+
+  @Test
+  @Owner(developers = DEEPAK)
+  @Category(UnitTests.class)
+  public void testIsEnabled_WhenAccountIdIsGiven() {
+    String accountId = "accountId";
+    FeatureFlag featureFlag = FeatureFlag.builder()
+                                  .name(SEARCH_REQUEST.name())
+                                  .enabled(true)
+                                  .accountIds(new HashSet<>(Arrays.asList(accountId)))
+                                  .build();
+    persistence.save(featureFlag);
+    boolean featureFlagEnabled = featureFlagService.isEnabled(SEARCH_REQUEST, accountId);
+    assertThat(featureFlagEnabled).isTrue();
+  }
+
+  @Test
+  @Owner(developers = DEEPAK)
+  @Category(UnitTests.class)
+  public void testIsEnabled_WhenAccountIdIsGivenAndFeatureFlagIsOff() {
+    String accountId = "accountId";
+    FeatureFlag featureFlag = FeatureFlag.builder()
+            .name(SEARCH_REQUEST.name())
+            .enabled(false)
+            .accountIds(new HashSet<>(Arrays.asList(accountId)))
+            .build();
+    persistence.save(featureFlag);
+    boolean featureFlagEnabled = featureFlagService.isEnabled(SEARCH_REQUEST, accountId);
+    assertThat(featureFlagEnabled).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/35223)
<!-- Reviewable:end -->
