### PR TITLE
[fix]: [PL-29470]: Updating CreateACLsFromRoleAssignmentsMigration to NoopMigration as it was specific for Hotfix.

### DIFF
--- a/access-control/build.properties
+++ b/access-control/build.properties
@@ -1,4 +1,4 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=77102
+build.number=77103
 build.patch=000

--- a/access-control/service/src/main/java/io/harness/accesscontrol/commons/migration/AccessControlMongoBackgroundMigrationDetails.java
+++ b/access-control/service/src/main/java/io/harness/accesscontrol/commons/migration/AccessControlMongoBackgroundMigrationDetails.java
@@ -12,7 +12,6 @@ import static io.harness.annotations.dev.HarnessTeam.PL;
 import io.harness.accesscontrol.acl.migration.ACLAddBooleanFieldsMigration;
 import io.harness.accesscontrol.resources.resourcegroups.migration.MultipleManagedResourceGroupMigration;
 import io.harness.accesscontrol.roleassignments.migration.AccountBasicRoleAssignmentAdditionMigration;
-import io.harness.accesscontrol.roleassignments.migration.CreateACLsFromRoleAssignmentsMigration;
 import io.harness.accesscontrol.roleassignments.migration.RoleAssignmentPrincipalScopeLevelMigration;
 import io.harness.accesscontrol.roleassignments.migration.RoleAssignmentResourceGroupMigration;
 import io.harness.accesscontrol.roleassignments.migration.RoleAssignmentScopeAdditionMigration;

--- a/access-control/service/src/main/java/io/harness/accesscontrol/commons/migration/AccessControlMongoBackgroundMigrationDetails.java
+++ b/access-control/service/src/main/java/io/harness/accesscontrol/commons/migration/AccessControlMongoBackgroundMigrationDetails.java
@@ -57,7 +57,7 @@ public class AccessControlMongoBackgroundMigrationDetails implements MigrationDe
         .add(Pair.of(12, ACLAddBooleanFieldsMigration.class))
         .add(Pair.of(13, AccountBasicRoleAssignmentAdditionMigration.class))
         .add(Pair.of(14, UserRoleAssignmentRemovalMigration.class))
-        .add(Pair.of(15, CreateACLsFromRoleAssignmentsMigration.class))
+        .add(Pair.of(15, NoopMigration.class))
         .build();
   }
 }


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/39578)
<!-- Reviewable:end -->
