### PR TITLE
fix: [CDS-45858]: [HF] Prevent reading logs from tf output and limit error message size

### DIFF
--- a/930-delegate-tasks/src/main/java/io/harness/delegate/exceptionhandler/handler/TerraformRuntimeExceptionHandler.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/exceptionhandler/handler/TerraformRuntimeExceptionHandler.java
@@ -32,7 +32,9 @@ import static io.harness.delegate.task.terraform.TerraformExceptionConstants.Hin
 import static io.harness.delegate.task.terraform.TerraformExceptionConstants.Hints.HINT_FAIL_TO_INSTALL_PROVIDER;
 import static io.harness.delegate.task.terraform.TerraformExceptionConstants.Hints.HINT_INVALID_CREDENTIALS_AWS;
 import static io.harness.delegate.task.terraform.TerraformExceptionConstants.Hints.HINT_INVALID_CRED_FOR_S3_BACKEND;
+import static io.harness.delegate.task.terraform.TerraformExceptionConstants.Message.GENERIC_NO_TERRAFORM_ERROR;
 import static io.harness.delegate.task.terraform.TerraformExceptionConstants.Message.MESSAGE_ERROR_INSPECTING_STATE_IN_BACKEND;
+import static io.harness.delegate.task.terraform.TerraformExceptionConstants.Message.MESSAGE_ERROR_TOO_LONG;
 import static io.harness.delegate.task.terraform.TerraformExceptionConstants.Message.MESSAGE_FAILED_TO_GET_EXISTING_WORKSPACES;
 import static io.harness.delegate.task.terraform.TerraformExceptionConstants.Message.MESSAGE_INVALID_CREDENTIALS_AWS;
 
