### PR TITLE
fix: [DEL-4672]: Download watcher script in every attempt to restart it

### DIFF
--- a/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
+++ b/260-delegate/src/main/java/io/harness/delegate/service/DelegateAgentServiceImpl.java
@@ -72,6 +72,7 @@ import static io.harness.utils.MemoryPerformanceUtils.memoryUsage;
 import static software.wings.beans.TaskType.SCRIPT;
 import static software.wings.beans.TaskType.SHELL_SCRIPT_TASK_NG;
 
+import static com.google.common.collect.Sets.newHashSet;
 import static java.lang.Boolean.TRUE;
 import static java.lang.String.format;
 import static java.time.Duration.ofMinutes;
@@ -325,6 +326,7 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
   private final double RESOURCE_USAGE_THRESHOLD = 0.90;
   private String MANAGER_PROXY_CURL = System.getenv().get("MANAGER_PROXY_CURL");
   private String MANAGER_HOST_AND_PORT = System.getenv().get("MANAGER_HOST_AND_PORT");
+  private static final String DEFAULT_PATCH_VERSION = "000";
 
   private final boolean BLOCK_SHELL_TASK = Boolean.parseBoolean(System.getenv().get("BLOCK_SHELL_TASK"));
 
@@ -1367,9 +1369,11 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
       } else {
         log.info("Checking for upgrade");
         try {
-          RestResponse<DelegateScripts> restResponse = HTimeLimiter.callInterruptible21(delegateHealthTimeLimiter,
-              Duration.ofMinutes(1),
-              () -> executeRestCall(delegateAgentManagerClient.getDelegateScripts(accountId, version, DELEGATE_NAME)));
+          RestResponse<DelegateScripts> restResponse =
+              HTimeLimiter.callInterruptible21(delegateHealthTimeLimiter, Duration.ofMinutes(1),
+                  ()
+                      -> executeRestCall(delegateAgentManagerClient.getDelegateScripts(
+                          accountId, version, DEFAULT_PATCH_VERSION, DELEGATE_NAME)));
           DelegateScripts delegateScripts = restResponse.getResource();
           if (delegateScripts.isDoUpgrade()) {
             upgradePending.set(true);
@@ -1605,13 +1609,16 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
         || (multiVersionRestartNeeded && multiVersionWatcherStarted.compareAndSet(false, true))) {
       String watcherProcess = messageService.getData(WATCHER_DATA, WATCHER_PROCESS, String.class);
       log.warn("Watcher process {} needs restart", watcherProcess);
-      healthMonitorExecutor.submit(() -> performWatcherUpgrade(watcherProcess, multiVersionRestartNeeded));
+      healthMonitorExecutor.submit(
+          () -> performWatcherUpgrade(watcherProcess, multiVersionRestartNeeded, expectedVersion));
     }
   }
 
-  private void performWatcherUpgrade(String watcherProcess, boolean multiVersionRestartNeeded) {
+  private void performWatcherUpgrade(String watcherProcess, boolean multiVersionRestartNeeded, String expectedVersion) {
     synchronized (this) {
       try {
+        // Download watcher script before restarting watcher.
+        downloadRunScriptsForWatcher(expectedVersion);
         ProcessControl.ensureKilled(watcherProcess, Duration.ofSeconds(120));
         messageService.closeChannel(WATCHER, watcherProcess);
         sleep(ofSeconds(2));
@@ -1635,6 +1642,48 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
       } catch (Exception e) {
         log.error("Error restarting watcher {}", watcherProcess, e);
       }
+    }
+  }
+
+  private void downloadRunScriptsForWatcher(String version) throws Exception {
+    RestResponse<DelegateScripts> restResponse;
+    if (!delegateNg) {
+      log.info("Calling getDelegateScripts with version{}}", version);
+      restResponse = HTimeLimiter.callInterruptible21(delegateHealthTimeLimiter, Duration.ofMinutes(1),
+          ()
+              -> executeRestCall(delegateAgentManagerClient.getDelegateScripts(
+                  accountId, version, DEFAULT_PATCH_VERSION, DELEGATE_NAME)));
+    } else {
+      log.info("Calling getDelegateScriptsNg with version{}}", version);
+      restResponse = HTimeLimiter.callInterruptible21(delegateHealthTimeLimiter, Duration.ofMinutes(1),
+          ()
+              -> executeRestCall(delegateAgentManagerClient.getDelegateScriptsNg(
+                  accountId, version, DEFAULT_PATCH_VERSION, DELEGATE_NAME)));
+    }
+
+    if (restResponse == null) {
+      log.warn("Received null response from manager.");
+      return;
+    }
+
+    DelegateScripts delegateScripts = restResponse.getResource();
+
+    File scriptFile = new File(START_SH);
+    String script = delegateScripts.getScriptByName(START_SH);
+
+    if (isNotEmpty(script)) {
+      Files.deleteIfExists(Paths.get(START_SH));
+      try (BufferedWriter writer = Files.newBufferedWriter(scriptFile.toPath())) {
+        writer.write(script, 0, script.length());
+        writer.flush();
+      }
+      log.info("Done replacing file [{}]. Set User and Group permission", scriptFile);
+      Files.setPosixFilePermissions(scriptFile.toPath(),
+          newHashSet(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.OWNER_WRITE,
+              PosixFilePermission.GROUP_READ, PosixFilePermission.OTHERS_READ));
+      log.info("Done setting file permissions");
+    } else {
+      log.error("Script for file [{}] was not replaced", scriptFile);
     }
   }
 
@@ -2412,13 +2461,13 @@ public class DelegateAgentServiceImpl implements DelegateAgentService {
           writer.write(script, 0, script.length());
           writer.flush();
         }
-        log.info("[Old] Done replacing file [{}]. Set User and Group permission", scriptFile);
+        log.info("Done replacing file [{}]. Set User and Group permission", scriptFile);
         Files.setPosixFilePermissions(scriptFile.toPath(),
             Sets.newHashSet(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE,
                 PosixFilePermission.OWNER_WRITE, PosixFilePermission.GROUP_READ, PosixFilePermission.OTHERS_READ));
-        log.info("[Old] Done setting file permissions");
+        log.info(" Done setting file permissions");
       } else {
-        log.error("[Old] Script for file [{}] was not replaced", scriptFile);
+        log.error("Script for file [{}] was not replaced", scriptFile);
       }
     }
   }

