### PR TITLE
fix: [CI-5347]: Add support for custom handling of Bitbucket Server API URL

### DIFF
--- a/933-ci-commons/src/main/java/io/harness/git/checks/GitStatusCheckHelper.java
+++ b/933-ci-commons/src/main/java/io/harness/git/checks/GitStatusCheckHelper.java
@@ -271,8 +271,35 @@ public class GitStatusCheckHelper {
       return BITBUCKET_API_URL;
     } else {
       String domain = GitClientHelper.getGitSCM(url);
+      domain = fetchCustomBitbucketDomain(url, domain);
       return "https://" + domain + "/";
     }
+  }
+
+  private static String fetchCustomBitbucketDomain(String url, String domain) {
+    final String SCM_SPLITTER = "/scm";
+    String[] splits = url.split(domain);
+    if (splits.length <= 1) {
+      // URL only contains the domain
+      return domain;
+    }
+
+    String scmString = splits[1];
+    if (!scmString.contains(SCM_SPLITTER)) {
+      // Remaining URL does not contain the custom splitter string
+      // Fallback to the original domain
+      return domain;
+    }
+
+    String[] endpointSplits = scmString.split(SCM_SPLITTER);
+    if (endpointSplits.length == 0) {
+      // URL does not have anything after the splitter
+      // as well as between domain and splitter
+      return domain;
+    }
+
+    String customEndpoint = endpointSplits[0];
+    return domain + customEndpoint;
   }
 
   private String getGitlabApiURL(String url) {

--- a/960-api-services/src/main/java/io/harness/git/GitClientHelper.java
+++ b/960-api-services/src/main/java/io/harness/git/GitClientHelper.java
@@ -237,8 +237,35 @@ public class GitClientHelper {
       return "https://api.bitbucket.org/";
     } else {
       String domain = GitClientHelper.getGitSCM(url);
+      domain = fetchCustomBitbucketDomain(url, domain);
       return getHttpProtocolPrefix(url) + domain + "/";
     }
+  }
+
+  private static String fetchCustomBitbucketDomain(String url, String domain) {
+    final String SCM_SPLITTER = "/scm";
+    String[] splits = url.split(domain);
+    if (splits.length <= 1) {
+      // URL only contains the domain
+      return domain;
+    }
+
+    String scmString = splits[1];
+    if (!scmString.contains(SCM_SPLITTER)) {
+      // Remaining URL does not contain the custom splitter string
+      // Fallback to the original domain
+      return domain;
+    }
+
+    String[] endpointSplits = scmString.split(SCM_SPLITTER);
+    if (endpointSplits.length == 0) {
+      // URL does not have anything after the splitter
+      // as well as between domain and splitter
+      return domain;
+    }
+
+    String customEndpoint = endpointSplits[0];
+    return domain + customEndpoint;
   }
 
   public static String getAzureRepoApiURL(String url) {

--- a/960-api-services/src/test/java/io/harness/git/GitClientHelperTest.java
+++ b/960-api-services/src/test/java/io/harness/git/GitClientHelperTest.java
@@ -503,6 +503,28 @@ public class GitClientHelperTest extends CategoryTest {
         .isEqualTo("https://api.bitbucket.org/");
     assertThat(GitClientHelper.getBitBucketApiURL("http://10.67.0.1/devkimittal/harness-core"))
         .isEqualTo("http://10.67.0.1/");
+    assertThat(GitClientHelper.getBitBucketApiURL("https://bb.harness.io/stash/scm/rutvijproject/rutvijrepo.git"))
+        .isEqualTo("https://bb.harness.io/stash/");
+    assertThat(GitClientHelper.getBitBucketApiURL("https://bb.harness.io/scm/rutvijproject/rutvijrepo.git"))
+        .isEqualTo("https://bb.harness.io/");
+    assertThat(
+        GitClientHelper.getBitBucketApiURL("https://rutvijmehta@bb.harness.io/stash/scm/rutvijproject/rutvijrepo.git"))
+        .isEqualTo("https://bb.harness.io/stash/");
+    assertThat(GitClientHelper.getBitBucketApiURL("https://rutvijmehta@bb.harness.io/scm/rutvijproject/rutvijrepo.git"))
+        .isEqualTo("https://bb.harness.io/");
+    assertThat(GitClientHelper.getBitBucketApiURL("https://bb.harness.io")).isEqualTo("https://bb.harness.io/");
+    assertThat(GitClientHelper.getBitBucketApiURL("https://bb.harness.io/")).isEqualTo("https://bb.harness.io/");
+    assertThat(GitClientHelper.getBitBucketApiURL("https://bb.harness.io/scm")).isEqualTo("https://bb.harness.io/");
+    assertThat(GitClientHelper.getBitBucketApiURL("https://bb.harness.io/scm/")).isEqualTo("https://bb.harness.io/");
+    assertThat(GitClientHelper.getBitBucketApiURL("https://bb.harness.io/stash/")).isEqualTo("https://bb.harness.io/");
+    assertThat(GitClientHelper.getBitBucketApiURL("https://bb.harness.io/stash/scm"))
+        .isEqualTo("https://bb.harness.io/stash/");
+    assertThat(GitClientHelper.getBitBucketApiURL("ssh://git@bb.harness.io/rutvijproject/rutvijrepo.git"))
+        .isEqualTo("https://bb.harness.io/");
+    assertThat(GitClientHelper.getBitBucketApiURL("ssh://git@bb.harness.io/scm/rutvijproject/rutvijrepo.git"))
+        .isEqualTo("https://bb.harness.io/");
+    assertThat(GitClientHelper.getBitBucketApiURL("ssh://git@bb.harness.io/stash/scm/rutvijproject/rutvijrepo.git"))
+        .isEqualTo("https://bb.harness.io/stash/");
   }
 
   @Test

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=76425
+build.number=76426
 build.patch=000
 delegate.version=22.08.12
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/36797)
<!-- Reviewable:end -->