@@ -68,6 +70,7 @@ public class TerraformRuntimeExceptionHandler implements ExceptionHandler {
   private static final Pattern ERROR_LOCATION_LINE_BLOCK_PATTERN =
       Pattern.compile("on\\s(.+?)\\sline\\s(\\d+),\\sin\\s(.+?):\\s+\\d+:(.*)");
   private static final Pattern ERROR_ARGUMENT_PATTERN = Pattern.compile(".+?\\s\".+?\"");
+  private static final int ERROR_MAX_CHARACTERS_LIMIT = 512;
 
   public static Set<Class<? extends Exception>> exceptions() {
     return ImmutableSet.<Class<? extends Exception>>builder().add(TerraformCliRuntimeException.class).build();
@@ -266,7 +269,19 @@ public class TerraformRuntimeExceptionHandler implements ExceptionHandler {
   }
 
   private String cleanError(String error) {
-    return error.replaceAll("\\[\\d{1,3}m", "");
+    if (isEmpty(error.trim())) {
+      return GENERIC_NO_TERRAFORM_ERROR;
+    }
+
+    return getMessageWithLimit(error.replaceAll("\\[\\d{1,3}m", ""));
+  }
+
+  private String getMessageWithLimit(String message) {
+    if (message.length() > ERROR_MAX_CHARACTERS_LIMIT) {
+      return message.substring(0, ERROR_MAX_CHARACTERS_LIMIT) + "... (" + MESSAGE_ERROR_TOO_LONG + ")";
+    }
+
+    return message;
   }
 
   @VisibleForTesting

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/terraform/TerraformExceptionConstants.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/terraform/TerraformExceptionConstants.java
@@ -59,6 +59,10 @@ public final class TerraformExceptionConstants {
     public static final String MESSAGE_INVALID_CREDENTIALS_AWS = "Invalid or missing credentials for AWS provider";
     public static final String MESSAGE_ERROR_INSPECTING_STATE_IN_BACKEND = "Failed to initialize terraform backend";
     public static final String MESSAGE_FAILED_TO_GET_EXISTING_WORKSPACES = "Failed to get existing workspaces";
+    public static final String GENERIC_NO_TERRAFORM_ERROR =
+        "Failed with unknown error. For more details please configure TF_LOG env variable and check execution logs";
+    public static final String MESSAGE_ERROR_TOO_LONG =
+        "Error message is too long to be fully displayed, please check execution logs for more details";
   }
 
   public static final class CliErrorMessages {

--- a/960-api-services/src/main/java/io/harness/cli/CliHelper.java
+++ b/960-api-services/src/main/java/io/harness/cli/CliHelper.java
@@ -69,9 +69,9 @@ public class CliHelper {
                                           .redirectError(new LogOutputStream() {
                                             @Override
                                             protected void processLine(String line) {
-                                              log.error(line);
                                               executionLogCallback.saveExecutionLog(line, LogLevel.ERROR);
                                               if (cliErrorPredicate.test(line)) {
+                                                log.error(line);
                                                 errorLogs.append(' ').append(line);
                                               }
                                             }

--- a/960-api-services/src/main/java/io/harness/cli/CliHelper.java
+++ b/960-api-services/src/main/java/io/harness/cli/CliHelper.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.zeroturnaround.exec.ProcessExecutor;
@@ -34,17 +35,27 @@ import org.zeroturnaround.exec.stream.LogOutputStream;
 @Singleton
 @OwnedBy(CDP)
 public class CliHelper {
+  private static final Predicate<String> NOOP_CLI_ERROR_PREDICATE = errorLine -> true;
+
   @Nonnull
   public CliResponse executeCliCommand(String command, long timeoutInMillis, Map<String, String> envVariables,
       String directory, LogCallback executionLogCallback) throws IOException, InterruptedException, TimeoutException {
-    return executeCliCommand(
-        command, timeoutInMillis, envVariables, directory, executionLogCallback, command, new EmptyLogOutputStream());
+    return executeCliCommand(command, timeoutInMillis, envVariables, directory, executionLogCallback, command,
+        new EmptyLogOutputStream(), NOOP_CLI_ERROR_PREDICATE);
   }
 
   @Nonnull
   public CliResponse executeCliCommand(String command, long timeoutInMillis, Map<String, String> envVariables,
       String directory, LogCallback executionLogCallback, String loggingCommand, LogOutputStream logOutputStream)
       throws IOException, InterruptedException, TimeoutException {
+    return executeCliCommand(command, timeoutInMillis, envVariables, directory, executionLogCallback, loggingCommand,
+        logOutputStream, NOOP_CLI_ERROR_PREDICATE);
+  }
+
+  @Nonnull
+  public CliResponse executeCliCommand(String command, long timeoutInMillis, Map<String, String> envVariables,
+      String directory, LogCallback executionLogCallback, String loggingCommand, LogOutputStream logOutputStream,
+      Predicate<String> cliErrorPredicate) throws IOException, InterruptedException, TimeoutException {
     executionLogCallback.saveExecutionLog(loggingCommand, LogLevel.INFO, RUNNING);
 
     StringBuilder errorLogs = new StringBuilder();
@@ -60,7 +71,9 @@ public class CliHelper {
                                             protected void processLine(String line) {
                                               log.error(line);
                                               executionLogCallback.saveExecutionLog(line, LogLevel.ERROR);
-                                              errorLogs.append(' ').append(line);
+                                              if (cliErrorPredicate.test(line)) {
+                                                errorLogs.append(' ').append(line);
+                                              }
                                             }
                                           });
 

--- a/960-api-services/src/main/java/io/harness/terraform/TerraformClientImpl.java
+++ b/960-api-services/src/main/java/io/harness/terraform/TerraformClientImpl.java
@@ -46,6 +46,7 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -55,6 +56,8 @@ import org.zeroturnaround.exec.stream.LogOutputStream;
 @Singleton
 @OwnedBy(CDP)
 public class TerraformClientImpl implements TerraformClient {
+  private static final Pattern TF_LOG_LINE_PATTERN =
+      Pattern.compile("\\[(?:TRACE|DEBUG|INFO|WARN|ERROR|CRITICAL)\\]\\s?(.+?)?:");
   public static final String TARGET_PARAM = "-target=";
   public static final String VAR_FILE_PARAM = "-var-file=";
 
@@ -308,7 +311,8 @@ public class TerraformClientImpl implements TerraformClient {
           noDirExistErrorMsg);
     }
 
-    return cliHelper.executeCliCommand(
-        command, timeoutInMillis, envVariables, scriptDirectory, executionLogCallBack, loggingCommand, logOutputStream);
+    return cliHelper.executeCliCommand(command, timeoutInMillis, envVariables, scriptDirectory, executionLogCallBack,
+        loggingCommand, logOutputStream,
+        logLine -> isNotEmpty(logLine) && !TF_LOG_LINE_PATTERN.matcher(logLine).find());
   }
 }

--- a/960-api-services/src/test/java/io/harness/terraform/TerraformClientImplTest.java
+++ b/960-api-services/src/test/java/io/harness/terraform/TerraformClientImplTest.java
@@ -96,7 +96,7 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(cliResponse)
         .when(cliHelper)
         .executeCliCommand(eq(format("echo \"no\" | %s", command)), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT),
-            eq(Collections.emptyMap()), eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any());
+            eq(Collections.emptyMap()), eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any(), any());
 
     CliResponse actualResponse = terraformClientImpl.init(terraformInitCommandRequest,
         DEFAULT_TERRAFORM_COMMAND_TIMEOUT, Collections.emptyMap(), SCRIPT_FILES_DIRECTORY, logCallback);
@@ -133,7 +133,7 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(cliResponse)
         .when(cliHelper)
         .executeCliCommand(eq(command), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT), eq(Collections.emptyMap()),
-            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any());
+            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any(), any());
 
     doReturn(getCliResponseTfVersion(version.getMajor(), version.getMinor(), version.getPatch()))
         .when(cliHelper)
@@ -160,7 +160,7 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(cliResponse)
         .when(cliHelper)
         .executeCliCommand(eq(command), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT), eq(Collections.emptyMap()),
-            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any());
+            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any(), any());
 
     CliResponse actualResponse = terraformClientImpl.plan(terraformPlanCommandRequest,
         DEFAULT_TERRAFORM_COMMAND_TIMEOUT, Collections.emptyMap(), SCRIPT_FILES_DIRECTORY, logCallback);
