### PR TITLE
fix: [CDS-41026]: separating client tools according to manifest and store types

### DIFF
--- a/260-delegate/src/main/java/software/wings/delegatetasks/k8s/K8sTask.java
+++ b/260-delegate/src/main/java/software/wings/delegatetasks/k8s/K8sTask.java
@@ -13,6 +13,9 @@ import static io.harness.data.structure.UUIDGenerator.generateUuid;
 import static io.harness.filesystem.FileIo.createDirectoryIfDoesNotExist;
 import static io.harness.filesystem.FileIo.deleteDirectoryAndItsContentIfExists;
 import static io.harness.filesystem.FileIo.waitForDirectoryToBeAccessibleOutOfProcess;
+import static io.harness.govern.Switch.unhandled;
+
+import static java.util.Objects.isNull;
 
 import io.harness.annotations.dev.HarnessModule;
 import io.harness.annotations.dev.OwnedBy;
@@ -154,27 +157,30 @@ public class K8sTask extends AbstractDelegateRunnableTask {
             .kubeconfigPath(K8sConstants.KUBECONFIG_FILENAME)
             .workingDirectory(workingDirectory);
 
-    switch (storeType) {
-      case Local:
-      case Remote:
-      case CUSTOM:
-        k8sDelegateTaskParamsBuilder.goTemplateClientPath(k8sGlobalConfigService.getGoTemplateClientPath());
-        break;
+    if (!isNull(storeType)) {
+      switch (storeType) {
+        case Local:
+        case Remote:
+        case CUSTOM:
+          k8sDelegateTaskParamsBuilder.goTemplateClientPath(k8sGlobalConfigService.getGoTemplateClientPath());
+          break;
 
-      case HelmChartRepo:
-      case HelmSourceRepo:
-        k8sDelegateTaskParamsBuilder.helmPath(k8sGlobalConfigService.getHelmPath(helmVersion));
-        break;
-      case KustomizeSourceRepo:
-        k8sDelegateTaskParamsBuilder
-            .kustomizeBinaryPath(k8sGlobalConfigService.getKustomizePath(isUseLatestKustomizeVersion))
-            .useLatestKustomizeVersion(isUseLatestKustomizeVersion);
-        break;
-      case OC_TEMPLATES:
-      case CUSTOM_OPENSHIFT_TEMPLATE:
-      case VALUES_YAML_FROM_HELM_REPO:
-      default:
-        break;
+        case HelmChartRepo:
+        case HelmSourceRepo:
+          k8sDelegateTaskParamsBuilder.helmPath(k8sGlobalConfigService.getHelmPath(helmVersion));
+          break;
+        case KustomizeSourceRepo:
+          k8sDelegateTaskParamsBuilder
+              .kustomizeBinaryPath(k8sGlobalConfigService.getKustomizePath(isUseLatestKustomizeVersion))
+              .useLatestKustomizeVersion(isUseLatestKustomizeVersion);
+          break;
+        case OC_TEMPLATES:
+        case CUSTOM_OPENSHIFT_TEMPLATE:
+        case VALUES_YAML_FROM_HELM_REPO:
+          break;
+        default:
+          unhandled(storeType);
+      }
     }
     return k8sDelegateTaskParamsBuilder.build();
   }

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/k8s/K8sTaskNG.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/k8s/K8sTaskNG.java
@@ -14,6 +14,8 @@ import static io.harness.filesystem.FileIo.createDirectoryIfDoesNotExist;
 import static io.harness.filesystem.FileIo.deleteDirectoryAndItsContentIfExists;
 import static io.harness.filesystem.FileIo.waitForDirectoryToBeAccessibleOutOfProcess;
 
+import static java.util.Objects.isNull;
+
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.delegate.beans.DelegateTaskPackage;
 import io.harness.delegate.beans.DelegateTaskResponse;
@@ -179,7 +181,7 @@ public class K8sTaskNG extends AbstractDelegateRunnableTask {
     return true;
   }
 
-  private K8sDelegateTaskParams getK8sDelegateTaskParamsBasedOnManifestType(String workingDirectory,
+  public K8sDelegateTaskParams getK8sDelegateTaskParamsBasedOnManifestType(String workingDirectory,
       HelmVersion helmVersion, boolean isUseNewKubectlVersion, boolean isUseLatestKustomizeVersion,
       ManifestType manifestType) {
     K8sDelegateTaskParams.K8sDelegateTaskParamsBuilder k8sDelegateTaskParamsBuilder =
@@ -189,26 +191,28 @@ public class K8sTaskNG extends AbstractDelegateRunnableTask {
             .kubeconfigPath(KUBECONFIG_FILENAME)
             .workingDirectory(workingDirectory);
 
-    switch (manifestType) {
-      case K8S_MANIFEST:
-        k8sDelegateTaskParamsBuilder.goTemplateClientPath(k8sGlobalConfigService.getGoTemplateClientPath());
-        break;
+    if (!isNull(manifestType)) {
+      switch (manifestType) {
+        case K8S_MANIFEST:
+          k8sDelegateTaskParamsBuilder.goTemplateClientPath(k8sGlobalConfigService.getGoTemplateClientPath());
+          break;
 
-      case HELM_CHART:
-        k8sDelegateTaskParamsBuilder.helmPath(k8sGlobalConfigService.getHelmPath(helmVersion));
-        break;
+        case HELM_CHART:
+          k8sDelegateTaskParamsBuilder.helmPath(k8sGlobalConfigService.getHelmPath(helmVersion));
+          break;
 
-      case OPENSHIFT_TEMPLATE:
-        break;
+        case OPENSHIFT_TEMPLATE:
+          break;
 
-      case KUSTOMIZE:
-        k8sDelegateTaskParamsBuilder.kustomizeBinaryPath(
-            k8sGlobalConfigService.getKustomizePath(isUseLatestKustomizeVersion));
-        break;
+        case KUSTOMIZE:
+          k8sDelegateTaskParamsBuilder.kustomizeBinaryPath(
+              k8sGlobalConfigService.getKustomizePath(isUseLatestKustomizeVersion));
+          break;
 
-      default:
-        throw new UnsupportedOperationException(
-            String.format("Manifest delegate config type: [%s]", manifestType.name()));
+        default:
+          throw new UnsupportedOperationException(
+              String.format("Manifest delegate config type: [%s]", manifestType.name()));
+      }
     }
     return k8sDelegateTaskParamsBuilder.build();
   }

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/k8s/K8sTaskNGTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/k8s/K8sTaskNGTest.java
@@ -234,7 +234,10 @@ public class K8sTaskNGTest extends CategoryTest {
         .when(rollingRequestHandler)
         .executeTask(eq(k8sDeployRequest), any(K8sDelegateTaskParams.class), eq(logStreamingTaskClient),
             eq(emptyCommandUnitsProgress));
-
+    doReturn(null)
+        .doReturn(K8sManifestDelegateConfig.builder().build())
+        .when(k8sDeployRequest)
+        .getManifestDelegateConfig();
     K8sDeployResponse result = k8sTaskNG.run(k8sDeployRequest);
 
     verify(rollingRequestHandler)
@@ -311,7 +314,6 @@ public class K8sTaskNGTest extends CategoryTest {
                     .build())
             .helmVersion(HelmVersion.V3)
             .build();
-
     testRunWithManifest(manifestConfig, HelmVersion.V3);
 
     verify(decryptionService).decrypt(manualConfigSpecDTO, encryptedDataDetails);
@@ -335,7 +337,6 @@ public class K8sTaskNGTest extends CategoryTest {
                     .build())
             .helmVersion(HelmVersion.V3)
             .build();
-
     testRunWithManifest(manifestConfig, HelmVersion.V3);
 
     verify(decryptionService, never()).decrypt(any(DecryptableEntity.class), eq(encryptedDataDetails));
@@ -406,6 +407,11 @@ public class K8sTaskNGTest extends CategoryTest {
         .when(rollingRequestHandler)
         .executeTask(eq(k8sDeployRequest), any(K8sDelegateTaskParams.class), eq(logStreamingTaskClient),
             eq(emptyCommandUnitsProgress));
+    ;
+    doReturn(manifest)
+        .doReturn(manifest == null ? K8sManifestDelegateConfig.builder().build() : manifest)
+        .when(k8sDeployRequest)
+        .getManifestDelegateConfig();
 
     Reflect.on(manifestDelegateConfigHelper).set("gitDecryptionHelper", gitDecryptionHelper);
     Reflect.on(manifestDelegateConfigHelper).set("decryptionService", decryptionService);
@@ -420,7 +426,7 @@ public class K8sTaskNGTest extends CategoryTest {
 
     K8sDelegateTaskParams k8sDelegateTaskParams = delegateTaskParamsCaptor.getValue();
     assertCleanupWorkingDirectory(k8sDelegateTaskParams);
-    assertClientPaths(k8sDelegateTaskParams, usedHelmVersion);
+    assertClientPaths(manifest, k8sDelegateTaskParams, usedHelmVersion);
     assertThat(result).isEqualTo(taskResponse);
   }
 
@@ -433,18 +439,27 @@ public class K8sTaskNGTest extends CategoryTest {
     }
   }
 
-  private void assertClientPaths(K8sDelegateTaskParams delegateTaskParams, HelmVersion helmVersion) {
+  private void assertClientPaths(
+      ManifestDelegateConfig manifest, K8sDelegateTaskParams delegateTaskParams, HelmVersion helmVersion) {
     assertThat(delegateTaskParams.getKubeconfigPath()).isEqualTo(KUBECONFIG_FILENAME);
     assertThat(delegateTaskParams.getKubectlPath()).isEqualTo(kubectlPath);
-    assertThat(delegateTaskParams.getGoTemplateClientPath()).isEqualTo(goTemplateClientPath);
     assertThat(delegateTaskParams.getOcPath()).isEqualTo(ocPath);
-    assertThat(delegateTaskParams.getKustomizeBinaryPath()).isEqualTo(kustomizePath);
-    if (null == helmVersion) {
-      assertThat(delegateTaskParams.getHelmPath()).isNull();
-    } else if (HelmVersion.V2 == helmVersion) {
-      assertThat(delegateTaskParams.getHelmPath()).isEqualTo(helmV2Path);
-    } else if (HelmVersion.V3 == helmVersion) {
-      assertThat(delegateTaskParams.getHelmPath()).isEqualTo(helmV3Path);
+    if (manifest != null) {
+      if (manifest.getManifestType().equals(ManifestType.K8S_MANIFEST)) {
+        assertThat(delegateTaskParams.getGoTemplateClientPath()).isEqualTo(goTemplateClientPath);
+      }
+      if (manifest.getManifestType().equals(ManifestType.HELM_CHART)) {
+        if (null == helmVersion) {
+          assertThat(delegateTaskParams.getHelmPath()).isNull();
+        } else if (HelmVersion.V2 == helmVersion) {
+          assertThat(delegateTaskParams.getHelmPath()).isEqualTo(helmV2Path);
+        } else if (HelmVersion.V3 == helmVersion) {
+          assertThat(delegateTaskParams.getHelmPath()).isEqualTo(helmV3Path);
+        }
+      }
+      if (manifest.getManifestType().equals(ManifestType.KUSTOMIZE)) {
+        assertThat(delegateTaskParams.getKustomizeBinaryPath()).isEqualTo(kustomizePath);
+      }
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/35801)
<!-- Reviewable:end -->
