### PR TITLE
[fix]: [PIE-4874]: Fixing execution input value coming null on retry steps when retyr is done by failure strategy

### DIFF
--- a/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/interrupts/helpers/RetryHelper.java
+++ b/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/interrupts/helpers/RetryHelper.java
@@ -67,7 +67,6 @@ public class RetryHelper {
     NodeExecution newNodeExecution =
         cloneForRetry(updatedRetriedNode, newUuid, finalAmbiance, interruptConfig, interruptId);
     NodeExecution savedNodeExecution = nodeExecutionService.save(newNodeExecution);
-    cloneAndSaveInputInstanceForRetry(nodeExecutionId, savedNodeExecution.getUuid());
 
     nodeExecutionService.updateRelationShipsForRetryNode(updatedRetriedNode.getUuid(), savedNodeExecution.getUuid());
     nodeExecutionService.markRetried(updatedRetriedNode.getUuid());
@@ -121,6 +120,8 @@ public class RetryHelper {
     List<InterruptEffect> interruptHistories =
         isEmpty(nodeExecution.getInterruptHistories()) ? new LinkedList<>() : nodeExecution.getInterruptHistories();
     interruptHistories.add(interruptEffect);
+    cloneAndSaveInputInstanceForRetry(nodeExecution.getUuid(), newUuid);
+
     return NodeExecution.builder()
         .uuid(newUuid)
         .ambiance(ambiance)

--- a/pipeline-service/modules/orchestration/src/test/java/io/harness/engine/interrupts/helpers/RetryHelperTest.java
+++ b/pipeline-service/modules/orchestration/src/test/java/io/harness/engine/interrupts/helpers/RetryHelperTest.java
@@ -189,6 +189,9 @@ public class RetryHelperTest extends OrchestrationTestBase {
                              .setManualIssuer(ManualIssuer.newBuilder().setIdentifier("admin@admin").build())
                              .build())
             .build();
+    doReturn(ExecutionInputInstance.builder().build())
+        .when(executionInputService)
+        .getExecutionInputInstance(nodeExecutionId);
     NodeExecution clonedNodeExecution = retryHelper.cloneForRetry(
         nodeExecution, newNodeUuid, nodeExecution.getAmbiance(), interruptConfig, generateUuid());
 
@@ -220,8 +223,7 @@ public class RetryHelperTest extends OrchestrationTestBase {
     doReturn(executionInputInstance).when(executionInputService).getExecutionInputInstance(originalNodeExecutionId);
 
     doReturn(ExecutionInputInstance.builder()
-                 .userInput(executionInputInstance.getUserInput())
-                 .template(executionInputInstance.getTemplate())
+                 .userInput(executionInputInstance.getUserInput()) o.template(executionInputInstance.getTemplate())
                  .mergedInputTemplate(executionInputInstance.getMergedInputTemplate())
                  .nodeExecutionId(newNodeExecutionId)
                  .inputInstanceId("RandomUUID")

--- a/pipeline-service/modules/orchestration/src/test/java/io/harness/engine/interrupts/helpers/RetryHelperTest.java
+++ b/pipeline-service/modules/orchestration/src/test/java/io/harness/engine/interrupts/helpers/RetryHelperTest.java
@@ -8,10 +8,12 @@
 package io.harness.engine.interrupts.helpers;
 
 import static io.harness.data.structure.UUIDGenerator.generateUuid;
+import static io.harness.rule.OwnerRule.BRIJESH;
 import static io.harness.rule.OwnerRule.PRASHANT;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,9 +22,11 @@ import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.category.element.UnitTests;
 import io.harness.engine.OrchestrationEngine;
+import io.harness.engine.execution.ExecutionInputService;
 import io.harness.engine.executions.node.NodeExecutionService;
 import io.harness.engine.executions.plan.PlanService;
 import io.harness.engine.utils.PmsLevelUtils;
+import io.harness.execution.ExecutionInputInstance;
 import io.harness.execution.NodeExecution;
 import io.harness.plan.PlanNode;
 import io.harness.pms.contracts.ambiance.Ambiance;
@@ -41,8 +45,10 @@ import io.harness.pms.contracts.steps.StepType;
 import io.harness.pms.execution.utils.AmbianceUtils;
 import io.harness.rule.Owner;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import org.junit.After;
 import org.junit.Before;
@@ -59,6 +65,7 @@ public class RetryHelperTest extends OrchestrationTestBase {
   @Mock NodeExecutionService nodeExecutionService;
   @Mock PlanService planService;
   @Mock ExecutorService executorService;
+  @Mock ExecutionInputService executionInputService;
   @Inject @InjectMocks RetryHelper retryHelper;
 
   @Before
@@ -127,6 +134,9 @@ public class RetryHelperTest extends OrchestrationTestBase {
     when(nodeExecutionService.markRetried(any())).thenReturn(true);
     when(planService.fetchNode(planId, nodeId)).thenReturn(planNode);
 
+    doReturn(ExecutionInputInstance.builder().build())
+        .when(executionInputService)
+        .getExecutionInputInstance(nodeExecutionId);
     retryHelper.retryNodeExecution(nodeExecution.getUuid(), interruptId, interruptConfig);
     verify(executorService).submit(any(Runnable.class));
   }
@@ -192,5 +202,39 @@ public class RetryHelperTest extends OrchestrationTestBase {
     assertThat(clonedNodeExecution.getStatus()).isEqualTo(Status.QUEUED);
     assertThat(clonedNodeExecution.getName()).isEqualTo("name");
     assertThat(clonedNodeExecution.getIdentifier()).isEqualTo("DUMMY");
+  }
+
+  @Test
+  @Owner(developers = BRIJESH)
+  @Category(UnitTests.class)
+  public void testCloneInputInstanceForRetry() {
+    String originalNodeExecutionId = "originalNodeExecutionId";
+    String newNodeExecutionId = "newNodeExecutionId";
+    Map<String, Object> mergedTemplateMap = ImmutableMap.of("key", "val");
+    ExecutionInputInstance executionInputInstance = ExecutionInputInstance.builder()
+                                                        .nodeExecutionId(originalNodeExecutionId)
+                                                        .template("template")
+                                                        .userInput("userinputyaml")
+                                                        .mergedInputTemplate(mergedTemplateMap)
+                                                        .build();
+    doReturn(executionInputInstance).when(executionInputService).getExecutionInputInstance(originalNodeExecutionId);
+
+    doReturn(ExecutionInputInstance.builder()
+                 .userInput(executionInputInstance.getUserInput())
+                 .template(executionInputInstance.getTemplate())
+                 .mergedInputTemplate(executionInputInstance.getMergedInputTemplate())
+                 .nodeExecutionId(newNodeExecutionId)
+                 .inputInstanceId("RandomUUID")
+                 .build())
+        .when(executionInputService)
+        .save(any());
+    ExecutionInputInstance clonedInstance =
+        retryHelper.cloneAndSaveInputInstanceForRetry(originalNodeExecutionId, newNodeExecutionId);
+
+    assertThat(executionInputInstance.getInputInstanceId()).isNotEqualTo(clonedInstance.getInputInstanceId());
+    assertThat(clonedInstance.getNodeExecutionId()).isEqualTo(newNodeExecutionId);
+    assertThat(clonedInstance.getMergedInputTemplate()).isEqualTo(executionInputInstance.getMergedInputTemplate());
+    assertThat(clonedInstance.getTemplate()).isEqualTo(executionInputInstance.getTemplate());
+    assertThat(clonedInstance.getUserInput()).isEqualTo(executionInputInstance.getUserInput());
   }
 }

--- a/pipeline-service/modules/orchestration/src/test/java/io/harness/engine/interrupts/helpers/RetryHelperTest.java
+++ b/pipeline-service/modules/orchestration/src/test/java/io/harness/engine/interrupts/helpers/RetryHelperTest.java
@@ -223,7 +223,8 @@ public class RetryHelperTest extends OrchestrationTestBase {
     doReturn(executionInputInstance).when(executionInputService).getExecutionInputInstance(originalNodeExecutionId);
 
     doReturn(ExecutionInputInstance.builder()
-                 .userInput(executionInputInstance.getUserInput()) o.template(executionInputInstance.getTemplate())
+                 .userInput(executionInputInstance.getUserInput())
+                 .template(executionInputInstance.getTemplate())
                  .mergedInputTemplate(executionInputInstance.getMergedInputTemplate())
                  .nodeExecutionId(newNodeExecutionId)
                  .inputInstanceId("RandomUUID")


### PR DESCRIPTION

## Describe your changes

Fixing execution input value coming null on step retries when retry is done through failure strategy.
Reason: On retry we create a new nodeExecution, so the execution input instance was not present for the new nodeExecutionId.
Fix: While cloning the nodeExecution for retry, we are now cloning the execution input instance as well.

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/36459)
<!-- Reviewable:end -->
