### PR TITLE
[feat]: [PL-28744]: updating default onDelegate value to true

### DIFF
--- a/440-connector-nextgen/src/main/java/io/harness/connector/entities/embedded/customsecretmanager/CustomSecretManagerConnector.java
+++ b/440-connector-nextgen/src/main/java/io/harness/connector/entities/embedded/customsecretmanager/CustomSecretManagerConnector.java
@@ -44,5 +44,5 @@ public class CustomSecretManagerConnector extends Connector {
   private String host;
   private String workingDirectory;
   private TemplateLinkConfigForCustomSecretManager template;
-  @Builder.Default private Boolean onDelegate = Boolean.FALSE;
+  @Builder.Default private Boolean onDelegate = Boolean.TRUE;
 }

--- a/440-connector-nextgen/src/test/java/io/harness/connector/mappers/secretmanagermappper/CustomSecretManagerConnectorTest.java
+++ b/440-connector-nextgen/src/test/java/io/harness/connector/mappers/secretmanagermappper/CustomSecretManagerConnectorTest.java
@@ -31,7 +31,7 @@ public class CustomSecretManagerConnectorTest extends CategoryTest {
     MockitoAnnotations.initMocks(this);
     defaultFieldNamesToValue = new HashMap<>();
     defaultFieldNamesToValue.put("isDefault", false);
-    defaultFieldNamesToValue.put("onDelegate", false);
+    defaultFieldNamesToValue.put("onDelegate", true);
   }
 
   @Test

--- a/440-connector-nextgen/src/test/java/io/harness/connector/mappers/secretmanagermappper/CustomSecretManagerDTOTest.java
+++ b/440-connector-nextgen/src/test/java/io/harness/connector/mappers/secretmanagermappper/CustomSecretManagerDTOTest.java
@@ -32,7 +32,7 @@ public class CustomSecretManagerDTOTest extends CategoryTest {
     defaultFieldNamesToValue = new HashMap<>();
     defaultFieldNamesToValue.put("isDefault", false);
     defaultFieldNamesToValue.put("harnessManaged", false);
-    defaultFieldNamesToValue.put("onDelegate", false);
+    defaultFieldNamesToValue.put("onDelegate", true);
   }
 
   @Test

--- a/440-connector-nextgen/src/test/java/io/harness/connector/mappers/secretmanagermappper/CustomSecretManagerDTOToEntityTest.java
+++ b/440-connector-nextgen/src/test/java/io/harness/connector/mappers/secretmanagermappper/CustomSecretManagerDTOToEntityTest.java
@@ -37,7 +37,7 @@ public class CustomSecretManagerDTOToEntityTest extends CategoryTest {
     MockitoAnnotations.initMocks(this);
     defaultFieldNamesToValue = new HashMap<>();
     defaultFieldNamesToValue.put("isDefault", false);
-    defaultFieldNamesToValue.put("onDelegate", false);
+    defaultFieldNamesToValue.put("onDelegate", true);
   }
 
   @Test

