### PR TITLE
fix: [CDS-45546]: Command string not escaping ampersand and pipe characters

### DIFF
--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/winrm/WinRmExecutorHelper.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/winrm/WinRmExecutorHelper.java
@@ -98,15 +98,33 @@ public class WinRmExecutorHelper {
       partOfCommand = partOfCommand.replace("$", "`$");
       // This is to escape quotes
       partOfCommand = partOfCommand.replaceAll("\"", "`\\\\\"");
+      // Replace pipe only if part of a string, else skip
+      partOfCommand = escapePipe(partOfCommand);
+      // Replace ampersand only if part of a string, else skip
+      partOfCommand = escapeAmpersand(partOfCommand);
       partOfCommand = escapeWordBreakChars(escapeLineBreakChars(partOfCommand));
       String appendTextToFileCommand = powershell + " Invoke-Command " + commandParametersString
           + " -command {[IO.File]::AppendAllText(\\\"" + psScriptFile + "\\\", \\\"" + partOfCommand + "\\\" ) }";
 
-      // Append each command with PS Invoke command which is write command to file and also add the PS newline character
-      // for correct escaping
       commandList.add(appendTextToFileCommand);
     }
     return commandList;
+  }
+
+  private static String escapePipe(String partOfCommand) {
+    Pattern patternForPipeWithinAString = Pattern.compile("[a-zA-Z]+\\|");
+    if (patternForPipeWithinAString.matcher(partOfCommand).find()) {
+      partOfCommand = partOfCommand.replaceAll("\\|", "`\\\"|`\\\"");
+    }
+    return partOfCommand;
+  }
+
+  private static String escapeAmpersand(String partOfCommand) {
+    Pattern patternForAmpersandWithinString = Pattern.compile("[a-zA-Z0-9]+&");
+    if (patternForAmpersandWithinString.matcher(partOfCommand).find()) {
+      partOfCommand = partOfCommand.replaceAll("&", "^&");
+    }
+    return partOfCommand;
   }
 
   private static String buildCommandParameters(List<WinRmCommandParameter> commandParameters) {

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/winrm/DefaultWinRmExecutorTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/winrm/DefaultWinRmExecutorTest.java
@@ -108,6 +108,18 @@ public class DefaultWinRmExecutorTest extends CategoryTest {
   }
 
   @Test
+  @Owner(developers = BOJAN)
+  @Category(UnitTests.class)
+  public void testCharacterEscaping() {
+    String command = "a!a@a#a$a%a^a&a*a(a)a_a+a-a=a[a]a{a}a;a'a\\a:a\"a|a,a.a/a<a>a?a\r\na";
+    String commandWithEscapedCharacters =
+        "a!a@a#a`$a%a^a^&a*a(a)a_a+a-a=a[a]a{a}a;a'a\\a:a`\\\"a`\"|`\"a,a.a/a<a>a?a`r`na";
+    List<String> result1 =
+        WinRmExecutorHelper.constructCommandsList(command, "tempPSScript.ps1", DefaultWinRmExecutor.POWERSHELL, null);
+    assertThat(result1.get(0)).contains(commandWithEscapedCharacters);
+  }
+
+  @Test
   @Owner(developers = SAHIL)
   @Category(UnitTests.class)
   public void testConstructPSScriptWithCommandsWithoutProfile() {

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=77030
+build.number=77031
 build.patch=000
 delegate.version=22.09.13
 delegate.patch=000


### PR DESCRIPTION
…acters

## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/39275)
<!-- Reviewable:end -->
