### PR TITLE
[fix]: [PIE-6214]: Returning null is pipeline is not present in default branch while getting InputSet

### DIFF
--- a/pipeline-service/service/src/main/java/io/harness/pms/plan/execution/service/PMSExecutionServiceImpl.java
+++ b/pipeline-service/service/src/main/java/io/harness/pms/plan/execution/service/PMSExecutionServiceImpl.java
@@ -412,8 +412,14 @@ public class PMSExecutionServiceImpl implements PMSExecutionService {
                 accountId, orgId, projectId, planExecutionId, !pipelineDeleted);
     if (pipelineExecutionSummaryEntityOptional.isPresent()) {
       PipelineExecutionSummaryEntity executionSummaryEntity = pipelineExecutionSummaryEntityOptional.get();
-      String latestTemplate = validateAndMergeHelper.getPipelineTemplate(
-          accountId, orgId, projectId, executionSummaryEntity.getPipelineIdentifier(), null);
+      String latestTemplate;
+      try {
+        latestTemplate = validateAndMergeHelper.getPipelineTemplate(
+            accountId, orgId, projectId, executionSummaryEntity.getPipelineIdentifier(), null);
+      } catch (InvalidRequestException e) {
+        latestTemplate = null;
+      }
+
       String yaml = executionSummaryEntity.getInputSetYaml();
       String template = executionSummaryEntity.getPipelineTemplate();
       if (resolveExpressions && EmptyPredicate.isNotEmpty(yaml)) {

--- a/pipeline-service/service/src/main/java/io/harness/repositories/pipeline/PMSPipelineRepositoryCustomImpl.java
+++ b/pipeline-service/service/src/main/java/io/harness/repositories/pipeline/PMSPipelineRepositoryCustomImpl.java
@@ -217,8 +217,12 @@ public class PMSPipelineRepositoryCustomImpl implements PMSPipelineRepositoryCus
         savedEntity = fetchRemoteEntityWithFallBackBranch(
             accountId, orgIdentifier, projectIdentifier, savedEntity, gitEntityInfo.getBranch());
       } else {
-        savedEntity =
-            fetchRemoteEntity(accountId, orgIdentifier, projectIdentifier, savedEntity, gitEntityInfo.getBranch());
+        try {
+          savedEntity =
+              fetchRemoteEntity(accountId, orgIdentifier, projectIdentifier, savedEntity, gitEntityInfo.getBranch());
+        } catch (Exception e) {
+          savedEntity = null;
+        }
       }
     }
     return Optional.of(savedEntity);


### PR DESCRIPTION
## Describe your changes:
Issue: Runtime Inputs were not being showed while viewing execution History because get call for pipeline in default branch was failing in get flow for inputsets.
Change: Now whenever exception is thrown it will be cathced and instead null pipelineEntity will be returned.
Testing: Expected behaviour observed on local.

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/40343)
<!-- Reviewable:end -->
