### PR TITLE
fix: [DEL-4613]: Remove DelegateAuth2 from api/version/watcher api call

### DIFF
--- a/400-rest/src/main/java/software/wings/resources/DelegateVersionInfoResource.java
+++ b/400-rest/src/main/java/software/wings/resources/DelegateVersionInfoResource.java
@@ -11,7 +11,7 @@ import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
 
 import io.harness.exception.InvalidRequestException;
 import io.harness.rest.RestResponse;
-import io.harness.security.annotations.DelegateAuth2;
+import io.harness.security.annotations.DelegateAuth;
 
 import software.wings.service.intfc.AccountService;
 
@@ -39,7 +39,7 @@ public class DelegateVersionInfoResource {
   @Path("/delegate")
   @Timed
   @ExceptionMetered
-  @DelegateAuth2
+  @DelegateAuth
   public RestResponse<List<String>> getDelegateVersion(@QueryParam("accountId") @NotEmpty String accountId) {
     return new RestResponse<>(accountService.getDelegateConfiguration(accountId).getDelegateVersions());
   }
@@ -48,7 +48,7 @@ public class DelegateVersionInfoResource {
   @Path("/watcher")
   @Timed
   @ExceptionMetered
-  @DelegateAuth2
+  @DelegateAuth
   public RestResponse<String> getWatcherVersion(@QueryParam("accountId") @NotEmpty String accountId) {
     final String watcherVersion = accountService.getWatcherVersion(accountId);
     if (isNotEmpty(watcherVersion)) {

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=76130
+build.number=76131
 build.patch=000
 delegate.version=22.07.12
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes
We are seeing unauthorized access errors in manager logs while making api/version/watcher api call from delegate.
As a temporary workaround we are removing DelegateAuth2 from these APIs

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/36203)
<!-- Reviewable:end -->
