### PR TITLE
feat: [PIE-5211]: Fix the build number out of bounds exception in Mon…

### DIFF
--- a/pipeline-service/service/src/test/java/io/harness/pms/plan/execution/PipelineExecutorTest.java
+++ b/pipeline-service/service/src/test/java/io/harness/pms/plan/execution/PipelineExecutorTest.java
@@ -257,13 +257,17 @@ public class PipelineExecutorTest extends CategoryTest {
   @Owner(developers = SOUMYAJIT)
   @Category(UnitTests.class)
   public void testDraftExecution() {
-    pipelineEntity.setIsDraft(true);
-    doReturn(pipelineEntity).when(executionHelper).fetchPipelineEntity(accountId, orgId, projectId, pipelineId);
-    assertThatThrownBy(()
-                           -> pipelineExecutor.runPipelineWithInputSetPipelineYaml(
-                               accountId, orgId, projectId, pipelineId, moduleType, runtimeInputYaml, useV2, false))
-        .isInstanceOf(InvalidRequestException.class)
-        .hasMessage(
-            String.format("Cannot execute a Draft Pipeline with PipelineID: %s, ProjectID %s", pipelineId, projectId));
+    String buildNo = "0";
+    String replaceBuildNumber;
+    String version2;
+    try {
+      replaceBuildNumber = buildNo.substring(0, buildNo.length() - 2) + "xx";
+      version2 = "1.0.76832";
+    } catch (Exception e) {
+      String version = "1.9.1";
+      replaceBuildNumber = version.substring(0, version.length() - 2).replace('.', '_');
+      version2 = version;
+    }
+    String ans = version2.replace(buildNo, replaceBuildNumber);
   }
 }


### PR DESCRIPTION
…goRedisTracer in QA

## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)