### PR TITLE
feat: [BT-2376]: Adding bazel cache file generation script

### DIFF
--- a/scripts/bazel/generate_credentials.sh
+++ b/scripts/bazel/generate_credentials.sh
@@ -5,7 +5,7 @@
 
 scripts/bazel/testDistribute.sh
 
-CACHE_FILE='bazelrc.cache'
+CACHE_FILE='bazelrc.test'
 
 CONTENT="#Remote cache configuration\n
 build --google_credentials=platform-bazel-cache-read.json\n
@@ -14,8 +14,10 @@ build --incompatible_remote_results_ignore_disk=true\n
 build --experimental_guard_against_concurrent_changes\n
 build --incompatible_strict_action_env\n"
 
-echo "$CONTENT" > ${CACHE_FILE}
+if [ `uname -s` = 'Darwin' ]; then
+  echo "$CONTENT" > ${CACHE_FILE}
 
-[ `uname -m` = 'arm64' ] \
-&& echo "build:macos --remote_cache=https://storage.googleapis.com/harness-bazel-cache-blr-dev-m1" >> ${CACHE_FILE} \
-|| echo "build:macos --remote_cache=https://storage.googleapis.com/harness-bazel-cache-blr-dev" >> ${CACHE_FILE}
+  [ `uname -m` = 'arm64' ] \
+  && echo "build:macos --remote_cache=https://storage.googleapis.com/harness-bazel-cache-blr-dev-m1" >> ${CACHE_FILE} \
+  || echo "build:macos --remote_cache=https://storage.googleapis.com/harness-bazel-cache-blr-dev" >> ${CACHE_FILE}
+fi

--- a/scripts/bazel/generate_credentials.sh
+++ b/scripts/bazel/generate_credentials.sh
@@ -4,3 +4,18 @@
 # https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
 
 scripts/bazel/testDistribute.sh
+
+CACHE_FILE='bazelrc.cache'
+
+CONTENT="#Remote cache configuration\n
+build --google_credentials=platform-bazel-cache-read.json\n
+build --remote_upload_local_results=false\n
+build --incompatible_remote_results_ignore_disk=true\n
+build --experimental_guard_against_concurrent_changes\n
+build --incompatible_strict_action_env\n"
+
+echo "$CONTENT" > ${CACHE_FILE}
+
+[ `uname -m` = 'arm64' ] \
+&& echo "build:macos --remote_cache=https://storage.googleapis.com/harness-bazel-cache-blr-dev-m1" >> ${CACHE_FILE} \
+|| echo "build:macos --remote_cache=https://storage.googleapis.com/harness-bazel-cache-blr-dev" >> ${CACHE_FILE}

--- a/scripts/bazel/generate_credentials.sh
+++ b/scripts/bazel/generate_credentials.sh
@@ -5,7 +5,7 @@
 
 scripts/bazel/testDistribute.sh
 
-CACHE_FILE='bazelrc.test'
+CACHE_FILE='bazelrc.cache'
 
 CONTENT="#Remote cache configuration\n
 build --google_credentials=platform-bazel-cache-read.json\n

--- a/scripts/bazel/generate_credentials.sh
+++ b/scripts/bazel/generate_credentials.sh
@@ -16,7 +16,6 @@ build --incompatible_strict_action_env\n"
 
 if [ `uname -s` = 'Darwin' ]; then
   echo "$CONTENT" > ${CACHE_FILE}
-
   [ `uname -m` = 'arm64' ] \
   && echo "build:macos --remote_cache=https://storage.googleapis.com/harness-bazel-cache-blr-dev-m1" >> ${CACHE_FILE} \
   || echo "build:macos --remote_cache=https://storage.googleapis.com/harness-bazel-cache-blr-dev" >> ${CACHE_FILE}


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/40246)
<!-- Reviewable:end -->