@@ -183,7 +183,7 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(cliResponse)
         .when(cliHelper)
         .executeCliCommand(and(contains(command), contains(varParams)), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT),
-            eq(Collections.emptyMap()), eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), contains(command), any());
+            eq(Collections.emptyMap()), eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), contains(command), any(), any());
 
     CliResponse actualResponse = terraformClientImpl.plan(terraformPlanCommandRequest,
         DEFAULT_TERRAFORM_COMMAND_TIMEOUT, Collections.emptyMap(), SCRIPT_FILES_DIRECTORY, logCallback);
@@ -212,7 +212,7 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(cliResponse)
         .when(cliHelper)
         .executeCliCommand(and(contains(command), contains(varParams)), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT),
-            eq(Collections.emptyMap()), eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), contains(command), any());
+            eq(Collections.emptyMap()), eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), contains(command), any(), any());
 
     assertThatThrownBy(()
                            -> terraformClientImpl.plan(terraformPlanCommandRequest, DEFAULT_TERRAFORM_COMMAND_TIMEOUT,
@@ -233,7 +233,7 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(cliResponse)
         .when(cliHelper)
         .executeCliCommand(eq(command), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT), eq(Collections.emptyMap()),
-            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any());
+            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any(), any());
 
     CliResponse actualResponse = terraformClientImpl.refresh(terraformRefreshCommandRequest,
         DEFAULT_TERRAFORM_COMMAND_TIMEOUT, Collections.emptyMap(), SCRIPT_FILES_DIRECTORY, logCallback);
@@ -263,7 +263,7 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(cliResponse)
         .when(cliHelper)
         .executeCliCommand(eq(command), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT), eq(Collections.emptyMap()),
-            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(loggingCommand), any());
+            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(loggingCommand), any(), any());
 
     CliResponse actualResponse = terraformClientImpl.refresh(terraformRefreshCommandRequest,
         DEFAULT_TERRAFORM_COMMAND_TIMEOUT, Collections.emptyMap(), SCRIPT_FILES_DIRECTORY, logCallback);
@@ -297,7 +297,7 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(cliResponse)
         .when(cliHelper)
         .executeCliCommand(eq(command), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT), eq(Collections.emptyMap()),
-            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any());
+            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any(), any());
 
     CliResponse actualResponse = terraformClientImpl.apply(terraformApplyCommandRequest,
         DEFAULT_TERRAFORM_COMMAND_TIMEOUT, Collections.emptyMap(), SCRIPT_FILES_DIRECTORY, logCallback);
@@ -315,7 +315,7 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(cliResponse)
         .when(cliHelper)
         .executeCliCommand(eq(command), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT), eq(Collections.emptyMap()),
-            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any());
+            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any(), any());
 
     CliResponse actualResponse = terraformClientImpl.workspace(workspace, true, DEFAULT_TERRAFORM_COMMAND_TIMEOUT,
         Collections.emptyMap(), SCRIPT_FILES_DIRECTORY, logCallback);
@@ -338,7 +338,7 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(cliResponse)
         .when(cliHelper)
         .executeCliCommand(eq(command), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT), eq(Collections.emptyMap()),
-            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any());
+            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any(), any());
 
     CliResponse actualResponse = terraformClientImpl.show(plan, DEFAULT_TERRAFORM_COMMAND_TIMEOUT,
         Collections.emptyMap(), SCRIPT_FILES_DIRECTORY, logCallback, planJsonLogOutputStream);
