### PR TITLE
fix: [CDS-40838]: hotfix pr pipeline

### DIFF
--- a/120-ng-manager/src/main/java/io/harness/ng/gitops/resource/ClusterResource.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/gitops/resource/ClusterResource.java
@@ -294,7 +294,7 @@ public class ClusterResource {
     Map<String, ClusterFromGitops> allClusters =
         Stream.of(accountLevelClusters.getContent(), projectLevelClusters.getContent())
             .flatMap(List::stream)
-            .collect(Collectors.toMap(e -> e.getIdentifier(), Function.identity()));
+            .collect(Collectors.toMap(e -> e.getIdentifier(), Function.identity(), (c1, c2) -> c1));
     return ResponseDTO.newResponse(getNGPageResponse(entities.map(e -> ClusterEntityMapper.writeDTO(e, allClusters))));
   }
 

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=76515
+build.number=76516
 build.patch=000
 delegate.version=22.08.13
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes
This hotfix includes a fix to the GitOps PR pipeline. The NG environment tab, cluster list call was throwing 500 a duplicate key error. Log lines were also being printed incorrectly. 

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/36971)
<!-- Reviewable:end -->
