### PR TITLE
fix:[BT-1643]:Get affected projects from git log

### DIFF
--- a/scripts/jenkins/release-branch-create-versions.sh
+++ b/scripts/jenkins/release-branch-create-versions.sh
@@ -18,7 +18,8 @@ PROJFILE="$SHDIR/jira-projects.txt"
 check_file_present $PROJFILE
 # Read contents of file into PROJECTS
 PROJECTS=$(<$PROJFILE)
-IFS="|" read -r -a PROJSPLIT <<< "${PROJECTS}"
+KEYPROJS=$(git log --pretty=oneline --abbrev-commit | awk "1;/Branching to release\//{exit}" | grep -o -iE '('${PROJECTS}')' | tr '[:lower:]' '[:upper:]' | sort | uniq)
+# IFS="|" read -r -a PROJSPLIT <<< "${PROJECTS}"
 # Set the release date of the version to the date that the build is being done.
 RELDATE=$(date +'%Y-%m-%d')
 # Set the next version number - this will be something like 1.23.5-704219
@@ -39,7 +40,7 @@ echo "Creating $NEXT_VERSION in product Jira projects"
 # Exclude projects that have been archived, replaced, deleted, or non-product
 EXCLUDE_PROJECTS=",ART,CCE,CDC,CDNG,CDP,CE,COMP,CV,CVNG,CVS,DX,ER,GIT,GTM,LWG,OENG,ONP,OPS,SEC,SWAT,"
 # Iterate over projects
-for PROJ in ${PROJSPLIT[@]}
+for PROJ in ${KEYPROJS}
  do
     if [[ $EXCLUDE_PROJECTS == *",$PROJ,"* ]]; then
       echo "Skipping $PROJ - it has been archived or is not applicable"


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions