### PR TITLE
[fix]: [CCM-8404]: Moving new scheduler jobs to us-east1 as a temporary fix

### DIFF
--- a/scripts/terraform/cloudfunctions/ce/src/python/gcp_inventory_init_main.py
+++ b/scripts/terraform/cloudfunctions/ce/src/python/gcp_inventory_init_main.py
@@ -23,7 +23,8 @@ PROJECTID = os.environ.get('GCP_PROJECT', 'ccm-play')
 INVENTORY_TYPE = ["disk", "instance"]
 sc_client = scheduler.CloudSchedulerClient()
 publisher = pubsub_v1.PublisherClient()
-parent = f"projects/{PROJECTID}/locations/us-central1"
+regions = ["us-central1", "us-east1"]
+parent = None
 
 
 def main(event, context):
@@ -65,10 +66,31 @@ def delete_job(name):
 
 
 def manage_scheduler_jobs(event_json):
+    global parent
     for event in event_json:
         for inventory_type in INVENTORY_TYPE:
+            for region in regions:
+                possible_parent = f"projects/{PROJECTID}/locations/{region}"
+                try:
+                    request = scheduler.GetJobRequest(
+                        name=f"{possible_parent}/jobs/ce-gcp-%s-data-%s" % (inventory_type, event["accountId"])
+                    )
+                    response = sc_client.get_job(request=request)
+                    parent = possible_parent
+                    print(f"Cloud Scheduler ce-gcp-%s-data-%s already exists in {region}. Using it." % (inventory_type, event["accountId"]))
+                    break
+                except Exception as e:
+                    print(e)
+                    # job was not found in this region
+            print(f"parent: {parent}")
+            if not parent:
+                # job was not found in any region, update region to any region whose quota is not exhausted: us-east1
+                print(f"Cloud Scheduler ce-gcp-%s-data-%s not found in any region. Using us-east1 region for this scheduler." % (inventory_type, event["accountId"]))
+                parent = f"projects/{PROJECTID}/locations/us-east1"
+
             manage_inventory_data_scheduler_job(event, inventory_type)
             manage_inventory_data_load_scheduler_job(event, inventory_type)
+            parent = None
 
 
 def manage_inventory_data_scheduler_job(event, inventory_type):


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions