### PR TITLE
fix: [PL-26457]: Allow '.' in usergroup name

### DIFF
--- a/970-ng-commons/src/main/java/io/harness/data/validator/NGEntityNameValidator.java
+++ b/970-ng-commons/src/main/java/io/harness/data/validator/NGEntityNameValidator.java
@@ -15,7 +15,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class NGEntityNameValidator implements ConstraintValidator<NGEntityName, String> {
   private static final String ALLOWED_CHARS_STRING =
-      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_ ";
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_. ";
   private static final int MAX_ALLOWED_LENGTH = 64;
 
   @Override

--- a/970-ng-commons/src/test/java/io/harness/data/validator/NGEntityNameValidatorTest.java
+++ b/970-ng-commons/src/test/java/io/harness/data/validator/NGEntityNameValidatorTest.java
@@ -8,6 +8,7 @@
 package io.harness.data.validator;
 
 import static io.harness.rule.OwnerRule.KARAN;
+import static io.harness.rule.OwnerRule.YUVRAJ;
 
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
@@ -69,6 +70,19 @@ public class NGEntityNameValidatorTest extends CategoryTest {
       } else {
         assertTrue("name : " + name, violationsCount > 0);
       }
+    }
+  }
+
+  @Test
+  @Owner(developers = YUVRAJ)
+  @Category(UnitTests.class)
+  public void testEntityNameValidatorForDot() {
+    String name = "abc.abc";
+    int violationsCount = validator.validate(EntityNameValidatorTestStructure.builder().name(name).build()).size();
+    if (isValidEntityName(name)) {
+      assertEquals("name : " + name, 0, violationsCount);
+    } else {
+      assertTrue("name : " + name, violationsCount > 0);
     }
   }
 

--- a/970-ng-commons/src/test/java/io/harness/data/validator/NGEntityNameValidatorTest.java
+++ b/970-ng-commons/src/test/java/io/harness/data/validator/NGEntityNameValidatorTest.java
@@ -33,7 +33,7 @@ public class NGEntityNameValidatorTest extends CategoryTest {
   private Validator validator;
 
   private static final String ALLOWED_CHARS_STRING =
-      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_ ";
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_. ";
   private static final int MAX_ALLOWED_LENGTH = 64;
 
   @Builder

--- a/970-ng-commons/src/test/java/io/harness/data/validator/NGEntityNameValidatorTest.java
+++ b/970-ng-commons/src/test/java/io/harness/data/validator/NGEntityNameValidatorTest.java
@@ -79,11 +79,7 @@ public class NGEntityNameValidatorTest extends CategoryTest {
   public void testEntityNameValidatorForDot() {
     String name = "abc.abc";
     int violationsCount = validator.validate(EntityNameValidatorTestStructure.builder().name(name).build()).size();
-    if (isValidEntityName(name)) {
-      assertEquals("name : " + name, 0, violationsCount);
-    } else {
-      assertTrue("name : " + name, violationsCount > 0);
-    }
+    assertEquals("name : " + name, 0, violationsCount);
   }
 
   private static String generateRandomAsciiString() {

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=76131
+build.number=76128
 build.patch=001
 delegate.version=22.07.12
 delegate.patch=000

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
 build.number=76131
-build.patch=000
+build.patch=001
 delegate.version=22.07.12
 delegate.patch=000


### PR DESCRIPTION
## Changes to allow the customer to update user groups that were linked through scim having '.' in their name as they were unable to do so currently.

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/36661)
<!-- Reviewable:end -->
