### PR TITLE
feat: [PL-27456]: Granular targets for 999-annotations

### DIFF
--- a/999-annotations/BUILD.bazel
+++ b/999-annotations/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//:tools/bazel/harness.bzl", "java_library")
-load("//:tools/bazel/macros.bzl", "run_analysis")
 
 HarnessTeam = "PT"
 
@@ -7,9 +6,7 @@ java_library(
     name = "module",
     visibility = ["//visibility:public"],
     exports = [
-        "//999-annotations/src/main/java/io/harness/agent/sdk",
-        "//999-annotations/src/main/java/io/harness/annotations/dev",
+        "//999-annotations/src/main/java/io/harness/agent/sdk:module",
+        "//999-annotations/src/main/java/io/harness/annotations/dev:module",
     ],
 )
-
-run_analysis()

--- a/999-annotations/BUILD.bazel
+++ b/999-annotations/BUILD.bazel
@@ -5,8 +5,11 @@ HarnessTeam = "PT"
 
 java_library(
     name = "module",
-    srcs = glob(["src/main/**/*.java"]),
     visibility = ["//visibility:public"],
+    exports = [
+        "//999-annotations/src/main/java/io/harness/agent/sdk",
+        "//999-annotations/src/main/java/io/harness/annotations/dev",
+    ],
 )
 
 run_analysis()

--- a/999-annotations/src/main/java/io/harness/agent/sdk/BUILD.bazel
+++ b/999-annotations/src/main/java/io/harness/agent/sdk/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "sdk",
+    srcs = glob(["*.java"]),
+    visibility = ["//visibility:public"],
+)

--- a/999-annotations/src/main/java/io/harness/agent/sdk/BUILD.bazel
+++ b/999-annotations/src/main/java/io/harness/agent/sdk/BUILD.bazel
@@ -1,7 +1,12 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//:tools/bazel/macros.bzl", "run_analysis_per_module")
+
+HarnessTeam = "PT"
 
 java_library(
-    name = "sdk",
+    name = "module",
     srcs = glob(["*.java"]),
     visibility = ["//visibility:public"],
 )
+
+run_analysis_per_module()

--- a/999-annotations/src/main/java/io/harness/annotations/dev/BUILD.bazel
+++ b/999-annotations/src/main/java/io/harness/annotations/dev/BUILD.bazel
@@ -1,7 +1,12 @@
 load("@rules_java//java:defs.bzl", "java_library")
+load("//:tools/bazel/macros.bzl", "run_analysis_per_module")
+
+HarnessTeam = "PT"
 
 java_library(
-    name = "dev",
+    name = "module",
     srcs = glob(["*.java"]),
     visibility = ["//visibility:public"],
 )
+
+run_analysis_per_module()

--- a/999-annotations/src/main/java/io/harness/annotations/dev/BUILD.bazel
+++ b/999-annotations/src/main/java/io/harness/annotations/dev/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "dev",
+    srcs = glob(["*.java"]),
+    visibility = ["//visibility:public"],
+)

--- a/tools/bazel/macros.bzl
+++ b/tools/bazel/macros.bzl
@@ -22,7 +22,7 @@ def sonarqube_test(
         name = None,
         project_key = None,
         project_name = None,
-        srcs = [],
+        srcs = ["src/main/java/**/*.java"],
         source_encoding = None,
         targets = [],
         test_srcs = [],
@@ -32,7 +32,7 @@ def sonarqube_test(
         sq_properties_template = None,
         tags = [],
         visibility = []):
-    srcs = native.glob(["src/main/java/**/*.java"])
+    srcs = native.glob(srcs)
     targets = [":module"]
     if name == None:
         name = "sonarqube"
@@ -65,9 +65,16 @@ def sonarqube_test(
         checkstyle_report_path = getCheckstyleReportPathForSonar(),
     )
 
+def run_analysis_per_module(
+        checkstyle_srcs = ["*"],
+        pmd_srcs = ["*"],
+        sonarqube_srcs = ["*.java"]):
+    run_analysis(checkstyle_srcs, pmd_srcs, sonarqube_srcs)
+
 def run_analysis(
         checkstyle_srcs = ["src/**/*"],
         pmd_srcs = ["src/main/**/*"],
+        sonarqube_srcs = ["src/main/java/**/*.java"],
         run_checkstyle = True,
         run_pmd = True,
         run_sonar = True,
@@ -80,7 +87,7 @@ def run_analysis(
         pmd(pmd_srcs)
 
     if run_sonar:
-        sonarqube_test(test_targets = test_targets)
+        sonarqube_test(srcs = sonarqube_srcs, test_targets = test_targets)
 
     if run_duplicated:
         report_duplicated()


### PR DESCRIPTION
## Describe your changes

Breaking 999-annotations module to have granular build targets. These files were created using the automated BuildCleaner tool.

## Checklist
- [X] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/36407)
<!-- Reviewable:end -->