@@ -362,7 +362,7 @@ public class TerraformClientImplTest extends CategoryTest {
     verify(cliHelper, never())
         .executeCliCommand(and(contains("terraform show"), contains("-json")), anyLong(),
             anyMapOf(String.class, String.class), anyString(), any(LogCallback.class), anyString(),
-            any(LogOutputStream.class));
+            any(LogOutputStream.class), any());
     assertThat(cliResponse.getCommandExecutionStatus()).isEqualTo(CommandExecutionStatus.SKIPPED);
   }
 
@@ -399,14 +399,14 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(CliResponse.builder().commandExecutionStatus(CommandExecutionStatus.SUCCESS).build())
         .when(cliHelper)
         .executeCliCommand(contains("terraform"), anyLong(), anyMapOf(String.class, String.class), anyString(),
-            any(LogCallback.class), contains("terraform"), any(LogOutputStream.class));
+            any(LogCallback.class), contains("terraform"), any(LogOutputStream.class), any());
 
     terraformClientImpl.show("planName", DEFAULT_TERRAFORM_COMMAND_TIMEOUT, Collections.emptyMap(),
         SCRIPT_FILES_DIRECTORY, logCallback, planJsonLogOutputStream);
 
     ArgumentCaptor<String> commandCaptor = ArgumentCaptor.forClass(String.class);
     verify(cliHelper).executeCliCommand(commandCaptor.capture(), anyLong(), anyMapOf(String.class, String.class),
-        anyString(), any(LogCallback.class), anyString(), any(LogOutputStream.class));
+        anyString(), any(LogCallback.class), anyString(), any(LogOutputStream.class), any());
     assertThat(commandCaptor.getAllValues().get(0)).contains("terraform show");
     assertThat(commandCaptor.getAllValues().get(0)).contains("-json");
   }
@@ -424,14 +424,14 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(CliResponse.builder().commandExecutionStatus(CommandExecutionStatus.SUCCESS).build())
         .when(cliHelper)
         .executeCliCommand(contains("terraform"), anyLong(), anyMapOf(String.class, String.class), anyString(),
-            any(LogCallback.class), contains("terraform"), any(LogOutputStream.class));
+            any(LogCallback.class), contains("terraform"), any(LogOutputStream.class), any());
 
     terraformClientImpl.show("planName", DEFAULT_TERRAFORM_COMMAND_TIMEOUT, Collections.emptyMap(),
         SCRIPT_FILES_DIRECTORY, logCallback, planJsonLogOutputStream);
 
     ArgumentCaptor<String> commandCaptor = ArgumentCaptor.forClass(String.class);
     verify(cliHelper).executeCliCommand(commandCaptor.capture(), anyLong(), anyMapOf(String.class, String.class),
-        anyString(), any(LogCallback.class), anyString(), any(LogOutputStream.class));
+        anyString(), any(LogCallback.class), anyString(), any(LogOutputStream.class), any());
     assertThat(commandCaptor.getAllValues().get(0)).contains("terraform show");
     assertThat(commandCaptor.getAllValues().get(0)).contains("-json");
   }
@@ -446,7 +446,7 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(cliResponse)
         .when(cliHelper)
         .executeCliCommand(eq(command), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT), eq(Collections.emptyMap()),
-            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any());
+            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any(), any());
 
     CliResponse actualResponse = terraformClientImpl.output(
         tfOutputsFile, DEFAULT_TERRAFORM_COMMAND_TIMEOUT, Collections.emptyMap(), SCRIPT_FILES_DIRECTORY, logCallback);
@@ -465,7 +465,7 @@ public class TerraformClientImplTest extends CategoryTest {
     doReturn(cliResponse)
         .when(cliHelper)
         .executeCliCommand(eq(command), eq(DEFAULT_TERRAFORM_COMMAND_TIMEOUT), eq(Collections.emptyMap()),
-            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any());
+            eq(SCRIPT_FILES_DIRECTORY), eq(logCallback), eq(command), any(), any());
 
     CliResponse actualResponse = terraformClientImpl.output(
         tfOutputsFile, DEFAULT_TERRAFORM_COMMAND_TIMEOUT, Collections.emptyMap(), SCRIPT_FILES_DIRECTORY, logCallback);

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=77224
+build.number=77225
 build.patch=000
 delegate.version=22.10.11
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/39552)
<!-- Reviewable:end -->
