### PR TITLE
feat: [DEL-4649]: Add 'mtls' flag to delegate during registration to mark mTLS delegates

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
@@ -1010,6 +1010,8 @@ public class DelegateServiceImpl implements DelegateService {
       setUnset(updateOperations, DelegateKeys.delegateTokenName, delegate.getDelegateTokenName());
     }
     setUnset(updateOperations, DelegateKeys.heartbeatAsObject, delegate.isHeartbeatAsObject());
+    setUnset(updateOperations, DelegateKeys.mtls, delegate.isMtls());
+
     return updateOperations;
   }
 
@@ -2576,7 +2578,7 @@ public class DelegateServiceImpl implements DelegateService {
   }
 
   @Override
-  public DelegateRegisterResponse register(final DelegateParams delegateParams) {
+  public DelegateRegisterResponse register(final DelegateParams delegateParams, final boolean isConnectedUsingMtls) {
     if (licenseService.isAccountDeleted(delegateParams.getAccountId())) {
       delegateMetricsService.recordDelegateMetrics(
           Delegate.builder().accountId(delegateParams.getAccountId()).version(delegateParams.getVersion()).build(),
@@ -2706,6 +2708,7 @@ public class DelegateServiceImpl implements DelegateService {
                                   .delegateTokenName(delegateTokenName.orElse(null))
                                   .heartbeatAsObject(delegateParams.isHeartbeatAsObject())
                                   .immutable(delegateParams.isImmutable())
+                                  .mtls(isConnectedUsingMtls)
                                   .build();
 
     if (ECS.equals(delegateParams.getDelegateType())) {

--- a/400-rest/src/main/java/software/wings/service/intfc/DelegateService.java
+++ b/400-rest/src/main/java/software/wings/service/intfc/DelegateService.java
@@ -135,7 +135,7 @@ public interface DelegateService extends OwnedByAccount {
 
   DelegateRegisterResponse register(@Valid Delegate delegate);
 
-  DelegateRegisterResponse register(@Valid DelegateParams delegateParams);
+  DelegateRegisterResponse register(@Valid DelegateParams delegateParams, boolean isConnectedUsingMtls);
 
   void unregister(String accountId, DelegateUnregisterRequest request);
 

--- a/400-rest/src/test/java/software/wings/resources/DelegateAgentResourceTest.java
+++ b/400-rest/src/test/java/software/wings/resources/DelegateAgentResourceTest.java
@@ -233,7 +233,7 @@ public class DelegateAgentResourceTest extends CategoryTest {
   @Category(UnitTests.class)
   public void shouldRegisterDelegate() {
     DelegateRegisterResponse registerResponse = DelegateRegisterResponse.builder().delegateId(ID_KEY).build();
-    when(delegateService.register(any(DelegateParams.class))).thenReturn(registerResponse);
+    when(delegateService.register(any(DelegateParams.class), any(boolean.class))).thenReturn(registerResponse);
     RestResponse<DelegateRegisterResponse> restResponse =
         RESOURCES.client()
             .target("/agent/delegates/register?accountId=" + ACCOUNT_ID)

--- a/400-rest/src/test/java/software/wings/service/delegate/DelegateServiceTest.java
+++ b/400-rest/src/test/java/software/wings/service/delegate/DelegateServiceTest.java
@@ -1376,6 +1376,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     String accountId = generateUuid();
     Delegate delegate = createDelegateBuilder().build();
     delegate.setAccountId(accountId);
+    delegate.setMtls(true);
     DelegateProfile primaryDelegateProfile =
         createDelegateProfileBuilder().accountId(delegate.getAccountId()).primary(true).build();
 
@@ -1388,6 +1389,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     delegateService.register(delegate);
     Delegate registeredDelegate = delegateCache.get(accountId, delegate.getUuid(), true);
     assertThat(registeredDelegate).isEqualToIgnoringGivenFields(delegate, DelegateKeys.validUntil);
+    assertThat(registeredDelegate.isMtls()).isTrue();
   }
 
   @Test

--- a/400-rest/src/test/java/software/wings/service/delegate/DelegateServiceTest.java
+++ b/400-rest/src/test/java/software/wings/service/delegate/DelegateServiceTest.java
@@ -1181,7 +1181,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     when(delegateProfileService.fetchNgPrimaryProfile(accountId, null)).thenReturn(profile);
     when(delegatesFeature.getMaxUsageAllowedForAccount(accountId)).thenReturn(Integer.MAX_VALUE);
 
-    DelegateRegisterResponse registerResponse = delegateService.register(params);
+    DelegateRegisterResponse registerResponse = delegateService.register(params, true);
     Delegate delegateFromDb = delegateCache.get(accountId, registerResponse.getDelegateId(), true);
     DelegateGroup delegateGroupFromDb = delegateCache.getDelegateGroup(accountId, delegateGroup.getUuid());
 
@@ -1198,6 +1198,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     assertThat(delegateFromDb.isPolllingModeEnabled()).isEqualTo(params.isPollingModeEnabled());
     assertThat(delegateFromDb.isSampleDelegate()).isEqualTo(params.isSampleDelegate());
     assertThat(delegateGroupFromDb.getTags()).containsExactlyInAnyOrder("tag1", "tag2");
+    assertThat(delegateFromDb.isMtls()).isTrue();
   }
 
   @Test
@@ -1229,7 +1230,7 @@ public class DelegateServiceTest extends WingsBaseTest {
 
     when(delegatesFeature.getMaxUsageAllowedForAccount(ACCOUNT_ID)).thenReturn(Integer.MAX_VALUE);
 
-    DelegateRegisterResponse registerResponse = delegateService.register(params);
+    DelegateRegisterResponse registerResponse = delegateService.register(params, false);
     Delegate delegateFromDb = delegateCache.get(ACCOUNT_ID, registerResponse.getDelegateId(), true);
     DelegateGroup delegateGroupFromDb = delegateCache.getDelegateGroup(ACCOUNT_ID, delegateGroup.getUuid());
 
@@ -1246,6 +1247,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     assertThat(delegateFromDb.isSampleDelegate()).isEqualTo(params.isSampleDelegate());
     assertThat(delegateGroupFromDb.getAccountId()).isEqualTo(delegateGroup.getAccountId());
     assertThat(delegateGroupFromDb.getName()).isEqualTo(delegateGroup.getName());
+    assertThat(delegateFromDb.isMtls()).isFalse();
   }
 
   @Test
@@ -1280,7 +1282,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     when(delegateProfileService.fetchNgPrimaryProfile(accountId, owner)).thenReturn(profile);
     when(delegatesFeature.getMaxUsageAllowedForAccount(accountId)).thenReturn(Integer.MAX_VALUE);
 
-    DelegateRegisterResponse registerResponse = delegateService.register(params);
+    DelegateRegisterResponse registerResponse = delegateService.register(params, false);
     Delegate delegateFromDb = delegateCache.get(accountId, registerResponse.getDelegateId(), true);
 
     assertThat(delegateFromDb.getOwner().getIdentifier()).isEqualTo(orgId);
@@ -1320,7 +1322,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     when(delegateProfileService.fetchNgPrimaryProfile(accountId, owner)).thenReturn(profile);
     when(delegatesFeature.getMaxUsageAllowedForAccount(accountId)).thenReturn(Integer.MAX_VALUE);
 
-    DelegateRegisterResponse registerResponse = delegateService.register(params);
+    DelegateRegisterResponse registerResponse = delegateService.register(params, false);
     Delegate delegateFromDb = delegateCache.get(accountId, registerResponse.getDelegateId(), true);
 
     assertThat(delegateFromDb.getOwner().getIdentifier()).isEqualTo("orgId/projectId");
@@ -1349,7 +1351,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     when(delegateProfileService.fetchCgPrimaryProfile(accountId)).thenReturn(profile);
     when(delegatesFeature.getMaxUsageAllowedForAccount(accountId)).thenReturn(Integer.MAX_VALUE);
 
-    DelegateRegisterResponse registerResponse = delegateService.register(params);
+    DelegateRegisterResponse registerResponse = delegateService.register(params, false);
     Delegate delegateFromDb = delegateCache.get(accountId, registerResponse.getDelegateId(), true);
 
     assertThat(delegateFromDb.getAccountId()).isEqualTo(params.getAccountId());
@@ -1364,6 +1366,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     assertThat(delegateFromDb.isPolllingModeEnabled()).isEqualTo(params.isPollingModeEnabled());
     assertThat(delegateFromDb.isSampleDelegate()).isEqualTo(params.isSampleDelegate());
     assertThat(delegateFromDb.isNg()).isEqualTo(params.isNg());
+    assertThat(delegateFromDb.isMtls()).isFalse();
   }
 
   @Test
@@ -1404,6 +1407,7 @@ public class DelegateServiceTest extends WingsBaseTest {
                             .polllingModeEnabled(false)
                             .sampleDelegate(false)
                             .tags(Arrays.asList("existingTag1", "existingTag2"))
+                            .mtls(false)
                             .build();
     DelegateProfile primaryDelegateProfile =
         createDelegateProfileBuilder().accountId(delegate.getAccountId()).primary(true).build();
@@ -1430,7 +1434,7 @@ public class DelegateServiceTest extends WingsBaseTest {
                                 .tags(Arrays.asList("newTag1", "newTag2"))
                                 .build();
 
-    delegateService.register(params);
+    delegateService.register(params, true);
 
     Delegate delegateFromDb = delegateCache.get(accountId, delegate.getUuid(), true);
     assertThat(delegateFromDb.getAccountId()).isEqualTo(params.getAccountId());
@@ -1446,6 +1450,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     assertThat(delegateFromDb.isSampleDelegate()).isEqualTo(params.isSampleDelegate());
     assertThat(delegate.getTags()).isEqualTo(Arrays.asList("existingTag1", "existingTag2"));
     assertThat(delegateFromDb.getTags()).isEqualTo(Arrays.asList("newTag1", "newTag2"));
+    assertThat(delegateFromDb.isMtls()).isTrue();
   }
 
   @Test
@@ -1466,6 +1471,7 @@ public class DelegateServiceTest extends WingsBaseTest {
                             .polllingModeEnabled(false)
                             .sampleDelegate(false)
                             .tags(Arrays.asList("existingTag1", "existingTag2"))
+                            .mtls(false)
                             .build();
     DelegateProfile primaryDelegateProfile =
         createDelegateProfileBuilder().accountId(delegate.getAccountId()).primary(true).build();
@@ -1493,7 +1499,7 @@ public class DelegateServiceTest extends WingsBaseTest {
                                 .tags(Arrays.asList("newTag1", "newTag2"))
                                 .build();
 
-    delegateService.register(params);
+    delegateService.register(params, true);
 
     Delegate delegateFromDb = delegateCache.get(accountId, delegate.getUuid(), true);
 
@@ -1509,6 +1515,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     assertThat(delegateFromDb.isNg()).isEqualTo(params.isNg());
     assertThat(delegate.getTags()).isEqualTo(Arrays.asList("existingTag1", "existingTag2"));
     assertThat(delegateFromDb.getTags()).isEqualTo(Arrays.asList("newTag1", "newTag2"));
+    assertThat(delegateFromDb.isMtls()).isTrue();
   }
 
   @Test
@@ -1726,7 +1733,7 @@ public class DelegateServiceTest extends WingsBaseTest {
                                 .ng(false)
                                 .build();
 
-    delegateService.register(params);
+    delegateService.register(params, false);
 
     Delegate delegateFromDb = delegateCache.get(accountId, delegate.getUuid(), true);
     assertThat(delegateFromDb.getAccountId()).isEqualTo(params.getAccountId());
@@ -1740,6 +1747,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     assertThat(delegateFromDb.isPolllingModeEnabled()).isEqualTo(params.isPollingModeEnabled());
     assertThat(delegateFromDb.isSampleDelegate()).isEqualTo(params.isSampleDelegate());
     assertThat(delegateFromDb.isNg()).isFalse();
+    assertThat(delegateFromDb.isMtls()).isFalse();
   }
 
   @Test
@@ -1783,7 +1791,7 @@ public class DelegateServiceTest extends WingsBaseTest {
                                         .lastHeartBeat(System.currentTimeMillis())
                                         .build();
     when(licenseService.isAccountDeleted("DELETED_ACCOUNT")).thenReturn(true);
-    DelegateRegisterResponse registerResponse = delegateService.register(delegateParams);
+    DelegateRegisterResponse registerResponse = delegateService.register(delegateParams, false);
     assertThat(registerResponse.getAction()).isEqualTo(DelegateRegisterResponse.Action.SELF_DESTRUCT);
   }
 
@@ -1830,7 +1838,7 @@ public class DelegateServiceTest extends WingsBaseTest {
                                         .delegateGroupId(delegateGroup.getUuid())
                                         .build();
 
-    DelegateRegisterResponse registerResponse = delegateService.register(delegateParams);
+    DelegateRegisterResponse registerResponse = delegateService.register(delegateParams, false);
     assertThat(registerResponse.getAction()).isEqualTo(DelegateRegisterResponse.Action.SELF_DESTRUCT);
   }
 
@@ -3588,7 +3596,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     when(delegateProfileService.fetchNgPrimaryProfile(accountId, null)).thenReturn(profile);
     when(delegatesFeature.getMaxUsageAllowedForAccount(accountId)).thenReturn(Integer.MAX_VALUE);
 
-    DelegateRegisterResponse registerResponse = delegateService.register(params);
+    DelegateRegisterResponse registerResponse = delegateService.register(params, false);
     assertThat(registerResponse.getAction()).isEqualTo(Action.SELF_DESTRUCT);
     assertThat(registerResponse.getDelegateId()).isNull();
   }
@@ -3613,7 +3621,7 @@ public class DelegateServiceTest extends WingsBaseTest {
 
     when(delegatesFeature.getMaxUsageAllowedForAccount(ACCOUNT_ID)).thenReturn(Integer.MAX_VALUE);
 
-    DelegateRegisterResponse registerResponse = delegateService.register(params);
+    DelegateRegisterResponse registerResponse = delegateService.register(params, true);
     Delegate delegateFromDb = delegateCache.get(ACCOUNT_ID, registerResponse.getDelegateId(), true);
     DelegateGroup delegateGroupFromDb = delegateCache.getDelegateGroup(ACCOUNT_ID, delegateFromDb.getDelegateGroupId());
 
@@ -3629,6 +3637,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     assertThat(delegateFromDb.isPolllingModeEnabled()).isEqualTo(params.isPollingModeEnabled());
     assertThat(delegateFromDb.isSampleDelegate()).isEqualTo(params.isSampleDelegate());
     assertThat(delegateGroupFromDb.getAccountId()).isEqualTo(ACCOUNT_ID);
+    assertThat(delegateFromDb.isMtls()).isTrue();
   }
 
   @Test
@@ -3967,7 +3976,7 @@ public class DelegateServiceTest extends WingsBaseTest {
     when(delegateProfileService.fetchNgPrimaryProfile(accountId, owner)).thenReturn(profile);
     when(delegatesFeature.getMaxUsageAllowedForAccount(accountId)).thenReturn(Integer.MAX_VALUE);
 
-    DelegateRegisterResponse registerResponse = delegateService.register(params);
+    DelegateRegisterResponse registerResponse = delegateService.register(params, false);
     Delegate delegateFromDb = delegateCache.get(accountId, registerResponse.getDelegateId(), true);
 
     assertThat(delegateFromDb.getOwner()).isEqualTo(owner);

--- a/920-delegate-service-beans/src/main/java/io/harness/delegate/beans/Delegate.java
+++ b/920-delegate-service-beans/src/main/java/io/harness/delegate/beans/Delegate.java
@@ -129,6 +129,8 @@ public class Delegate implements PersistentEntity, UuidAware, CreatedAtAware, Ac
 
   private boolean immutable;
 
+  private boolean mtls;
+
   @Override
   public void updateNextIteration(String fieldName, long nextIteration) {
     if (DelegateKeys.taskExpiryCheckNextIteration.equals(fieldName)) {

--- a/980-commons/src/main/java/io/harness/agent/AgentGatewayUtils.java
+++ b/980-commons/src/main/java/io/harness/agent/AgentGatewayUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.agent;
+
+import static io.harness.annotations.dev.HarnessTeam.DEL;
+import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
+
+import io.harness.annotations.dev.OwnedBy;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * Provides helper methods for agent gateway related functionality.
+ */
+@UtilityClass
+@OwnedBy(DEL)
+public class AgentGatewayUtils {
+  /**
+   * Determines whether an agent is connected using mTLS by analyzing the
+   * AgentGatewayConstants.HEADER_AGENT_MTLS_AUTHORITY header.
+   * @param agentMtlsAuthorityHeader AgentGatewayConstants.HEADER_AGENT_MTLS_AUTHORITY header, or null if it doesn't
+   *     exist.
+   * @return true if the agent is connected using mTLS.
+   */
+  public boolean isAgentConnectedUsingMtls(String agentMtlsAuthorityHeader) {
+    return isNotEmpty(agentMtlsAuthorityHeader);
+  }
+}


### PR DESCRIPTION
## Describe your changes
Adding an `mlts` field to the delegate class which indicates whether a delegate is connected via mTLS.
The flag is set during delegate registration.

This change helps us to display the mTLS status of delegates in the UI, and thus customers to track their mTLS delegates during onboarding to mTLS.

### Testing
- UTs
- Local testing: Started both a new delegate with mTLS and without mTLS, an existing one that keeps the same connection type (mTLS and non-mTLS), and an existing one that changes from/to mTLS. Ensured that delegates collection entry got created / updated as expected.

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [x] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/36314)
<!-- Reviewable:end -->
