### PR TITLE
feat: [PL-28359]: get file for branch having slash

### DIFF
--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/impl/ScmFacilitatorServiceImpl.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/impl/ScmFacilitatorServiceImpl.java
@@ -204,7 +204,7 @@ public class ScmFacilitatorServiceImpl implements ScmFacilitatorService {
 
     ApiResponseDTO response = getGetFileAPIResponse(scmConnector, fileContent, getLatestCommitOnFileResponse);
 
-    if (ScmApiErrorHandlingHelper.isFailureResponse(fileContent.getStatus(), scmConnector.getConnectorType())) {
+    if (ScmApiErrorHandlingHelper.isFailureResponse(response.getStatusCode(), scmConnector.getConnectorType())) {
       ScmApiErrorHandlingHelper.processAndThrowError(ScmApis.GET_FILE, scmConnector.getConnectorType(),
           scmConnector.getUrl(), response.getStatusCode(), response.getError(),
           ErrorMetadata.builder()

--- a/952-scm-java-client/src/main/java/io/harness/impl/scm/ScmServiceClientImpl.java
+++ b/952-scm-java-client/src/main/java/io/harness/impl/scm/ScmServiceClientImpl.java
@@ -215,8 +215,15 @@ public class ScmServiceClientImpl implements ScmServiceClient {
     String slug = scmGitProviderHelper.getSlug(scmConnector);
     final GetFileRequest.Builder gitFileRequestBuilder =
         GetFileRequest.newBuilder().setPath(gitFilePathDetails.getFilePath()).setProvider(gitProvider).setSlug(slug);
-    if (isNotEmpty(gitFilePathDetails.getBranch())) {
+    if (isNotEmpty(gitFilePathDetails.getBranch()) && !gitFilePathDetails.getBranch().contains("/")) {
       gitFileRequestBuilder.setBranch(gitFilePathDetails.getBranch());
+    } else if (isNotEmpty(gitFilePathDetails.getBranch())) {
+      GetLatestCommitOnFileResponse getLatestCommitOnFileResponse = getLatestCommitOnFile(
+          scmConnector, scmBlockingStub, gitFilePathDetails.getBranch(), gitFilePathDetails.getFilePath());
+      if (isNotEmpty(getLatestCommitOnFileResponse.getError())) {
+        return FileContent.newBuilder().setStatus(400).setError(getLatestCommitOnFileResponse.getError()).build();
+      }
+      gitFileRequestBuilder.setRef(getLatestCommitOnFileResponse.getCommitId());
     } else if (isNotEmpty(gitFilePathDetails.getRef())) {
       gitFileRequestBuilder.setRef(gitFilePathDetails.getRef());
     }


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)