### PR TITLE
feat: [PL-28849]: added UT for fetch url operation for account level bitbucket onprem connector

### DIFF
--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/common/helper/GitFilePathHelperTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/common/helper/GitFilePathHelperTest.java
@@ -9,6 +9,7 @@ package io.harness.gitsync.common.helper;
 
 import static io.harness.annotations.dev.HarnessTeam.PL;
 import static io.harness.rule.OwnerRule.BHAVYA;
+import static io.harness.rule.OwnerRule.MOHIT_GARG;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyString;
@@ -51,6 +52,7 @@ public class GitFilePathHelperTest extends CategoryTest {
   String branch = "branch";
   String connectorRef = "connectorRef";
   String repoName = "repoName";
+  String org = "org";
   Scope scope = Scope.of(accountIdentifier, orgIdentifier, projectIdentifier);
   GitRepositoryDTO gitRepositoryDTO = GitRepositoryDTO.builder().name(repoName).build();
   @Before
@@ -175,6 +177,27 @@ public class GitFilePathHelperTest extends CategoryTest {
     String fileUrl = gitFilePathHelper.getFileUrl(scope, connectorRef, branch, filePath, gitRepositoryDTO);
     assertThat(fileUrl).isEqualTo(
         "https://bitbucket.dev.harness.io/projects/harness/repos/repoName/browse/filePath?at=refs/heads/branch");
+  }
+
+  @Test
+  @Owner(developers = MOHIT_GARG)
+  @Category(UnitTests.class)
+  public void testGetFileUrlForBitbucketServerAccountLevelConnector() {
+    String accountUrl = "https://bitbucket.dev.harness.io/scm";
+    BitbucketConnectorDTO bitbucketConnectorDTO =
+        BitbucketConnectorDTO.builder()
+            .connectionType(GitConnectionType.ACCOUNT)
+            .authentication(BitbucketAuthenticationDTO.builder().authType(GitAuthType.HTTP).build())
+            .url(accountUrl)
+            .build();
+    doReturn(bitbucketConnectorDTO)
+        .when(gitSyncConnectorHelper)
+        .getScmConnectorForGivenRepo(anyString(), anyString(), anyString(), anyString(), anyString());
+    String repo = org + "/" + repoName;
+    GitRepositoryDTO gitRepositoryDTO = GitRepositoryDTO.builder().name(repo).build();
+    String fileUrl = gitFilePathHelper.getFileUrl(scope, connectorRef, branch, filePath, gitRepositoryDTO);
+    assertThat(fileUrl).isEqualTo(
+        "https://bitbucket.dev.harness.io/projects/org/repos/repoName/browse/filePath?at=refs/heads/branch");
   }
 
   @Test


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>
  
- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>
  
  You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`
  
- Compile: `trigger compile`
- CodeFormat: `trigger codeformat`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- runDockerizationCheck: `trigger dockerizationcheck`
- runAuthorCheck: `trigger authorcheck`
- Checkstyle: `trigger checkstyle`
- PMD: `trigger pmd`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/39581)
<!-- Reviewable:end -->
