### PR TITLE
fix: [PIE-4628]: Add check to enforce pipeline runtime values must be provided before execution

### DIFF
--- a/pipeline-service/service/src/main/java/io/harness/pms/ngpipeline/inputset/helpers/InputSetErrorsHelper.java
+++ b/pipeline-service/service/src/main/java/io/harness/pms/ngpipeline/inputset/helpers/InputSetErrorsHelper.java
@@ -28,6 +28,7 @@ import io.harness.pms.ngpipeline.inputset.beans.entity.InputSetEntityType;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -184,5 +185,28 @@ public class InputSetErrorsHelper {
     });
     inputSetFQNs.forEach(fqn -> errorMap.put(fqn, "Field not a runtime input"));
     return errorMap;
+  }
+
+  /**
+   * Return a list of {@link FQN} of declared runtime input from a pipeline.
+   */
+  public List<FQN> getMissingFQNsInInputSet(YamlConfig pipelineYamlConfig) {
+    YamlConfig templateYamlConfig = RuntimeInputFormHelper.createRuntimeInputFormYamlConfig(pipelineYamlConfig, true);
+    return getMissingFQNsInInputSetFromTemplateConfig(templateYamlConfig);
+  }
+
+  List<FQN> getMissingFQNsInInputSetFromTemplateConfig(YamlConfig templateConfig) {
+    List<FQN> errors = new LinkedList<>();
+    if (EmptyPredicate.isEmpty(templateConfig.getFqnToValueMap())) {
+      return errors;
+    }
+    for (FQN key : templateConfig.getFqnToValueMap().keySet()) {
+      if (key.isType() || key.isIdentifierOrVariableName()) {
+        continue;
+      } else {
+        errors.add(key);
+      }
+    }
+    return errors;
   }
 }

