### PR TITLE
[fix]: [CCM-8233]: Increased watcher creation retry count and Reset watcher count while deleting it

### DIFF
--- a/260-delegate/src/main/java/io/harness/perpetualtask/k8s/watch/NodeWatcher.java
+++ b/260-delegate/src/main/java/io/harness/perpetualtask/k8s/watch/NodeWatcher.java
@@ -36,6 +36,7 @@ import io.kubernetes.client.openapi.models.V1NodeList;
 import io.kubernetes.client.util.CallGeneratorParams;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import lombok.extern.slf4j.Slf4j;
@@ -84,7 +85,8 @@ public class NodeWatcher implements ResourceEventHandler<V1Node> {
                 -> {
               log.info("Node watcher :: Resource version: {}, timeoutSeconds: {}, watch: {}",
                   callGeneratorParams.resourceVersion, callGeneratorParams.timeoutSeconds, callGeneratorParams.watch);
-              if (!"0".equals(callGeneratorParams.resourceVersion)) {
+              if (!"0".equals(callGeneratorParams.resourceVersion)
+                  && Objects.nonNull(callGeneratorParams.timeoutSeconds)) {
                 K8sWatcherHelper.updateLastSeen(
                     String.format(K8sWatcherHelper.NODE_WATCHER_PREFIX, clusterId), Instant.now());
               }

--- a/260-delegate/src/main/java/io/harness/perpetualtask/k8s/watch/PVWatcher.java
+++ b/260-delegate/src/main/java/io/harness/perpetualtask/k8s/watch/PVWatcher.java
@@ -44,6 +44,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.TimeUnit;
@@ -105,7 +106,8 @@ public class PVWatcher implements ResourceEventHandler<V1PersistentVolume> {
                 -> {
               log.info("PV watcher :: Resource version: {}, timeoutSeconds: {}, watch: {}",
                   callGeneratorParams.resourceVersion, callGeneratorParams.timeoutSeconds, callGeneratorParams.watch);
-              if (!"0".equals(callGeneratorParams.resourceVersion)) {
+              if (!"0".equals(callGeneratorParams.resourceVersion)
+                  && Objects.nonNull(callGeneratorParams.timeoutSeconds)) {
                 K8sWatcherHelper.updateLastSeen(
                     String.format(K8sWatcherHelper.PV_WATCHER_PREFIX, clusterId), Instant.now());
               }

--- a/260-delegate/src/main/java/io/harness/perpetualtask/k8s/watch/PodWatcher.java
+++ b/260-delegate/src/main/java/io/harness/perpetualtask/k8s/watch/PodWatcher.java
@@ -54,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import lombok.extern.slf4j.Slf4j;
@@ -114,7 +115,8 @@ public class PodWatcher implements ResourceEventHandler<V1Pod> {
                 -> {
               log.info("Pod watcher :: Resource version: {}, timeoutSeconds: {}, watch: {}",
                   callGeneratorParams.resourceVersion, callGeneratorParams.timeoutSeconds, callGeneratorParams.watch);
-              if (!"0".equals(callGeneratorParams.resourceVersion)) {
+              if (!"0".equals(callGeneratorParams.resourceVersion)
+                  && Objects.nonNull(callGeneratorParams.timeoutSeconds)) {
                 K8sWatcherHelper.updateLastSeen(
                     String.format(K8sWatcherHelper.POD_WATCHER_PREFIX, clusterId), Instant.now());
               }

--- a/930-delegate-tasks/src/main/java/io/harness/perpetualtask/k8s/utils/K8sWatcherHelper.java
+++ b/930-delegate-tasks/src/main/java/io/harness/perpetualtask/k8s/utils/K8sWatcherHelper.java
@@ -45,6 +45,7 @@ public class K8sWatcherHelper {
         && WATCHER_ID_COUNT.getOrDefault(watchId, 0) < WATCHER_CREATION_MAX_COUNT;
     if (shouldCreateWatcher) {
       WATCHER_ID_COUNT.put(watchId, WATCHER_ID_COUNT.getOrDefault(watchId, 0) + 1);
+      log.info("Count of watcher id {}: {}", watchId, WATCHER_ID_COUNT.get(watchId));
     }
     return shouldCreateWatcher;
   }
@@ -72,6 +73,8 @@ public class K8sWatcherHelper {
     deleteWatcher(watchId, POD_WATCHER_PREFIX);
     deleteWatcher(watchId, NODE_WATCHER_PREFIX);
     deleteWatcher(watchId, PV_WATCHER_PREFIX);
+    WATCHER_ID_COUNT.remove(watchId);
+    log.info("Removed/Deleted watcher id: {}", watchId);
   }
 
   private static void deleteWatcher(@NonNull final String watchId, @NonNull final String prefix) {

--- a/930-delegate-tasks/src/main/java/io/harness/perpetualtask/k8s/utils/K8sWatcherHelper.java
+++ b/930-delegate-tasks/src/main/java/io/harness/perpetualtask/k8s/utils/K8sWatcherHelper.java
@@ -28,7 +28,7 @@ public class K8sWatcherHelper {
   public static final String NODE_WATCHER_PREFIX = "NodeWatcher-%s";
   public static final String PV_WATCHER_PREFIX = "PVWatcher-%s";
   private static final long WAIT_TIME = Duration.ofMinutes(20).getSeconds();
-  private static final int WATCHER_CREATION_MAX_COUNT = 2;
+  private static final int WATCHER_CREATION_MAX_COUNT = 4;
   private static final Map<String, Instant> WATCHER_ID_LAST_SEEN = new ConcurrentHashMap<>();
   private static final Map<String, Integer> WATCHER_ID_COUNT = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
## Describe your changes
- Increased watcher creation retry count
- Reset watcher id count while deleting it
- Added nonNull conditions on `timeoutSeconds` to verify if API is failing or not.

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [x] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/35748)
<!-- Reviewable:end -->