--- a/440-connector-nextgen/src/test/java/io/harness/connector/mappers/secretmanagermappper/CustomSecretManagerEntityToDTOTest.java
+++ b/440-connector-nextgen/src/test/java/io/harness/connector/mappers/secretmanagermappper/CustomSecretManagerEntityToDTOTest.java
@@ -37,7 +37,7 @@ public class CustomSecretManagerEntityToDTOTest extends CategoryTest {
     MockitoAnnotations.initMocks(this);
     defaultFieldNamesToValue = new HashMap<>();
     defaultFieldNamesToValue.put("isDefault", false);
-    defaultFieldNamesToValue.put("onDelegate", false);
+    defaultFieldNamesToValue.put("onDelegate", true);
     defaultFieldNamesToValue.put("harnessManaged", false);
     // Default of connector ref is secret ref data object which has all fields as null.
     defaultFieldNamesToValue.put("connectorRef", new SecretRefData());
@@ -54,7 +54,7 @@ public class CustomSecretManagerEntityToDTOTest extends CategoryTest {
         customSecretManagerEntitytoDTO.createConnectorDTO(customSecretManagerConnector);
     // Check
     assertNotNull(customSecretManagerConnectorDTO);
-    assertThat(customSecretManagerConnectorDTO.getOnDelegate()).isEqualTo(false);
+    assertThat(customSecretManagerConnectorDTO.getOnDelegate()).isEqualTo(true);
   }
 
   @Test
@@ -69,7 +69,7 @@ public class CustomSecretManagerEntityToDTOTest extends CategoryTest {
         customSecretManagerEntitytoDTO.createConnectorDTO(customSecretManagerConnector);
     // Check
     assertNotNull(customSecretManagerConnectorDTO);
-    assertThat(customSecretManagerConnectorDTO.getOnDelegate()).isEqualTo(false);
+    assertThat(customSecretManagerConnectorDTO.getOnDelegate()).isEqualTo(true);
   }
 
   @Test

--- a/954-connector-beans/src/main/java/io/harness/delegate/beans/connector/customsecretmanager/CustomSecretManagerConnectorDTO.java
+++ b/954-connector-beans/src/main/java/io/harness/delegate/beans/connector/customsecretmanager/CustomSecretManagerConnectorDTO.java
@@ -47,7 +47,7 @@ import lombok.experimental.FieldDefaults;
 @Schema(name = "CustomSecretManager", description = "This contains details of Custom Secret Manager connectors")
 public class CustomSecretManagerConnectorDTO extends ConnectorConfigDTO implements DelegateSelectable {
   Set<String> delegateSelectors;
-  @Builder.Default Boolean onDelegate = Boolean.FALSE;
+  @Builder.Default Boolean onDelegate = Boolean.TRUE;
   @Schema(description = SecretManagerDescriptionConstants.DEFAULT) private boolean isDefault;
   @Schema @JsonIgnore private boolean harnessManaged;
 

--- a/954-connector-beans/src/main/java/io/harness/delegate/beans/connector/customsecretmanager/CustomSecretManagerConnectorDTO.java
+++ b/954-connector-beans/src/main/java/io/harness/delegate/beans/connector/customsecretmanager/CustomSecretManagerConnectorDTO.java
@@ -70,7 +70,7 @@ public class CustomSecretManagerConnectorDTO extends ConnectorConfigDTO implemen
 
   @Override
   public void validate() {
-    if (onDelegate) {
+    if (Boolean.TRUE.equals(onDelegate)) {
       boolean throwException = false;
       StringBuilder errorMessageBuilder =
           new StringBuilder("Target machine information should be absent if execution is on delegate. Found ");

--- a/954-connector-beans/src/main/java/io/harness/delegate/beans/connector/customsecretmanager/CustomSecretManagerConnectorDTO.java
+++ b/954-connector-beans/src/main/java/io/harness/delegate/beans/connector/customsecretmanager/CustomSecretManagerConnectorDTO.java
@@ -15,6 +15,9 @@ import io.harness.connector.DelegateSelectable;
 import io.harness.delegate.beans.connector.ConnectorConfigDTO;
 import io.harness.encryption.SecretRefData;
 import io.harness.encryption.SecretReference;
+import io.harness.eraro.ErrorCode;
+import io.harness.exception.InvalidRequestException;
+import io.harness.exception.WingsException;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -22,6 +25,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import javax.validation.constraints.NotNull;
@@ -62,5 +66,47 @@ public class CustomSecretManagerConnectorDTO extends ConnectorConfigDTO implemen
   @Override
   public List<DecryptableEntity> getDecryptableEntities() {
     return Collections.singletonList(this);
+  }
+
+  @Override
+  public void validate() {
+    if (onDelegate) {
+      boolean throwException = false;
+      StringBuilder errorMessageBuilder =
+          new StringBuilder("Target machine information should be absent if execution is on delegate. Found ");
+      if (host != null) {
+        throwException = true;
+        errorMessageBuilder.append(String.format("host = %s ", host));
+      }
+      if (connectorRef != null) {
+        throwException = true;
+        errorMessageBuilder.append(String.format("connector ref = %s ", connectorRef));
+      }
+      if (workingDirectory != null) {
+        throwException = true;
+        errorMessageBuilder.append(String.format("working directory = %s ", workingDirectory));
+      }
+      if (throwException) {
+        throw new InvalidRequestException(
+            errorMessageBuilder.toString(), ErrorCode.INVALID_REQUEST, WingsException.USER);
+      }
+    } else {
+      List<String> targetMachineNullFields = new LinkedList<>();
+      if (host == null) {
+        targetMachineNullFields.add("host");
+      }
+      if (workingDirectory == null) {
+        targetMachineNullFields.add("working directory");
+      }
+      if (connectorRef == null) {
+        targetMachineNullFields.add("connector ref");
+      }
+      String errorMessage =
+          "Target machine information should be present if execution is not on delegate. But the following values are absent. "
+          + targetMachineNullFields;
+      if (targetMachineNullFields.size() > 0) {
+        throw new InvalidRequestException(errorMessage, ErrorCode.INVALID_REQUEST, WingsException.USER);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Describe your changes
Changing default value of OnDelegate to true. 
## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/38371)
<!-- Reviewable:end -->