--- a/420-delegate-agent/src/main/java/io/harness/managerclient/DelegateAgentManagerClient.java
+++ b/420-delegate-agent/src/main/java/io/harness/managerclient/DelegateAgentManagerClient.java
@@ -111,7 +111,13 @@ public interface DelegateAgentManagerClient {
 
   @GET("agent/delegates/delegateScripts")
   Call<RestResponse<DelegateScripts>> getDelegateScripts(@Query("accountId") String accountId,
-      @Query("delegateVersion") String delegateVersion, @Query("delegateName") String delegateName);
+      @Query("delegateVersion") String delegateVersion, @Query("patchVersion") String patchVersion,
+      @Query("delegateName") String delegateName);
+
+  @GET("agent/delegates/delegateScriptsNg")
+  Call<RestResponse<DelegateScripts>> getDelegateScriptsNg(@Query("accountId") String accountId,
+      @Query("delegateVersion") String delegateVersion, @Query("patchVersion") String patchVersion,
+      @Query("delegateType") String delegateType);
 
   @GET("agent/infra-download/delegate-auth/delegate/logging-token")
   Call<RestResponse<AccessTokenBean>> getLoggingToken(@Query("accountId") String accountId);

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=76319
+build.number=76320
 build.patch=000
 delegate.version=22.08.11
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes
This change contains the step to download run scripts every time when delegate tries to start watcher.
This can be useful in scenario when start.sh script went corrupted for intermittent period while publishing new watcher version.
## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/36494)
<!-- Reviewable:end -->
