### PR TITLE
Revert "fix: [CDS-39386]: moving aggregate and read queries for CG dashboard and instance stats related collections to secondary node"

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/instance/InstanceServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/instance/InstanceServiceImpl.java
@@ -45,6 +45,7 @@ import software.wings.beans.infrastructure.instance.key.InstanceKey;
 import software.wings.beans.infrastructure.instance.key.PcfInstanceKey;
 import software.wings.beans.infrastructure.instance.key.PodInstanceKey;
 import software.wings.dl.WingsMongoPersistence;
+import software.wings.dl.WingsPersistence;
 import software.wings.service.intfc.AppService;
 import software.wings.service.intfc.instance.InstanceService;
 
@@ -52,6 +53,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.mongodb.ReadPreference;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -78,7 +80,8 @@ import org.mongodb.morphia.query.UpdateOperations;
 @OwnedBy(HarnessTeam.DX)
 public class InstanceServiceImpl implements InstanceService {
   @Inject FeatureFlagService featureFlagService;
-  @Inject private WingsMongoPersistence wingsPersistence;
+  @Inject private WingsPersistence wingsPersistence;
+  @Inject private WingsMongoPersistence wingsMongoPersistence;
   @Inject private AppService appService;
   @Inject private PersistentLocker persistentLocker;
   @Inject private QueuePublisher<InstanceEvent> eventQueue;
@@ -345,13 +348,13 @@ public class InstanceServiceImpl implements InstanceService {
   @Override
   public PageResponse<Instance> list(PageRequest<Instance> pageRequest) {
     pageRequest.addFilter("isDeleted", Operator.EQ, false);
-    return wingsPersistence.querySecondary(Instance.class, pageRequest);
+    return wingsPersistence.query(Instance.class, pageRequest);
   }
 
   @Override
   public List<Instance> listV2(Query<Instance> query) {
     query.filter(InstanceKeys.isDeleted, false);
-    return query.asList(wingsPersistence.analyticNodePreferenceOptions());
+    return query.asList();
   }
 
   @Override
@@ -359,7 +362,7 @@ public class InstanceServiceImpl implements InstanceService {
     long twoDaysOldTimeInMills = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2);
     query.and(query.or(query.criteria(InstanceKeys.deletedAt).greaterThanOrEq(twoDaysOldTimeInMills),
         query.criteria(InstanceKeys.isDeleted).equal(false)));
-    return query.asList(wingsPersistence.analyticNodePreferenceOptions());
+    return query.asList(new FindOptions().readPreference(ReadPreference.secondaryPreferred()));
   }
 
   @Override
@@ -503,17 +506,14 @@ public class InstanceServiceImpl implements InstanceService {
     // todo: GA this FF if works good and remove else clause
     if (featureFlagService.isGlobalEnabled(CHANGE_INSTANCE_QUERY_OPERATOR_TO_NE)) {
       pageRequest.addFilter(InstanceKeys.lastWorkflowExecutionId, Operator.NOT_EQ, new Object[] {null});
-      instance = wingsPersistence.convertToQuery(Instance.class, pageRequest)
-                     .get(wingsPersistence.analyticNodePreferenceOptions());
+      instance = wingsPersistence.convertToQuery(Instance.class, pageRequest).get();
     } else {
-      instance = wingsPersistence.convertToQuery(Instance.class, pageRequest)
-                     .get(wingsPersistence.analyticNodePreferenceOptions());
+      instance = wingsPersistence.convertToQuery(Instance.class, pageRequest).get();
       if (instance.getLastWorkflowExecutionId() == null) {
         log.error("Got last workflow execution Id null which is not expected. Details: appid:{}, inframapping id: {}.",
             appId, infrastructureDefinitionId);
         pageRequest.addFilter(InstanceKeys.lastWorkflowExecutionId, Operator.EXISTS);
-        instance = wingsPersistence.convertToQuery(Instance.class, pageRequest)
-                       .get(wingsPersistence.analyticNodePreferenceOptions());
+        instance = wingsPersistence.convertToQuery(Instance.class, pageRequest).get();
       }
     }
 

--- a/400-rest/src/main/java/software/wings/service/impl/instance/stats/InstanceStatServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/instance/stats/InstanceStatServiceImpl.java
@@ -18,7 +18,7 @@ import software.wings.beans.Account;
 import software.wings.beans.User;
 import software.wings.beans.infrastructure.instance.stats.InstanceStatsSnapshot;
 import software.wings.beans.infrastructure.instance.stats.InstanceStatsSnapshot.InstanceStatsSnapshotKeys;
-import software.wings.dl.WingsMongoPersistence;
+import software.wings.dl.WingsPersistence;
 import software.wings.resources.stats.model.InstanceTimeline;
 import software.wings.resources.stats.rbac.TimelineRbacFilters;
 import software.wings.security.UserThreadLocal;
@@ -55,7 +55,7 @@ import org.mongodb.morphia.query.Sort;
 @ParametersAreNonnullByDefault
 @Slf4j
 public class InstanceStatServiceImpl implements InstanceStatService {
-  @Inject private WingsMongoPersistence persistence;
+  @Inject private WingsPersistence persistence;
   @Inject private AppService appService;
   @Inject private UserService userService;
   @Inject private DashboardStatisticsService dashboardStatsService;
@@ -145,8 +145,7 @@ public class InstanceStatServiceImpl implements InstanceStatService {
 
     List<InstanceStatsSnapshot> timeline = new LinkedList<>();
 
-    try (HIterator<InstanceStatsSnapshot> iterator =
-             new HIterator<>(query.fetch(persistence.analyticNodePreferenceOptions()))) {
+    try (HIterator<InstanceStatsSnapshot> iterator = new HIterator<>(query.fetch())) {
       while (iterator.hasNext()) {
         timeline.add(iterator.next());
       }
@@ -158,7 +157,7 @@ public class InstanceStatServiceImpl implements InstanceStatService {
   @Override
   @Nullable
   public Instant getLastSnapshotTime(String accountId) {
-    FindOptions options = persistence.analyticNodePreferenceOptions();
+    FindOptions options = new FindOptions();
     options.limit(1);
 
     List<InstanceStatsSnapshot> snapshots = persistence.createQuery(InstanceStatsSnapshot.class)
@@ -176,7 +175,7 @@ public class InstanceStatServiceImpl implements InstanceStatService {
   @Override
   @Nullable
   public Instant getFirstSnapshotTime(String accountId) {
-    FindOptions options = persistence.analyticNodePreferenceOptions();
+    FindOptions options = new FindOptions();
     options.limit(1);
 
     List<InstanceStatsSnapshot> snapshots = persistence.createQuery(InstanceStatsSnapshot.class)
@@ -202,7 +201,7 @@ public class InstanceStatServiceImpl implements InstanceStatService {
                                                  .field("timestamp")
                                                  .lessThan(to)
                                                  .project("total", true)
-                                                 .asList(persistence.analyticNodePreferenceOptions())
+                                                 .asList()
                                                  .stream()
                                                  .sorted(Comparator.comparingInt(InstanceStatsSnapshot::getTotal))
                                                  .collect(Collectors.toList());
@@ -213,7 +212,7 @@ public class InstanceStatServiceImpl implements InstanceStatService {
 
   @Override
   public double currentCount(String accountId) {
-    FindOptions options = persistence.analyticNodePreferenceOptions();
+    FindOptions options = new FindOptions();
     options.limit(1);
 
     List<InstanceStatsSnapshot> snapshots = persistence.createQuery(InstanceStatsSnapshot.class)

--- a/400-rest/src/main/java/software/wings/service/impl/instance/stats/ServerlessInstanceStatServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/instance/stats/ServerlessInstanceStatServiceImpl.java
@@ -16,7 +16,7 @@ import software.wings.beans.User;
 import software.wings.beans.infrastructure.instance.InvocationCount.InvocationCountKey;
 import software.wings.beans.infrastructure.instance.stats.ServerlessInstanceStats;
 import software.wings.beans.infrastructure.instance.stats.ServerlessInstanceStats.ServerlessInstanceStatsKeys;
-import software.wings.dl.WingsMongoPersistence;
+import software.wings.dl.WingsPersistence;
 import software.wings.resources.stats.model.ServerlessInstanceTimeline;
 import software.wings.resources.stats.rbac.TimelineRbacFilters;
 import software.wings.security.UserThreadLocal;
@@ -46,7 +46,7 @@ import org.mongodb.morphia.query.Sort;
 @Singleton
 public class ServerlessInstanceStatServiceImpl implements ServerlessInstanceStatService {
   public static final String TIMESTAMP = "timestamp";
-  @Inject private WingsMongoPersistence persistence;
+  @Inject private WingsPersistence persistence;
   @Inject private ServerlessDashboardService serverlessDashboardService;
   @Inject private AppService appService;
   @Inject private UserService userService;
@@ -67,7 +67,7 @@ public class ServerlessInstanceStatServiceImpl implements ServerlessInstanceStat
   @Override
   @Nullable
   public Instant getLastSnapshotTime(@NotNull String accountId) {
-    FindOptions options = persistence.analyticNodePreferenceOptions();
+    FindOptions options = new FindOptions();
     options.limit(1);
 
     List<ServerlessInstanceStats> snapshots = persistence.createQuery(ServerlessInstanceStats.class)
@@ -85,7 +85,7 @@ public class ServerlessInstanceStatServiceImpl implements ServerlessInstanceStat
   @Override
   @Nullable
   public Instant getFirstSnapshotTime(@NotNull String accountId) {
-    FindOptions options = persistence.analyticNodePreferenceOptions();
+    FindOptions options = new FindOptions();
     options.limit(1);
 
     List<ServerlessInstanceStats> snapshots = persistence.createQuery(ServerlessInstanceStats.class)
@@ -171,8 +171,7 @@ public class ServerlessInstanceStatServiceImpl implements ServerlessInstanceStat
 
     List<ServerlessInstanceStats> timeline = new LinkedList<>();
 
-    try (HIterator<ServerlessInstanceStats> iterator =
-             new HIterator<>(query.fetch(persistence.analyticNodePreferenceOptions()))) {
+    try (HIterator<ServerlessInstanceStats> iterator = new HIterator<>(query.fetch())) {
       while (iterator.hasNext()) {
         timeline.add(iterator.next());
       }

--- a/400-rest/src/test/java/software/wings/service/impl/instance/stats/ServerlessInstanceStatServiceImplTest.java
+++ b/400-rest/src/test/java/software/wings/service/impl/instance/stats/ServerlessInstanceStatServiceImplTest.java
@@ -31,7 +31,7 @@ import io.harness.rule.Owner;
 import software.wings.beans.User;
 import software.wings.beans.infrastructure.instance.InvocationCount.InvocationCountKey;
 import software.wings.beans.infrastructure.instance.stats.ServerlessInstanceStats;
-import software.wings.dl.WingsMongoPersistence;
+import software.wings.dl.WingsPersistence;
 import software.wings.resources.stats.model.ServerlessInstanceTimeline;
 import software.wings.security.UserPermissionInfo;
 import software.wings.security.UserRequestContext;
@@ -43,9 +43,6 @@ import software.wings.service.intfc.instance.ServerlessDashboardService;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
-import com.mongodb.ReadPreference;
-import com.mongodb.Tag;
-import com.mongodb.TagSet;
 import java.time.Instant;
 import java.util.Collections;
 import org.junit.Before;
@@ -63,7 +60,7 @@ import org.mongodb.morphia.query.UpdateOperations;
 import org.mongodb.morphia.query.UpdateResults;
 
 public class ServerlessInstanceStatServiceImplTest extends CategoryTest {
-  @Mock private WingsMongoPersistence wingsPersistence;
+  @Mock private WingsPersistence wingsPersistence;
   @Mock private ServerlessDashboardService serverlessDashboardService;
   @Mock private UserService userService;
 
@@ -97,11 +94,9 @@ public class ServerlessInstanceStatServiceImplTest extends CategoryTest {
   @Category(UnitTests.class)
   public void test_getLastSnapshotTime() {
     final Mocks mocks = setup_wingspersistence();
-    doReturn(new FindOptions().readPreference(
-                 ReadPreference.secondaryPreferred(new TagSet(new Tag("nodeType", "ANALYTICS")))))
-        .when(wingsPersistence)
-        .analyticNodePreferenceOptions();
-    doReturn(Collections.singletonList(getServerlessInstanceStats())).when(mocks.getQueryMock()).asList(any());
+    doReturn(Collections.singletonList(getServerlessInstanceStats()))
+        .when(mocks.getQueryMock())
+        .asList(any(FindOptions.class));
     final Instant lastSnapshotTime = serverlessInstanceStatService.getLastSnapshotTime(ACCOUNTID);
     assertThat(lastSnapshotTime).isBeforeOrEqualTo(Instant.now());
   }
@@ -111,11 +106,9 @@ public class ServerlessInstanceStatServiceImplTest extends CategoryTest {
   @Category(UnitTests.class)
   public void test_getFirstSnapshotTime() {
     final Mocks mocks = setup_wingspersistence();
-    doReturn(new FindOptions().readPreference(
-                 ReadPreference.secondaryPreferred(new TagSet(new Tag("nodeType", "ANALYTICS")))))
-        .when(wingsPersistence)
-        .analyticNodePreferenceOptions();
-    doReturn(Collections.singletonList(getServerlessInstanceStats())).when(mocks.getQueryMock()).asList(any());
+    doReturn(Collections.singletonList(getServerlessInstanceStats()))
+        .when(mocks.getQueryMock())
+        .asList(any(FindOptions.class));
     final Instant lastSnapshotTime = serverlessInstanceStatService.getFirstSnapshotTime(ACCOUNTID);
     assertThat(lastSnapshotTime).isBeforeOrEqualTo(Instant.now());
   }
@@ -130,7 +123,7 @@ public class ServerlessInstanceStatServiceImplTest extends CategoryTest {
     doReturn(morphiaIteratorMock).when(queryMock).fetch();
     doReturn(getServerlessInstanceStats()).when(morphiaIteratorMock).next();
     doReturn(true).doReturn(false).when(morphiaIteratorMock).hasNext();
-    doReturn(morphiaIteratorMock).when(queryMock).fetch(any());
+    doReturn(morphiaIteratorMock).when(queryMock).fetch();
     doReturn(Collections.emptySet())
         .when(serverlessDashboardService)
         .getDeletedAppIds(anyString(), anyLong(), anyLong());

--- a/960-persistence/src/main/java/io/harness/mongo/MongoModule.java
+++ b/960-persistence/src/main/java/io/harness/mongo/MongoModule.java
@@ -230,7 +230,7 @@ public class MongoModule extends AbstractModule {
     if (Objects.isNull(tags)) {
       readPreference = ReadPreference.secondaryPreferred();
     } else {
-      readPreference = ReadPreference.secondaryPreferred(tags);
+      readPreference = ReadPreference.secondary(tags);
     }
 
     final String mongoClientUrl = mongoConfig.getUri();

--- a/960-persistence/src/main/java/io/harness/persistence/HPersistence.java
+++ b/960-persistence/src/main/java/io/harness/persistence/HPersistence.java
@@ -12,16 +12,12 @@ import io.harness.beans.PageRequest;
 import io.harness.beans.PageResponse;
 import io.harness.exception.ExceptionUtils;
 import io.harness.health.HealthMonitor;
-import io.harness.ng.DbAliases;
 import io.harness.persistence.HQuery.QueryChecks;
 
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.MongoSocketOpenException;
 import com.mongodb.MongoSocketReadException;
-import com.mongodb.ReadPreference;
-import com.mongodb.Tag;
-import com.mongodb.TagSet;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -30,7 +26,6 @@ import java.util.Set;
 import org.mongodb.morphia.AdvancedDatastore;
 import org.mongodb.morphia.FindAndModifyOptions;
 import org.mongodb.morphia.query.CountOptions;
-import org.mongodb.morphia.query.FindOptions;
 import org.mongodb.morphia.query.Query;
 import org.mongodb.morphia.query.UpdateOperations;
 import org.mongodb.morphia.query.UpdateResults;
@@ -40,7 +35,6 @@ import org.slf4j.LoggerFactory;
 public interface HPersistence extends HealthMonitor {
   String ANALYTICS_STORE_NAME = "analytic";
   Store DEFAULT_STORE = Store.builder().name("default").build();
-  Store CG_HARNESS_STORE = Store.builder().name(DbAliases.HARNESS).build();
   Store ANALYTIC_STORE = Store.builder().name(ANALYTICS_STORE_NAME).build();
 
   static Logger logger() {
@@ -110,7 +104,7 @@ public interface HPersistence extends HealthMonitor {
                .orElseGet(() -> DEFAULT_STORE));
 
     // only if the request is for cg db, get from analytics node
-    if (DEFAULT_STORE.equals(classStore) || CG_HARNESS_STORE.equals(classStore)) {
+    if (DEFAULT_STORE.equals(classStore)) {
       return getDatastore(ANALYTIC_STORE);
     }
     return getDatastore(classStore);
@@ -434,10 +428,5 @@ public interface HPersistence extends HealthMonitor {
     }
     // one last try
     return executor.execute();
-  }
-
-  default FindOptions analyticNodePreferenceOptions() {
-    return new FindOptions().readPreference(
-        ReadPreference.secondaryPreferred(new TagSet(new Tag("nodeType", "ANALYTICS"))));
   }
 }


### PR DESCRIPTION
Reverts harness/harness-core#37919

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/38078)
<!-- Reviewable:end -->
