### PR TITLE
fix: [DEL-4667]:  Send self_destruct to delegate when account status set as INACTIVE

### DIFF
--- a/400-rest/src/main/java/software/wings/licensing/LicenseService.java
+++ b/400-rest/src/main/java/software/wings/licensing/LicenseService.java
@@ -40,6 +40,8 @@ public interface LicenseService {
 
   boolean isAccountExpired(String accountId);
 
+  boolean isAccountStatusInActive(String accountId);
+
   void validateLicense(String accountId, String operation);
 
   void setLicense(Account account);

--- a/400-rest/src/main/java/software/wings/licensing/LicenseServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/licensing/LicenseServiceImpl.java
@@ -569,6 +569,11 @@ public class LicenseServiceImpl implements LicenseService {
     return false;
   }
 
+  @Override
+  public boolean isAccountStatusInActive(String accountId) {
+    return AccountStatus.INACTIVE.equals(accountService.getAccountStatus(accountId));
+  }
+
   private void expireLicense(String accountId, LicenseInfo licenseInfo) {
     licenseInfo.setAccountStatus(AccountStatus.EXPIRED);
     updateAccountLicense(accountId, licenseInfo);

--- a/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
@@ -2523,7 +2523,8 @@ public class DelegateServiceImpl implements DelegateService {
 
   @Override
   public DelegateRegisterResponse register(Delegate delegate) {
-    if (licenseService.isAccountDeleted(delegate.getAccountId())) {
+    if (licenseService.isAccountDeleted(delegate.getAccountId())
+        || licenseService.isAccountStatusInActive(delegate.getAccountId())) {
       delegateMetricsService.recordDelegateMetrics(delegate, DELEGATE_DESTROYED);
       broadcasterFactory.lookup(STREAM_DELEGATE + delegate.getAccountId(), true).broadcast(SELF_DESTRUCT);
       log.warn("Sending self destruct command from register delegate because the account is deleted.");
@@ -2577,7 +2578,8 @@ public class DelegateServiceImpl implements DelegateService {
 
   @Override
   public DelegateRegisterResponse register(final DelegateParams delegateParams) {
-    if (licenseService.isAccountDeleted(delegateParams.getAccountId())) {
+    if (licenseService.isAccountDeleted(delegateParams.getAccountId())
+        || licenseService.isAccountStatusInActive(delegateParams.getAccountId())) {
       delegateMetricsService.recordDelegateMetrics(
           Delegate.builder().accountId(delegateParams.getAccountId()).version(delegateParams.getVersion()).build(),
           DELEGATE_DESTROYED);


### PR DESCRIPTION
## Describe your changes
Summary:
When account status is INACTIVE then delegate keep pinging manager for heartbeat and registration
So solution is send SELF_DESTRUCT to delegate when account status is INACTIVE

## Checklist
- [ X] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/36436)
<!-- Reviewable:end -->
