### PR TITLE
[CDS-36296]: QA hotfix refarding infrastructure table in NG caused du…

### DIFF
--- a/950-ng-project-n-orgs/src/resources/timescale/create_infrastructure_table.sql
+++ b/950-ng-project-n-orgs/src/resources/timescale/create_infrastructure_table.sql
@@ -22,7 +22,6 @@ CREATE TABLE IF NOT EXISTS public.infrastructures (
     namespace text,
     resource_group text
 );
-ALTER TABLE ONLY public.infrastructures
-    ADD CONSTRAINT infrastructures_pkey PRIMARY KEY (id);
+ALTER TABLE public.infrastructures DROP CONSTRAINT IF EXISTS infrastructures_pkey;
 
 COMMIT;

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=77012
+build.number=77013
 build.patch=000
 delegate.version=22.09.13
 delegate.patch=000


### PR DESCRIPTION
…e to a bug leading to change in version

## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/38400)
<!-- Reviewable:end -->