--- a/pipeline-service/service/src/main/java/io/harness/pms/plan/execution/ExecutionHelper.java
+++ b/pipeline-service/service/src/main/java/io/harness/pms/plan/execution/ExecutionHelper.java
@@ -242,6 +242,12 @@ public class ExecutionHelper {
     long start = System.currentTimeMillis();
     if (isEmpty(mergedRuntimeInputYaml)) {
       pipelineYamlConfig = new YamlConfig(pipelineEntity.getYaml());
+      // WHEN A PIPELINE DECLARES THAT NEEDS RUNTIME INPUTS, IT IS REQUIRED TO
+      // PROVIDE THESE VALUES BEFORE THE EXECUTIONS.
+      List<FQN> missingFQNs = InputSetErrorsHelper.getMissingFQNsInInputSet(pipelineYamlConfig);
+      if (EmptyPredicate.isNotEmpty(missingFQNs)) {
+        throw new InvalidRequestException("Pipeline needs runtime input values");
+      }
       pipelineYamlConfigForSchemaValidations = pipelineYamlConfig;
     } else {
       YamlConfig pipelineEntityYamlConfig = new YamlConfig(pipelineEntity.getYaml());

--- a/pipeline-service/service/src/test/resources/missing-runtime-none.yaml
+++ b/pipeline-service/service/src/test/resources/missing-runtime-none.yaml
@@ -1,0 +1,31 @@
+pipeline:
+  name: Missing Runtime
+  identifier: Missing_Runtime
+  projectIdentifier: FernandoD
+  orgIdentifier: default
+  tags: {}
+  stages:
+    - stage:
+        name: Stage A
+        identifier: StageA
+        description: ""
+        type: Custom
+        spec:
+          execution:
+            steps:
+              - step:
+                  type: ShellScript
+                  name: Ping
+                  identifier: Ping
+                  spec:
+                    shell: Bash
+                    onDelegate: true
+                    source:
+                      type: Inline
+                      spec:
+                        script: echo "Ping"
+                    environmentVariables: []
+                    outputVariables: []
+                    executionTarget: {}
+                  timeout: 10m
+        tags: {}

--- a/pipeline-service/service/src/test/resources/missing-runtime-step-env-input.yaml
+++ b/pipeline-service/service/src/test/resources/missing-runtime-step-env-input.yaml
@@ -1,0 +1,39 @@
+pipeline:
+  name: Missing Runtime
+  identifier: Missing_Runtime
+  projectIdentifier: FernandoD
+  orgIdentifier: default
+  tags: {}
+  stages:
+    - stage:
+        name: Stage A
+        identifier: StageA
+        description: ""
+        type: Custom
+        spec:
+          execution:
+            steps:
+              - step:
+                  type: ShellScript
+                  name: Ping
+                  identifier: Ping
+                  spec:
+                    shell: Bash
+                    onDelegate: true
+                    source:
+                      type: Inline
+                      spec:
+                        script: echo "Ping"
+                    environmentVariables:
+                      - name: var1
+                        type: String
+                        value: <+input>
+                    outputVariables: []
+                    executionTarget: {}
+                  timeout: 2m
+        tags: {}
+        variables:
+          - name: var3
+            type: String
+            value: <+input>
+  variables: []

--- a/pipeline-service/service/src/test/resources/missing-runtime-step-expression.yaml
+++ b/pipeline-service/service/src/test/resources/missing-runtime-step-expression.yaml
@@ -1,0 +1,39 @@
+pipeline:
+  name: Missing Runtime
+  identifier: Missing_Runtime
+  projectIdentifier: FernandoD
+  orgIdentifier: default
+  tags: {}
+  stages:
+    - stage:
+        name: Stage A
+        identifier: StageA
+        description: ""
+        type: Custom
+        spec:
+          execution:
+            steps:
+              - step:
+                  type: ShellScript
+                  name: Ping
+                  identifier: Ping
+                  spec:
+                    shell: Bash
+                    onDelegate: true
+                    source:
+                      type: Inline
+                      spec:
+                        script: echo "Ping"
+                    environmentVariables: []
+                    outputVariables: []
+                    executionTarget: {}
+                  timeout: <+stage.variables.var3>
+        tags: {}
+        variables:
+          - name: var1
+            type: String
+            value: "1234"
+          - name: var3
+            type: String
+            value: <+input>
+  variables: []

--- a/pipeline-service/service/src/test/resources/missing-runtime-step-input.yaml
+++ b/pipeline-service/service/src/test/resources/missing-runtime-step-input.yaml
@@ -1,0 +1,32 @@
+pipeline:
+  name: Missing Runtime
+  identifier: Missing_Runtime
+  projectIdentifier: FernandoD
+  orgIdentifier: default
+  tags: {}
+  stages:
+    - stage:
+        name: Stage A
+        identifier: StageA
+        description: ""
+        type: Custom
+        spec:
+          execution:
+            steps:
+              - step:
+                  type: ShellScript
+                  name: Ping
+                  identifier: Ping
+                  spec:
+                    shell: Bash
+                    onDelegate: true
+                    source:
+                      type: Inline
+                      spec:
+                        script: echo "Ping"
+                    environmentVariables: []
+                    outputVariables: []
+                    executionTarget: {}
+                  timeout: <+input>
+        tags: {}
+  variables: []

--- a/pipeline-service/service/src/test/resources/missing-runtime-step-n-var-input.yaml
+++ b/pipeline-service/service/src/test/resources/missing-runtime-step-n-var-input.yaml
@@ -1,0 +1,39 @@
+pipeline:
+  name: Missing Runtime
+  identifier: Missing_Runtime
+  projectIdentifier: FernandoD
+  orgIdentifier: default
+  tags: {}
+  stages:
+    - stage:
+        name: Stage A
+        identifier: StageA
+        description: ""
+        type: Custom
+        spec:
+          execution:
+            steps:
+              - step:
+                  type: ShellScript
+                  name: Ping
+                  identifier: Ping
+                  spec:
+                    shell: Bash
+                    onDelegate: true
+                    source:
+                      type: Inline
+                      spec:
+                        script: echo "Ping"
+                    environmentVariables: []
+                    outputVariables: []
+                    executionTarget: {}
+                  timeout: <+input>
+        tags: {}
+        variables:
+          - name: var1
+            type: String
+            value: "1234"
+          - name: var2
+            type: String
+            value: <+input>
+  variables: []

--- a/pipeline-service/service/src/test/resources/missing-runtime-variable-allowedValues.yaml
+++ b/pipeline-service/service/src/test/resources/missing-runtime-variable-allowedValues.yaml
@@ -1,0 +1,35 @@
+pipeline:
+  name: Missing Runtime
+  identifier: Missing_Runtime
+  projectIdentifier: FernandoD
+  orgIdentifier: default
+  tags: {}
+  stages:
+    - stage:
+        name: Stage A
+        identifier: StageA
+        description: ""
+        type: Custom
+        spec:
+          execution:
+            steps:
+              - step:
+                  type: ShellScript
+                  name: Ping
+                  identifier: Ping
+                  spec:
+                    shell: Bash
+                    onDelegate: true
+                    source:
+                      type: Inline
+                      spec:
+                        script: echo "Ping"
+                    environmentVariables: []
+                    outputVariables: []
+                    executionTarget: {}
+                  timeout: 10m
+        tags: {}
+  variables:
+    - name: var2
+      type: Number
+      value: <+input>.allowedValues(1,2,3)

--- a/pipeline-service/service/src/test/resources/missing-runtime-variable-default-value.yaml
+++ b/pipeline-service/service/src/test/resources/missing-runtime-variable-default-value.yaml
@@ -1,0 +1,35 @@
+pipeline:
+  name: Missing Runtime
+  identifier: Missing_Runtime
+  projectIdentifier: FernandoD
+  orgIdentifier: default
+  tags: {}
+  stages:
+    - stage:
+        name: Stage A
+        identifier: StageA
+        description: ""
+        type: Custom
+        spec:
+          execution:
+            steps:
+              - step:
+                  type: ShellScript
+                  name: Ping
+                  identifier: Ping
+                  spec:
+                    shell: Bash
+                    onDelegate: true
+                    source:
+                      type: Inline
+                      spec:
+                        script: echo "Ping"
+                    environmentVariables: []
+                    outputVariables: []
+                    executionTarget: {}
+                  timeout: 10m
+        tags: {}
+  variables:
+    - name: var1
+      type: Number
+      value: 1410

--- a/pipeline-service/service/src/test/resources/missing-runtime-variable-input.yaml
+++ b/pipeline-service/service/src/test/resources/missing-runtime-variable-input.yaml
@@ -1,0 +1,35 @@
+pipeline:
+  name: Missing Runtime
+  identifier: Missing_Runtime
+  projectIdentifier: FernandoD
+  orgIdentifier: default
+  tags: {}
+  stages:
+    - stage:
+        name: Stage A
+        identifier: StageA
+        description: ""
+        type: Custom
+        spec:
+          execution:
+            steps:
+              - step:
+                  type: ShellScript
+                  name: Ping
+                  identifier: Ping
+                  spec:
+                    shell: Bash
+                    onDelegate: true
+                    source:
+                      type: Inline
+                      spec:
+                        script: echo "Ping"
+                    environmentVariables: []
+                    outputVariables: []
+                    executionTarget: {}
+                  timeout: 10m
+        tags: {}
+  variables:
+    - name: var1
+      type: Number
+      value: <+input>


### PR DESCRIPTION
## Describe your changes
- When a pipeline declares that needs runtime inputs, it is required to provide these values before the executions. 
- The UI execution already checks for this, but REST calls don't.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions