### PR TITLE
[feat]: [PL-28135]: adding empty classes needed for supporting gcp secret man…

### DIFF
--- a/440-connector-nextgen/src/main/java/io/harness/connector/entities/embedded/gcpsm/GcpSMConnector.java
+++ b/440-connector-nextgen/src/main/java/io/harness/connector/entities/embedded/gcpsm/GcpSMConnector.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.connector.entities.embedded.gcpsm;
+
+import static io.harness.annotations.dev.HarnessTeam.PL;
+
+import io.harness.annotations.StoreIn;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.connector.entities.Connector;
+import io.harness.ng.DbAliases;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
+import lombok.experimental.FieldNameConstants;
+import org.mongodb.morphia.annotations.Entity;
+import org.springframework.data.annotation.Persistent;
+import org.springframework.data.annotation.TypeAlias;
+
+@OwnedBy(PL)
+@Value
+@Builder
+@ToString()
+@EqualsAndHashCode(callSuper = true)
+@FieldNameConstants(innerTypeName = "GcpSMConnectorKeys")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@StoreIn(DbAliases.NG_MANAGER)
+@Entity(value = "connectors", noClassnameStored = true)
+@Persistent
+@TypeAlias("io.harness.connector.entities.embedded.gcpsm.GcpSMConnector")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GcpSMConnector extends Connector {
+  // Fields to be added later
+}

--- a/440-connector-nextgen/src/main/java/io/harness/connector/heartbeat/GcpSMValidationParamProvider.java
+++ b/440-connector-nextgen/src/main/java/io/harness/connector/heartbeat/GcpSMValidationParamProvider.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.connector.heartbeat;
+
+import io.harness.connector.ConnectorInfoDTO;
+import io.harness.delegate.beans.connector.ConnectorValidationParams;
+
+public class GcpSMValidationParamProvider
+    extends SecretManagerConnectorValidationParamsProvider implements ConnectorValidationParamsProvider {
+  @Override
+  public ConnectorValidationParams getConnectorValidationParams(ConnectorInfoDTO connectorInfoDTO, String connectorName,
+      String accountIdentifier, String orgIdentifier, String projectIdentifier) {
+    return null;
+  }
+}

--- a/440-connector-nextgen/src/main/java/io/harness/connector/mappers/secretmanagermapper/GcpSMDTOToEntity.java
+++ b/440-connector-nextgen/src/main/java/io/harness/connector/mappers/secretmanagermapper/GcpSMDTOToEntity.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.connector.mappers.secretmanagermapper;
+
+import io.harness.connector.entities.embedded.gcpsm.GcpSMConnector;
+import io.harness.connector.mappers.ConnectorDTOToEntityMapper;
+import io.harness.delegate.beans.connector.gcpsecretmanager.GcpSMConnectorDTO;
+
+public class GcpSMDTOToEntity implements ConnectorDTOToEntityMapper<GcpSMConnectorDTO, GcpSMConnector> {
+  @Override
+  public GcpSMConnector toConnectorEntity(GcpSMConnectorDTO connectorDTO) {
+    return null;
+  }
+}

--- a/440-connector-nextgen/src/main/java/io/harness/connector/mappers/secretmanagermapper/GcpSMEntityToDTO.java
+++ b/440-connector-nextgen/src/main/java/io/harness/connector/mappers/secretmanagermapper/GcpSMEntityToDTO.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.connector.mappers.secretmanagermapper;
+
+import io.harness.connector.entities.embedded.gcpsm.GcpSMConnector;
+import io.harness.connector.mappers.ConnectorEntityToDTOMapper;
+import io.harness.delegate.beans.connector.gcpsecretmanager.GcpSMConnectorDTO;
+
+public class GcpSMEntityToDTO implements ConnectorEntityToDTOMapper<GcpSMConnectorDTO, GcpSMConnector> {
+  @Override
+  public GcpSMConnectorDTO createConnectorDTO(GcpSMConnector connector) {
+    return null;
+  }
+}

--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/beans/connector/gcpsmconnector/GcpSMValidationParams.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/beans/connector/gcpsmconnector/GcpSMValidationParams.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.delegate.beans.connector.gcpsmconnector;
+
+import static io.harness.annotations.dev.HarnessTeam.PL;
+
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.delegate.beans.connector.ConnectorType;
+import io.harness.delegate.beans.connector.ConnectorValidationParams;
+import io.harness.delegate.beans.executioncapability.ExecutionCapability;
+import io.harness.delegate.beans.executioncapability.ExecutionCapabilityDemander;
+import io.harness.expression.ExpressionEvaluator;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Value;
+
+@OwnedBy(PL)
+@Value
+@Builder
+public class GcpSMValidationParams implements ConnectorValidationParams, ExecutionCapabilityDemander {
+  String connectorName;
+  @Override
+  public ConnectorType getConnectorType() {
+    return null;
+  }
+
+  @Override
+  public List<ExecutionCapability> fetchRequiredExecutionCapabilities(ExpressionEvaluator maskingEvaluator) {
+    return null;
+  }
+}

--- a/954-connector-beans/src/main/java/io/harness/delegate/beans/connector/gcpsecretmanager/GcpSMConnectorDTO.java
+++ b/954-connector-beans/src/main/java/io/harness/delegate/beans/connector/gcpsecretmanager/GcpSMConnectorDTO.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.delegate.beans.connector.gcpsecretmanager;
+
+import io.harness.SecretManagerDescriptionConstants;
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.beans.DecryptableEntity;
+import io.harness.connector.DelegateSelectable;
+import io.harness.delegate.beans.connector.ConnectorConfigDTO;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.annotations.ApiModel;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@ApiModel("GcpSM")
+@OwnedBy(HarnessTeam.PL)
+@Schema(name = "GcpSM", description = "This contains details of GCP Secret Manager")
+public class GcpSMConnectorDTO extends ConnectorConfigDTO implements DelegateSelectable {
+  // Other Fields to be added
+  @Schema(description = SecretManagerDescriptionConstants.DEFAULT) private boolean isDefault;
+  @Override
+  public List<DecryptableEntity> getDecryptableEntities() {
+    return null;
+  }
+
+  @Override
+  public Set<String> getDelegateSelectors() {
+    return null;
+  }
+
+  @Override
+  public void setDelegateSelectors(Set<String> delegateSelectors) {}
+}


### PR DESCRIPTION
…ager

## Describe your changes
Adding empty classes needed to support GCP Secret manager. 
## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/37369)
<!-- Reviewable:end -->
