### PR TITLE
feat: [CDS-35470]: command flags in K8s steps

### DIFF
--- a/120-ng-manager/src/main/java/io/harness/ng/core/service/resources/ServiceResource.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/core/service/resources/ServiceResource.java
@@ -21,6 +21,7 @@ import io.harness.NGCommonEntityConstants;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.cdng.manifest.yaml.HelmCommandFlagType;
+import io.harness.cdng.manifest.yaml.K8sCommandFlagType;
 import io.harness.k8s.model.HelmVersion;
 import io.harness.ng.beans.PageResponse;
 import io.harness.ng.core.dto.ErrorDTO;
@@ -204,5 +205,19 @@ public class ServiceResource {
       }
     }
     return ResponseDTO.newResponse(helmCmdFlags);
+  }
+
+  @GET
+  @Path("k8sCmdFlags")
+  @ApiOperation(value = "Get Command flags for K8s", nickname = "k8sCmdFlags")
+  public ResponseDTO<Set<K8sCommandFlagType>> getK8sCommandFlags(
+      @QueryParam("serviceSpecType") @NotNull String serviceSpecType) {
+    Set<K8sCommandFlagType> k8sCmdFlags = new HashSet<>();
+    for (K8sCommandFlagType k8sCommandFlagType : K8sCommandFlagType.values()) {
+      if (k8sCommandFlagType.getServiceSpecTypes().contains(serviceSpecType)) {
+        k8sCmdFlags.add(k8sCommandFlagType);
+      }
+    }
+    return ResponseDTO.newResponse(k8sCmdFlags);
   }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sApplyBaseStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sApplyBaseStepInfo.java
@@ -49,4 +49,5 @@ public class K8sApplyBaseStepInfo {
   ParameterField<List<TaskSelectorYaml>> delegateSelectors;
   @JsonProperty("overrides") List<ManifestConfigWrapper> overrides;
   @ApiModelProperty(dataType = BOOLEAN_CLASSPATH) @YamlSchemaTypes({string}) ParameterField<Boolean> skipRendering;
+  @ApiModelProperty(dataType = SwaggerConstants.STRING_CLASSPATH) ParameterField<String> commandFlags;
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sApplyStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sApplyStepInfo.java
@@ -55,8 +55,9 @@ public class K8sApplyStepInfo extends K8sApplyBaseStepInfo implements CDStepInfo
   @Builder(builderMethodName = "infoBuilder")
   public K8sApplyStepInfo(ParameterField<Boolean> skipDryRun, ParameterField<Boolean> skipSteadyStateCheck,
       ParameterField<List<String>> filePaths, ParameterField<List<TaskSelectorYaml>> delegateSelectors,
-      List<ManifestConfigWrapper> overrides, ParameterField<Boolean> skipRendering) {
-    super(skipDryRun, skipSteadyStateCheck, filePaths, delegateSelectors, overrides, skipRendering);
+      List<ManifestConfigWrapper> overrides, ParameterField<Boolean> skipRendering,
+      ParameterField<String> commandFlags) {
+    super(skipDryRun, skipSteadyStateCheck, filePaths, delegateSelectors, overrides, skipRendering, commandFlags);
   }
 
   @Override
@@ -78,6 +79,7 @@ public class K8sApplyStepInfo extends K8sApplyBaseStepInfo implements CDStepInfo
         .delegateSelectors(delegateSelectors)
         .overrides(overrides)
         .skipRendering(skipRendering)
+        .commandFlags(commandFlags)
         .build();
   }
 

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sApplyStepParameters.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sApplyStepParameters.java
@@ -37,8 +37,9 @@ public class K8sApplyStepParameters extends K8sApplyBaseStepInfo implements K8sS
   @Builder(builderMethodName = "infoBuilder")
   public K8sApplyStepParameters(ParameterField<Boolean> skipDryRun, ParameterField<Boolean> skipSteadyStateCheck,
       ParameterField<List<String>> filePaths, ParameterField<List<TaskSelectorYaml>> delegateSelectors,
-      List<ManifestConfigWrapper> overrides, ParameterField<Boolean> skipRendering) {
-    super(skipDryRun, skipSteadyStateCheck, filePaths, delegateSelectors, overrides, skipRendering);
+      List<ManifestConfigWrapper> overrides, ParameterField<Boolean> skipRendering,
+      ParameterField<String> commandFlags) {
+    super(skipDryRun, skipSteadyStateCheck, filePaths, delegateSelectors, overrides, skipRendering, commandFlags);
   }
 
   @Nonnull

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sBlueGreenBaseStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sBlueGreenBaseStepInfo.java
@@ -14,6 +14,7 @@ import static io.harness.yaml.schema.beans.SupportedPossibleFieldTypes.string;
 
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.yaml.YamlSchemaTypes;
@@ -38,4 +39,5 @@ public class K8sBlueGreenBaseStepInfo {
   @YamlSchemaTypes({runtime})
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
   ParameterField<List<TaskSelectorYaml>> delegateSelectors;
+  @YamlSchemaTypes({runtime}) List<K8sStepCommandFlag> commandFlags;
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sBlueGreenStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sBlueGreenStepInfo.java
@@ -11,6 +11,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDP;
 
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.cdng.pipeline.CDStepInfo;
 import io.harness.cdng.visitor.helpers.cdstepinfo.K8sBlueGreenStepInfoVisitorHelper;
 import io.harness.executions.steps.StepSpecTypeConstants;
@@ -53,8 +54,8 @@ public class K8sBlueGreenStepInfo extends K8sBlueGreenBaseStepInfo implements CD
 
   @Builder(builderMethodName = "infoBuilder")
   public K8sBlueGreenStepInfo(ParameterField<Boolean> skipDryRun, ParameterField<Boolean> pruningEnabled,
-      ParameterField<List<TaskSelectorYaml>> delegateSelectors) {
-    super(skipDryRun, pruningEnabled, delegateSelectors);
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors, List<K8sStepCommandFlag> commandFlags) {
+    super(skipDryRun, pruningEnabled, delegateSelectors, commandFlags);
   }
 
   @Override
@@ -73,6 +74,7 @@ public class K8sBlueGreenStepInfo extends K8sBlueGreenBaseStepInfo implements CD
         .skipDryRun(skipDryRun)
         .pruningEnabled(pruningEnabled)
         .delegateSelectors(delegateSelectors)
+        .commandFlags(commandFlags)
         .build();
   }
 

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sBlueGreenStepParameters.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sBlueGreenStepParameters.java
@@ -12,6 +12,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDP;
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.cdng.CDStepHelper;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.executions.steps.ExecutionNodeType;
 import io.harness.k8s.K8sCommandUnitConstants;
 import io.harness.plancreator.steps.TaskSelectorYaml;
@@ -32,8 +33,8 @@ import org.springframework.data.annotation.TypeAlias;
 public class K8sBlueGreenStepParameters extends K8sBlueGreenBaseStepInfo implements K8sSpecParameters {
   @Builder(builderMethodName = "infoBuilder")
   public K8sBlueGreenStepParameters(ParameterField<Boolean> skipDryRun, ParameterField<Boolean> pruningEnabled,
-      ParameterField<List<TaskSelectorYaml>> delegateSelectors) {
-    super(skipDryRun, pruningEnabled, delegateSelectors);
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors, List<K8sStepCommandFlag> commandFlags) {
+    super(skipDryRun, pruningEnabled, delegateSelectors, commandFlags);
   }
   @NotNull
   @Override

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sCanaryBaseStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sCanaryBaseStepInfo.java
@@ -14,6 +14,7 @@ import static io.harness.yaml.schema.beans.SupportedPossibleFieldTypes.string;
 
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.yaml.YamlSchemaTypes;
@@ -39,4 +40,5 @@ public class K8sCanaryBaseStepInfo {
   @YamlSchemaTypes({runtime})
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
   ParameterField<List<TaskSelectorYaml>> delegateSelectors;
+  @YamlSchemaTypes({runtime}) List<K8sStepCommandFlag> commandFlags;
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sCanaryStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sCanaryStepInfo.java
@@ -11,6 +11,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDP;
 
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.cdng.pipeline.CDStepInfo;
 import io.harness.cdng.visitor.helpers.cdstepinfo.K8sCanaryStepInfoVisitorHelper;
 import io.harness.executions.steps.StepSpecTypeConstants;
@@ -57,8 +58,9 @@ public class K8sCanaryStepInfo extends K8sCanaryBaseStepInfo implements CDStepIn
 
   @Builder(builderMethodName = "infoBuilder")
   public K8sCanaryStepInfo(InstanceSelectionWrapper instanceSelection, ParameterField<Boolean> skipDryRun,
-      ParameterField<List<TaskSelectorYaml>> delegateSelectors, String name, String identifier) {
-    super(instanceSelection, skipDryRun, delegateSelectors);
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors, String name, String identifier,
+      List<K8sStepCommandFlag> commandFlags) {
+    super(instanceSelection, skipDryRun, delegateSelectors, commandFlags);
     this.name = name;
     this.identifier = identifier;
   }
@@ -84,6 +86,7 @@ public class K8sCanaryStepInfo extends K8sCanaryBaseStepInfo implements CDStepIn
         .instanceSelection(instanceSelection)
         .skipDryRun(skipDryRun)
         .delegateSelectors(delegateSelectors)
+        .commandFlags(commandFlags)
         .build();
   }
 

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sCanaryStepParameters.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sCanaryStepParameters.java
@@ -11,6 +11,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDP;
 
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.pms.yaml.ParameterField;
 
@@ -28,7 +29,7 @@ import org.springframework.data.annotation.TypeAlias;
 public class K8sCanaryStepParameters extends K8sCanaryBaseStepInfo implements K8sSpecParameters {
   @Builder(builderMethodName = "infoBuilder")
   public K8sCanaryStepParameters(InstanceSelectionWrapper instanceSelection, ParameterField<Boolean> skipDryRun,
-      ParameterField<List<TaskSelectorYaml>> delegateSelectors) {
-    super(instanceSelection, skipDryRun, delegateSelectors);
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors, List<K8sStepCommandFlag> commandFlags) {
+    super(instanceSelection, skipDryRun, delegateSelectors, commandFlags);
   }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingBaseStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingBaseStepInfo.java
@@ -14,6 +14,7 @@ import static io.harness.yaml.schema.beans.SupportedPossibleFieldTypes.string;
 
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.yaml.YamlSchemaTypes;
@@ -40,4 +41,5 @@ public class K8sRollingBaseStepInfo {
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
   ParameterField<List<TaskSelectorYaml>> delegateSelectors;
   @JsonIgnore String canaryStepFqn;
+  @YamlSchemaTypes({runtime}) List<K8sStepCommandFlag> commandFlags;
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingRollbackBaseStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingRollbackBaseStepInfo.java
@@ -14,6 +14,7 @@ import static io.harness.yaml.schema.beans.SupportedPossibleFieldTypes.string;
 
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.SwaggerConstants;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.plancreator.steps.TaskSelectorYaml;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.yaml.YamlSchemaTypes;
@@ -39,4 +40,5 @@ public class K8sRollingRollbackBaseStepInfo {
   @ApiModelProperty(dataType = SwaggerConstants.STRING_LIST_CLASSPATH)
   ParameterField<List<TaskSelectorYaml>> delegateSelectors;
   @JsonIgnore String rollingStepFqn;
+  @YamlSchemaTypes({runtime}) List<K8sStepCommandFlag> commandFlags;
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingRollbackStep.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingRollbackStep.java
@@ -11,7 +11,9 @@ import static io.harness.annotations.dev.HarnessTeam.CDP;
 
 import io.harness.account.services.AccountService;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.beans.FeatureName;
 import io.harness.cdng.CDStepHelper;
+import io.harness.cdng.featureFlag.CDFeatureFlagHelper;
 import io.harness.cdng.infra.beans.InfrastructureOutcome;
 import io.harness.cdng.instance.info.InstanceInfoService;
 import io.harness.cdng.k8s.K8sRollingRollbackBaseStepInfo.K8sRollingRollbackBaseStepInfoKeys;
@@ -21,6 +23,7 @@ import io.harness.cdng.stepsdependency.constants.OutcomeExpressionConstants;
 import io.harness.common.NGTimeConversionHelper;
 import io.harness.data.structure.EmptyPredicate;
 import io.harness.delegate.beans.instancesync.mapper.K8sPodToServiceInstanceInfoMapper;
+import io.harness.delegate.task.k8s.K8sCommandFlag;
 import io.harness.delegate.task.k8s.K8sDeployResponse;
 import io.harness.delegate.task.k8s.K8sRollingDeployRollbackResponse;
 import io.harness.delegate.task.k8s.K8sRollingRollbackDeployRequest;
@@ -66,6 +69,7 @@ public class K8sRollingRollbackStep extends TaskExecutableWithRollbackAndRbac<K8
   @Inject private InstanceInfoService instanceInfoService;
   @Inject private StepHelper stepHelper;
   @Inject private AccountService accountService;
+  @Inject private CDFeatureFlagHelper cdFeatureFlagHelper;
 
   @Override
   public Class<StepElementParameters> getStepParametersClass() {
@@ -114,7 +118,11 @@ public class K8sRollingRollbackStep extends TaskExecutableWithRollbackAndRbac<K8
     K8sRollingRollbackDeployRequestBuilder rollbackRequestBuilder = K8sRollingRollbackDeployRequest.builder();
     InfrastructureOutcome infrastructure = (InfrastructureOutcome) outcomeService.resolve(
         ambiance, RefObjectUtils.getOutcomeRefObject(OutcomeExpressionConstants.INFRASTRUCTURE_OUTCOME));
-
+    K8sCommandFlag k8sCommandFlag = null;
+    if (cdFeatureFlagHelper.isEnabled(accountId, FeatureName.NG_K8_COMMAND_FLAGS)) {
+      k8sCommandFlag = k8sStepHelper.getDelegateK8sCommandFlag(k8sRollingRollbackStepParameters.getCommandFlags());
+    }
+    rollbackRequestBuilder.k8sCommandFlag(k8sCommandFlag);
     if (k8sRollingOptionalOutput.isFound()) {
       K8sRollingOutcome k8sRollingOutcome = (K8sRollingOutcome) k8sRollingOptionalOutput.getOutput();
       rollbackRequestBuilder.releaseName(k8sRollingOutcome.getReleaseName())

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingRollbackStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingRollbackStepInfo.java
@@ -11,6 +11,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDP;
 
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.cdng.pipeline.CDStepInfo;
 import io.harness.cdng.visitor.helpers.cdstepinfo.K8sRollingRollbackStepInfoVisitorHelper;
 import io.harness.executions.steps.StepSpecTypeConstants;
@@ -53,8 +54,8 @@ public class K8sRollingRollbackStepInfo extends K8sRollingRollbackBaseStepInfo i
 
   @Builder(builderMethodName = "infoBuilder")
   public K8sRollingRollbackStepInfo(ParameterField<Boolean> pruningEnabled,
-      ParameterField<List<TaskSelectorYaml>> delegateSelectors, String rollingStepFqn) {
-    super(pruningEnabled, delegateSelectors, rollingStepFqn);
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors, String rollingStepFqn,List<K8sStepCommandFlag> commandFlags) {
+    super(pruningEnabled, delegateSelectors, rollingStepFqn, commandFlags);
   }
 
   @Override
@@ -73,6 +74,7 @@ public class K8sRollingRollbackStepInfo extends K8sRollingRollbackBaseStepInfo i
         .pruningEnabled(pruningEnabled)
         .delegateSelectors(delegateSelectors)
         .rollingStepFqn(rollingStepFqn)
+        .commandFlags(commandFlags)
         .build();
   }
 

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingRollbackStepParameters.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingRollbackStepParameters.java
@@ -12,6 +12,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDP;
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.cdng.CDStepHelper;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.executions.steps.ExecutionNodeType;
 import io.harness.k8s.K8sCommandUnitConstants;
 import io.harness.plancreator.steps.TaskSelectorYaml;
@@ -34,8 +35,8 @@ import org.springframework.data.annotation.TypeAlias;
 public class K8sRollingRollbackStepParameters extends K8sRollingRollbackBaseStepInfo implements K8sSpecParameters {
   @Builder(builderMethodName = "infoBuilder")
   public K8sRollingRollbackStepParameters(ParameterField<Boolean> pruningEnabled,
-      ParameterField<List<TaskSelectorYaml>> delegateSelectors, String rollingStepFqn) {
-    super(pruningEnabled, delegateSelectors, rollingStepFqn);
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors, String rollingStepFqn,List<K8sStepCommandFlag> commandFlags) {
+    super(pruningEnabled, delegateSelectors, rollingStepFqn,commandFlags);
   }
 
   @Nonnull

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingStepInfo.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingStepInfo.java
@@ -11,6 +11,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDP;
 
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.cdng.pipeline.CDStepInfo;
 import io.harness.cdng.visitor.helpers.cdstepinfo.K8sRollingStepInfoVisitorHelper;
 import io.harness.executions.steps.StepSpecTypeConstants;
@@ -53,8 +54,9 @@ public class K8sRollingStepInfo extends K8sRollingBaseStepInfo implements CDStep
 
   @Builder(builderMethodName = "infoBuilder")
   public K8sRollingStepInfo(ParameterField<Boolean> skipDryRun, ParameterField<Boolean> pruningEnabled,
-      ParameterField<List<TaskSelectorYaml>> delegateSelectors, String canaryStepFqn) {
-    super(skipDryRun, pruningEnabled, delegateSelectors, canaryStepFqn);
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors, String canaryStepFqn,
+      List<K8sStepCommandFlag> commandFlags) {
+    super(skipDryRun, pruningEnabled, delegateSelectors, canaryStepFqn, commandFlags);
   }
 
   @Override
@@ -74,6 +76,7 @@ public class K8sRollingStepInfo extends K8sRollingBaseStepInfo implements CDStep
         .pruningEnabled(pruningEnabled)
         .delegateSelectors(this.getDelegateSelectors())
         .canaryStepFqn(canaryStepFqn)
+        .commandFlags(commandFlags)
         .build();
   }
 

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingStepParameters.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sRollingStepParameters.java
@@ -12,6 +12,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDP;
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.cdng.CDStepHelper;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.executions.steps.ExecutionNodeType;
 import io.harness.k8s.K8sCommandUnitConstants;
 import io.harness.plancreator.steps.TaskSelectorYaml;
@@ -34,8 +35,9 @@ import org.springframework.data.annotation.TypeAlias;
 public class K8sRollingStepParameters extends K8sRollingBaseStepInfo implements K8sSpecParameters {
   @Builder(builderMethodName = "infoBuilder")
   public K8sRollingStepParameters(ParameterField<Boolean> skipDryRun, ParameterField<Boolean> pruningEnabled,
-      ParameterField<List<TaskSelectorYaml>> delegateSelectors, String canaryStepFqn) {
-    super(skipDryRun, pruningEnabled, delegateSelectors, canaryStepFqn);
+      ParameterField<List<TaskSelectorYaml>> delegateSelectors, String canaryStepFqn,
+      List<K8sStepCommandFlag> commandFlags) {
+    super(skipDryRun, pruningEnabled, delegateSelectors, canaryStepFqn, commandFlags);
   }
 
   @NotNull

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sStepHelper.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/k8s/K8sStepHelper.java
@@ -42,6 +42,7 @@ import io.harness.cdng.manifest.yaml.HelmChartManifestOutcome;
 import io.harness.cdng.manifest.yaml.HelmChartManifestOutcome.HelmChartManifestOutcomeKeys;
 import io.harness.cdng.manifest.yaml.K8sManifestOutcome;
 import io.harness.cdng.manifest.yaml.K8sManifestOutcome.K8sManifestOutcomeKeys;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.cdng.manifest.yaml.KustomizeManifestOutcome;
 import io.harness.cdng.manifest.yaml.KustomizeManifestOutcome.KustomizeManifestOutcomeKeys;
 import io.harness.cdng.manifest.yaml.KustomizePatchesManifestOutcome;
@@ -64,6 +65,7 @@ import io.harness.delegate.task.git.GitFetchResponse;
 import io.harness.delegate.task.git.TaskStatus;
 import io.harness.delegate.task.helm.HelmFetchFileResult;
 import io.harness.delegate.task.helm.HelmValuesFetchResponse;
+import io.harness.delegate.task.k8s.K8sCommandFlag;
 import io.harness.delegate.task.k8s.K8sDeployRequest;
 import io.harness.delegate.task.k8s.K8sDeployResponse;
 import io.harness.delegate.task.localstore.LocalStoreFetchFilesResult;
@@ -76,6 +78,7 @@ import io.harness.exception.InvalidRequestException;
 import io.harness.expression.ExpressionEvaluatorUtils;
 import io.harness.git.model.FetchFilesResult;
 import io.harness.k8s.K8sCommandUnitConstants;
+import io.harness.k8s.K8sSubCommandType;
 import io.harness.k8s.model.KubernetesResourceId;
 import io.harness.logging.LogCallback;
 import io.harness.manifest.CustomSourceFile;
@@ -951,5 +954,18 @@ public class K8sStepHelper extends K8sHelmCommonStepHelper {
       return prunedResourceIds == null ? Collections.emptyList() : prunedResourceIds;
     }
     return Collections.emptyList();
+  }
+
+  public K8sCommandFlag getDelegateK8sCommandFlag(List<K8sStepCommandFlag> commandFlags) {
+    if (commandFlags == null) {
+      return K8sCommandFlag.builder().valueMap(new HashMap<>()).build();
+    }
+
+    Map<K8sSubCommandType, String> commandsValueMap = new HashMap<>();
+    for (K8sStepCommandFlag commandFlag : commandFlags) {
+      commandsValueMap.put(commandFlag.getCommandType().getSubCommandType(), commandFlag.getFlag().getValue());
+    }
+
+    return K8sCommandFlag.builder().valueMap(commandsValueMap).build();
   }
 }

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/creator/variables/K8sApplyStepVariableCreatorTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/creator/variables/K8sApplyStepVariableCreatorTest.java
@@ -58,6 +58,7 @@ public class K8sApplyStepVariableCreatorTest extends CategoryTest {
             "pipeline.stages.K8s.spec.execution.steps.K8s_Apply_Step.spec.skipDryRun",
             "pipeline.stages.K8s.spec.execution.steps.K8s_Apply_Step.spec.delegateSelectors",
             "pipeline.stages.K8s.spec.execution.steps.K8s_Apply_Step.spec.skipSteadyStateCheck",
-            "pipeline.stages.K8s.spec.execution.steps.K8s_Apply_Step.spec.skipRendering");
+            "pipeline.stages.K8s.spec.execution.steps.K8s_Apply_Step.spec.skipRendering",
+            "pipeline.stages.K8s.spec.execution.steps.K8s_Apply_Step.spec.commandFlags");
   }
 }

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/k8s/AbstractK8sStepExecutorTestBase.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/k8s/AbstractK8sStepExecutorTestBase.java
@@ -21,17 +21,23 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.cdng.CDStepHelper;
 import io.harness.cdng.infra.beans.InfrastructureOutcome;
 import io.harness.cdng.k8s.beans.K8sExecutionPassThroughData;
+import io.harness.cdng.manifest.yaml.K8sCommandFlagType;
 import io.harness.cdng.manifest.yaml.K8sManifestOutcome;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.cdng.manifest.yaml.storeConfig.StoreConfig;
 import io.harness.delegate.beans.logstreaming.UnitProgressData;
+import io.harness.delegate.task.k8s.K8sCommandFlag;
 import io.harness.delegate.task.k8s.K8sDeployRequest;
 import io.harness.delegate.task.k8s.K8sInfraDelegateConfig;
 import io.harness.delegate.task.k8s.K8sManifestDelegateConfig;
+import io.harness.k8s.K8sSubCommandType;
 import io.harness.plancreator.steps.common.StepElementParameters;
 import io.harness.pms.contracts.ambiance.Ambiance;
 import io.harness.pms.sdk.core.steps.executables.TaskChainResponse;
 import io.harness.pms.yaml.ParameterField;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -60,11 +66,19 @@ public abstract class AbstractK8sStepExecutorTestBase extends CategoryTest {
                           .skipResourceVersioning(ParameterField.createValueField(true))
                           .store(storeConfig)
                           .build();
+    K8sCommandFlag k8sCommandFlag =
+        K8sCommandFlag.builder().valueMap(ImmutableMap.of(K8sSubCommandType.APPLY, "--server-side")).build();
     doReturn(infraDelegateConfig).when(cdStepHelper).getK8sInfraDelegateConfig(infrastructureOutcome, ambiance);
     doReturn(manifestDelegateConfig)
         .when(k8sStepHelper)
         .getManifestDelegateConfigWrapper(any(), eq(manifestOutcome), eq(ambiance), any());
     doReturn(true).when(k8sStepHelper).getSkipResourceVersioning(manifestOutcome);
+    doReturn(k8sCommandFlag)
+        .when(k8sStepHelper)
+        .getDelegateK8sCommandFlag(Collections.singletonList(K8sStepCommandFlag.builder()
+                                                                 .commandType(K8sCommandFlagType.Apply)
+                                                                 .flag(ParameterField.createValueField("--server-side"))
+                                                                 .build()));
     doReturn(releaseName).when(cdStepHelper).getReleaseName(ambiance, infrastructureOutcome);
     doReturn(TaskChainResponse.builder().chainEnd(true).build())
         .when(k8sStepHelper)

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/k8s/K8sBGSwapServicesStepTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/k8s/K8sBGSwapServicesStepTest.java
@@ -144,7 +144,6 @@ public class K8sBGSwapServicesStepTest extends CategoryTest {
     assertThat(request.getService2()).isEqualTo(stageService);
     assertThat(request.getK8sInfraDelegateConfig()).isEqualTo(infraDelegateConfig);
     assertThat(request.getCommandName()).isEqualTo(K8sBGSwapServicesStep.K8S_BG_SWAP_SERVICES_COMMAND_NAME);
-
     // We need this null as K8sBGSwapServicesStep does not depend upon Manifests
     assertThat(request.getManifestDelegateConfig()).isNull();
 

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/k8s/K8sCanaryStepTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/k8s/K8sCanaryStepTest.java
@@ -26,19 +26,24 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.NGInstanceUnitType;
 import io.harness.category.element.UnitTests;
 import io.harness.cdng.CDStepHelper;
+import io.harness.cdng.featureFlag.CDFeatureFlagHelper;
 import io.harness.cdng.instance.info.InstanceInfoService;
 import io.harness.cdng.k8s.beans.K8sExecutionPassThroughData;
+import io.harness.cdng.manifest.yaml.K8sCommandFlagType;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.cdng.stepsdependency.constants.OutcomeExpressionConstants;
 import io.harness.delegate.beans.logstreaming.UnitProgressData;
 import io.harness.delegate.exception.TaskNGDataException;
 import io.harness.delegate.task.k8s.K8sCanaryDeployRequest;
 import io.harness.delegate.task.k8s.K8sCanaryDeployResponse;
+import io.harness.delegate.task.k8s.K8sCommandFlag;
 import io.harness.delegate.task.k8s.K8sDeployResponse;
 import io.harness.delegate.task.k8s.K8sTaskType;
 import io.harness.delegate.task.k8s.data.K8sCanaryDataException;
 import io.harness.exception.GeneralException;
 import io.harness.exception.InvalidArgumentsException;
 import io.harness.exception.InvalidRequestException;
+import io.harness.k8s.K8sSubCommandType;
 import io.harness.plancreator.steps.common.StepElementParameters;
 import io.harness.pms.contracts.execution.Status;
 import io.harness.pms.sdk.core.plan.creation.yaml.StepOutcomeGroup;
@@ -49,7 +54,10 @@ import io.harness.pms.sdk.core.steps.io.StepResponse.StepOutcome;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.rule.Owner;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.junit.Test;
@@ -63,15 +71,25 @@ public class K8sCanaryStepTest extends AbstractK8sStepExecutorTestBase {
   @Mock ExecutionSweepingOutputService executionSweepingOutputService;
   @Mock InstanceInfoService instanceInfoService;
   @InjectMocks private K8sCanaryStep k8sCanaryStep;
+  @Mock private CDFeatureFlagHelper cdFeatureFlagHelper;
 
   @Test
   @Owner(developers = ABOSII)
   @Category(UnitTests.class)
   public void testExecuteTask() {
+    when(cdFeatureFlagHelper.isEnabled(any(), any())).thenReturn(true);
     CountInstanceSelection instanceSelection = new CountInstanceSelection();
     instanceSelection.setCount(ParameterField.createValueField("10"));
     K8sCanaryStepParameters stepParameters = new K8sCanaryStepParameters();
     stepParameters.setSkipDryRun(ParameterField.createValueField(true));
+    K8sCommandFlag k8sCommandFlag =
+        K8sCommandFlag.builder().valueMap(ImmutableMap.of(K8sSubCommandType.APPLY, "--server-side")).build();
+    List<K8sStepCommandFlag> commandFlags =
+        Collections.singletonList(K8sStepCommandFlag.builder()
+                                      .commandType(K8sCommandFlagType.Apply)
+                                      .flag(ParameterField.createValueField("--server-side"))
+                                      .build());
+    stepParameters.setCommandFlags(commandFlags);
     stepParameters.setInstanceSelection(
         InstanceSelectionWrapper.builder().type(K8sInstanceUnitType.Count).spec(instanceSelection).build());
     final StepElementParameters stepElementParameters =
@@ -87,6 +105,7 @@ public class K8sCanaryStepTest extends AbstractK8sStepExecutorTestBase {
     assertThat(request.isSkipDryRun()).isTrue();
     assertThat(request.getTimeoutIntervalInMin()).isEqualTo(30);
     assertThat(request.isSkipResourceVersioning()).isTrue();
+    assertThat(request.getK8sCommandFlag()).isEqualTo(k8sCommandFlag);
 
     ArgumentCaptor<String> releaseNameCaptor = ArgumentCaptor.forClass(String.class);
     verify(k8sStepHelper, times(1)).publishReleaseNameStepDetails(eq(ambiance), releaseNameCaptor.capture());

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/k8s/K8sRollingRollbackStepTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/k8s/K8sRollingRollbackStepTest.java
@@ -25,6 +25,7 @@ import io.harness.account.services.AccountService;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.category.element.UnitTests;
 import io.harness.cdng.CDStepHelper;
+import io.harness.cdng.featureFlag.CDFeatureFlagHelper;
 import io.harness.cdng.instance.info.InstanceInfoService;
 import io.harness.cdng.k8s.beans.K8sExecutionPassThroughData;
 import io.harness.cdng.k8s.beans.K8sRollingReleaseOutput;
@@ -72,6 +73,7 @@ public class K8sRollingRollbackStepTest extends CategoryTest {
   private final Ambiance ambiance = Ambiance.newBuilder().addLevels(level).build();
   private final StepInputPackage stepInputPackage = StepInputPackage.builder().build();
 
+  @Mock private CDFeatureFlagHelper cdFeatureFlagHelper;
   @Mock private OutcomeService outcomeService;
   @Mock private ExecutionSweepingOutputService executionSweepingOutputService;
   @Mock private K8sStepHelper k8sStepHelper;

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/k8s/K8sRollingStepTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/k8s/K8sRollingStepTest.java
@@ -28,6 +28,7 @@ import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.category.element.UnitTests;
 import io.harness.cdng.CDStepHelper;
+import io.harness.cdng.featureFlag.CDFeatureFlagHelper;
 import io.harness.cdng.instance.info.InstanceInfoService;
 import io.harness.cdng.instance.outcome.DeploymentInfoOutcome;
 import io.harness.cdng.k8s.beans.GitFetchResponsePassThroughData;
@@ -35,14 +36,18 @@ import io.harness.cdng.k8s.beans.HelmValuesFetchResponsePassThroughData;
 import io.harness.cdng.k8s.beans.K8sExecutionPassThroughData;
 import io.harness.cdng.k8s.beans.K8sRollingReleaseOutput;
 import io.harness.cdng.k8s.beans.StepExceptionPassThroughData;
+import io.harness.cdng.manifest.yaml.K8sCommandFlagType;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.cdng.stepsdependency.constants.OutcomeExpressionConstants;
 import io.harness.delegate.beans.logstreaming.UnitProgressData;
+import io.harness.delegate.task.k8s.K8sCommandFlag;
 import io.harness.delegate.task.k8s.K8sDeployRequest;
 import io.harness.delegate.task.k8s.K8sDeployResponse;
 import io.harness.delegate.task.k8s.K8sRollingDeployRequest;
 import io.harness.delegate.task.k8s.K8sRollingDeployResponse;
 import io.harness.delegate.task.k8s.K8sTaskType;
 import io.harness.exception.GeneralException;
+import io.harness.k8s.K8sSubCommandType;
 import io.harness.plancreator.steps.common.StepElementParameters;
 import io.harness.pms.contracts.execution.Status;
 import io.harness.pms.sdk.core.data.OptionalSweepingOutput;
@@ -54,8 +59,10 @@ import io.harness.pms.sdk.core.steps.io.StepResponse.StepOutcome;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.rule.Owner;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.junit.Test;
@@ -68,6 +75,8 @@ import org.mockito.Mock;
 public class K8sRollingStepTest extends AbstractK8sStepExecutorTestBase {
   @Mock ExecutionSweepingOutputService executionSweepingOutputService;
   @Mock private InstanceInfoService instanceInfoService;
+  @Mock private CDFeatureFlagHelper cdFeatureFlagHelper;
+
   @InjectMocks private K8sRollingStep k8sRollingStep;
   final String canaryStepFqn = "canaryStep";
 
@@ -75,7 +84,16 @@ public class K8sRollingStepTest extends AbstractK8sStepExecutorTestBase {
   @Owner(developers = ABOSII)
   @Category(UnitTests.class)
   public void testExecuteK8sTask() {
+    when(cdFeatureFlagHelper.isEnabled(any(), any())).thenReturn(true);
     K8sRollingStepParameters stepParameters = new K8sRollingStepParameters();
+    K8sCommandFlag k8sCommandFlag =
+        K8sCommandFlag.builder().valueMap(ImmutableMap.of(K8sSubCommandType.APPLY, "--server-side")).build();
+    List<K8sStepCommandFlag> commandFlags =
+        Collections.singletonList(K8sStepCommandFlag.builder()
+                                      .commandType(K8sCommandFlagType.Apply)
+                                      .flag(ParameterField.createValueField("--server-side"))
+                                      .build());
+    stepParameters.setCommandFlags(commandFlags);
     stepParameters.setSkipDryRun(ParameterField.createValueField(true));
     stepParameters.setCanaryStepFqn(canaryStepFqn);
     final StepElementParameters stepElementParameters =
@@ -95,7 +113,7 @@ public class K8sRollingStepTest extends AbstractK8sStepExecutorTestBase {
     assertThat(request.getAccountId()).isEqualTo(accountId);
     assertThat(request.isSkipResourceVersioning()).isTrue();
     assertThat(request.isInCanaryWorkflow()).isFalse();
-
+    assertThat(request.getK8sCommandFlag()).isEqualTo(k8sCommandFlag);
     ArgumentCaptor<K8sRollingReleaseOutput> releaseOutputCaptor =
         ArgumentCaptor.forClass(K8sRollingReleaseOutput.class);
     verify(executionSweepingOutputService, times(1))

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/k8s/K8sStepHelperTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/k8s/K8sStepHelperTest.java
@@ -28,6 +28,7 @@ import static io.harness.rule.OwnerRule.ACHYUTH;
 import static io.harness.rule.OwnerRule.ANSHUL;
 import static io.harness.rule.OwnerRule.NAMAN_TALAYCHA;
 import static io.harness.rule.OwnerRule.PRATYUSH;
+import static io.harness.rule.OwnerRule.TARUN_UBA;
 import static io.harness.rule.OwnerRule.VAIBHAV_SI;
 
 import static java.util.Arrays.asList;
@@ -74,7 +75,9 @@ import io.harness.cdng.manifest.yaml.HelmManifestCommandFlag;
 import io.harness.cdng.manifest.yaml.HttpStoreConfig;
 import io.harness.cdng.manifest.yaml.InheritFromManifestStoreConfig;
 import io.harness.cdng.manifest.yaml.InlineStoreConfig;
+import io.harness.cdng.manifest.yaml.K8sCommandFlagType;
 import io.harness.cdng.manifest.yaml.K8sManifestOutcome;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.cdng.manifest.yaml.KustomizeManifestOutcome;
 import io.harness.cdng.manifest.yaml.KustomizePatchesManifestOutcome;
 import io.harness.cdng.manifest.yaml.ManifestConfig;
@@ -139,6 +142,7 @@ import io.harness.delegate.task.helm.HelmValuesFetchRequest;
 import io.harness.delegate.task.helm.HelmValuesFetchResponse;
 import io.harness.delegate.task.k8s.DirectK8sInfraDelegateConfig;
 import io.harness.delegate.task.k8s.HelmChartManifestDelegateConfig;
+import io.harness.delegate.task.k8s.K8sCommandFlag;
 import io.harness.delegate.task.k8s.K8sManifestDelegateConfig;
 import io.harness.delegate.task.k8s.K8sRollingDeployRequest;
 import io.harness.delegate.task.k8s.KustomizeManifestDelegateConfig;
@@ -162,6 +166,7 @@ import io.harness.filestore.utils.FileStoreNodeUtils;
 import io.harness.git.model.FetchFilesResult;
 import io.harness.git.model.GitFile;
 import io.harness.helm.HelmSubCommandType;
+import io.harness.k8s.K8sSubCommandType;
 import io.harness.k8s.model.HelmVersion;
 import io.harness.k8s.model.KubernetesResourceId;
 import io.harness.logging.LogCallback;
@@ -4142,6 +4147,21 @@ public class K8sStepHelperTest extends CategoryTest {
     List<String> valuesFilesContent = valuesFilesContentCaptor.getValue();
     assertThat(valuesFilesContent).isEmpty();
     assertThat(valuesFilesContent.size()).isEqualTo(0);
+  }
+
+  @Test
+  @Owner(developers = TARUN_UBA)
+  @Category(UnitTests.class)
+  public void testGetDelegateK8sCommandFlag() {
+    List<K8sStepCommandFlag> commandFlags =
+        Collections.singletonList(K8sStepCommandFlag.builder()
+                                      .commandType(K8sCommandFlagType.Apply)
+                                      .flag(ParameterField.createValueField("--server-side"))
+                                      .build());
+    K8sCommandFlag k8sCommandFlagExpected =
+        K8sCommandFlag.builder().valueMap(ImmutableMap.of(K8sSubCommandType.APPLY, "--server-side")).build();
+    K8sCommandFlag k8sCommandFlag = k8sStepHelper.getDelegateK8sCommandFlag(commandFlags);
+    assertThat(k8sCommandFlag).isEqualTo(k8sCommandFlagExpected);
   }
 
   private FileStoreNodeDTO getFileStoreNode(String path, String name) {

--- a/125-cd-nextgen/src/test/resources/schema/DeploymentStage/all.json
+++ b/125-cd-nextgen/src/test/resources/schema/DeploymentStage/all.json
@@ -6282,6 +6282,9 @@
         {
           "type": "object",
           "properties": {
+            "commandFlags": {
+              "type": "string"
+            },
             "delegateSelectors": {
               "oneOf": [
                 {
@@ -6437,6 +6440,21 @@
         {
           "type": "object",
           "properties": {
+            "commandFlags": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/K8sStepCommandFlag"
+                  }
+                },
+                {
+                  "type": "string",
+                  "pattern": "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength": 1
+                }
+              ]
+            },
             "delegateSelectors": {
               "oneOf": [
                 {
@@ -6507,6 +6525,21 @@
             "instanceSelection"
           ],
           "properties": {
+            "commandFlags": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/K8sStepCommandFlag"
+                  }
+                },
+                {
+                  "type": "string",
+                  "pattern": "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength": 1
+                }
+              ]
+            },
             "delegateSelectors": {
               "oneOf": [
                 {
@@ -6667,6 +6700,21 @@
         {
           "type": "object",
           "properties": {
+            "commandFlags": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/K8sStepCommandFlag"
+                  }
+                },
+                {
+                  "type": "string",
+                  "pattern": "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength": 1
+                }
+              ]
+            },
             "delegateSelectors": {
               "oneOf": [
                 {
@@ -6705,6 +6753,21 @@
         {
           "type": "object",
           "properties": {
+            "commandFlags": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/K8sStepCommandFlag"
+                  }
+                },
+                {
+                  "type": "string",
+                  "pattern": "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength": 1
+                }
+              ]
+            },
             "delegateSelectors": {
               "oneOf": [
                 {
@@ -6792,6 +6855,24 @@
           }
         }
       ],
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "K8sStepCommandFlag": {
+      "type": "object",
+      "required": [
+        "commandType"
+      ],
+      "properties": {
+        "commandType": {
+          "type": "string",
+          "enum": [
+            "Apply"
+          ]
+        },
+        "flag": {
+          "type": "string"
+        }
+      },
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
     "KubernetesServiceSpec": {

--- a/125-cd-nextgen/src/test/resources/schema/DeploymentSteps/all.json
+++ b/125-cd-nextgen/src/test/resources/schema/DeploymentSteps/all.json
@@ -3370,6 +3370,9 @@
         {
           "type": "object",
           "properties": {
+            "commandFlags": {
+              "type": "string"
+            },
             "delegateSelectors": {
               "oneOf": [
                 {
@@ -3477,6 +3480,21 @@
         {
           "type": "object",
           "properties": {
+            "commandFlags": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/K8sStepCommandFlag"
+                  }
+                },
+                {
+                  "type": "string",
+                  "pattern": "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength": 1
+                }
+              ]
+            },
             "delegateSelectors": {
               "oneOf": [
                 {
@@ -3547,6 +3565,21 @@
             "instanceSelection"
           ],
           "properties": {
+            "commandFlags": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/K8sStepCommandFlag"
+                  }
+                },
+                {
+                  "type": "string",
+                  "pattern": "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength": 1
+                }
+              ]
+            },
             "delegateSelectors": {
               "oneOf": [
                 {
@@ -3669,6 +3702,21 @@
         {
           "type": "object",
           "properties": {
+            "commandFlags": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/K8sStepCommandFlag"
+                  }
+                },
+                {
+                  "type": "string",
+                  "pattern": "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength": 1
+                }
+              ]
+            },
             "delegateSelectors": {
               "oneOf": [
                 {
@@ -3707,6 +3755,21 @@
         {
           "type": "object",
           "properties": {
+            "commandFlags": {
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/K8sStepCommandFlag"
+                  }
+                },
+                {
+                  "type": "string",
+                  "pattern": "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength": 1
+                }
+              ]
+            },
             "delegateSelectors": {
               "oneOf": [
                 {
@@ -3794,6 +3857,24 @@
           }
         }
       ],
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    },
+    "K8sStepCommandFlag": {
+      "type": "object",
+      "required": [
+        "commandType"
+      ],
+      "properties": {
+        "commandType": {
+          "type": "string",
+          "enum": [
+            "Apply"
+          ]
+        },
+        "flag": {
+          "type": "string"
+        }
+      },
       "$schema": "http://json-schema.org/draft-07/schema#"
     },
     "KustomizeManifest": {

--- a/127-cd-nextgen-entities/src/main/java/io/harness/cdng/manifest/yaml/K8sCommandFlagType.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/cdng/manifest/yaml/K8sCommandFlagType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.cdng.manifest.yaml;
+
+import static io.harness.annotations.dev.HarnessTeam.CDP;
+
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.k8s.K8sSubCommandType;
+import io.harness.ng.core.k8s.ServiceSpecType;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import lombok.Getter;
+
+@Getter
+@OwnedBy(CDP)
+public enum K8sCommandFlagType {
+  Apply(K8sSubCommandType.APPLY, ImmutableSet.of(ServiceSpecType.NATIVE_HELM, ServiceSpecType.KUBERNETES));
+
+  private final K8sSubCommandType subCommandType;
+  private final Set<String> serviceSpecTypes;
+  K8sCommandFlagType(K8sSubCommandType subCommandType, Set<String> serviceSpecTypes) {
+    this.subCommandType = subCommandType;
+    this.serviceSpecTypes = serviceSpecTypes;
+  }
+}

--- a/127-cd-nextgen-entities/src/main/java/io/harness/cdng/manifest/yaml/K8sStepCommandFlag.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/cdng/manifest/yaml/K8sStepCommandFlag.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.cdng.manifest.yaml;
+
+import static io.harness.annotations.dev.HarnessTeam.CDP;
+
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.beans.SwaggerConstants;
+import io.harness.pms.yaml.ParameterField;
+import io.harness.pms.yaml.SkipAutoEvaluation;
+
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.data.annotation.TypeAlias;
+
+@Data
+@Builder
+@EqualsAndHashCode(exclude = {"flag"})
+@TypeAlias("k8sStepCommandFlag")
+@OwnedBy(CDP)
+public class K8sStepCommandFlag {
+  @NotNull K8sCommandFlagType commandType;
+  @SkipAutoEvaluation @ApiModelProperty(dataType = SwaggerConstants.STRING_CLASSPATH) ParameterField<String> flag;
+}

--- a/127-cd-nextgen-entities/src/main/java/io/harness/serializer/kryo/NGEntitiesKryoRegistrar.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/serializer/kryo/NGEntitiesKryoRegistrar.java
@@ -97,7 +97,9 @@ import io.harness.cdng.manifest.yaml.HelmCommandFlagType;
 import io.harness.cdng.manifest.yaml.HelmManifestCommandFlag;
 import io.harness.cdng.manifest.yaml.HttpStoreConfig;
 import io.harness.cdng.manifest.yaml.InheritFromManifestStoreConfig;
+import io.harness.cdng.manifest.yaml.K8sCommandFlagType;
 import io.harness.cdng.manifest.yaml.K8sManifestOutcome;
+import io.harness.cdng.manifest.yaml.K8sStepCommandFlag;
 import io.harness.cdng.manifest.yaml.KustomizeManifestOutcome;
 import io.harness.cdng.manifest.yaml.KustomizePatchesManifestOutcome;
 import io.harness.cdng.manifest.yaml.ManifestConfig;
@@ -341,5 +343,7 @@ public class NGEntitiesKryoRegistrar implements KryoRegistrar {
     kryo.register(TasManifestOutcome.class, 140054);
     kryo.register(AutoScalerManifestOutcome.class, 140055);
     kryo.register(VarsManifestOutcome.class, 140056);
+    kryo.register(K8sCommandFlagType.class, 1400172);
+    kryo.register(K8sStepCommandFlag.class, 1400173);
   }
 }

--- a/260-delegate/src/main/java/software/wings/delegatetasks/k8s/taskhandler/K8sApplyTaskHandler.java
+++ b/260-delegate/src/main/java/software/wings/delegatetasks/k8s/taskhandler/K8sApplyTaskHandler.java
@@ -129,7 +129,7 @@ public class K8sApplyTaskHandler extends K8sTaskHandler {
     }
 
     success = k8sTaskHelperBase.applyManifests(k8sApplyHandlerConfig.getClient(), k8sApplyHandlerConfig.getResources(),
-        k8sDelegateTaskParams, k8sTaskHelper.getExecutionLogCallback(k8sApplyTaskParameters, Apply), true);
+        k8sDelegateTaskParams, k8sTaskHelper.getExecutionLogCallback(k8sApplyTaskParameters, Apply), true, null);
     if (!success) {
       return getFailureResponse();
     }

--- a/260-delegate/src/main/java/software/wings/delegatetasks/k8s/taskhandler/K8sBlueGreenDeployTaskHandler.java
+++ b/260-delegate/src/main/java/software/wings/delegatetasks/k8s/taskhandler/K8sBlueGreenDeployTaskHandler.java
@@ -161,7 +161,7 @@ public class K8sBlueGreenDeployTaskHandler extends K8sTaskHandler {
 
     success = k8sTaskHelperBase.applyManifests(k8sBlueGreenHandlerConfig.getClient(),
         k8sBlueGreenHandlerConfig.getResources(), k8sDelegateTaskParams,
-        k8sTaskHelper.getExecutionLogCallback(k8sBlueGreenDeployTaskParameters, Apply), true);
+        k8sTaskHelper.getExecutionLogCallback(k8sBlueGreenDeployTaskParameters, Apply), true, null);
     if (!success) {
       k8sBlueGreenHandlerConfig.getReleaseHistory().setReleaseStatus(IK8sRelease.Status.Failed);
       k8sTaskHelperBase.saveReleaseHistoryInConfigMap(k8sBlueGreenHandlerConfig.getKubernetesConfig(),

--- a/260-delegate/src/main/java/software/wings/delegatetasks/k8s/taskhandler/K8sRollingDeployRollbackTaskHandler.java
+++ b/260-delegate/src/main/java/software/wings/delegatetasks/k8s/taskhandler/K8sRollingDeployRollbackTaskHandler.java
@@ -87,7 +87,7 @@ public class K8sRollingDeployRollbackTaskHandler extends K8sTaskHandler {
       ExecutionLogCallback pruneLogCallback = k8sTaskHelper.getExecutionLogCallback(request, RecreatePrunedResource);
       try {
         resourceRecreationStatus = k8sRollingRollbackBaseHandler.recreatePrunedResources(rollbackHandlerConfig,
-            request.getReleaseNumber(), request.getPrunedResourcesIds(), pruneLogCallback, k8sDelegateTaskParams);
+            request.getReleaseNumber(), request.getPrunedResourcesIds(), pruneLogCallback, k8sDelegateTaskParams, null);
         k8sRollingRollbackBaseHandler.logResourceRecreationStatus(resourceRecreationStatus, pruneLogCallback);
       } catch (Exception ex) {
         resourceRecreationStatus = ResourceRecreationStatus.RESOURCE_CREATION_FAILED;
@@ -106,7 +106,7 @@ public class K8sRollingDeployRollbackTaskHandler extends K8sTaskHandler {
     boolean success = k8sRollingRollbackBaseHandler.rollback(rollbackHandlerConfig, k8sDelegateTaskParams,
         request.getReleaseNumber(), k8sTaskHelper.getExecutionLogCallback(request, Rollback),
         k8sRollingRollbackBaseHandler.getResourcesRecreated(request.getPrunedResourcesIds(), resourceRecreationStatus),
-        false);
+        false, null);
     if (!success) {
       return K8sTaskExecutionResponse.builder().commandExecutionStatus(CommandExecutionStatus.FAILURE).build();
     }

--- a/260-delegate/src/main/java/software/wings/delegatetasks/k8s/taskhandler/K8sRollingDeployTaskHandler.java
+++ b/260-delegate/src/main/java/software/wings/delegatetasks/k8s/taskhandler/K8sRollingDeployTaskHandler.java
@@ -171,9 +171,9 @@ public class K8sRollingDeployTaskHandler extends K8sTaskHandler {
     List<K8sPod> existingPodList = k8sRollingBaseHandler.getExistingPods(steadyStateTimeoutInMillis, allWorkloads,
         k8sRollingHandlerConfig.getKubernetesConfig(), k8sRollingHandlerConfig.getReleaseName(), prepareLogCallback);
 
-    success =
-        k8sTaskHelperBase.applyManifests(k8sRollingHandlerConfig.getClient(), k8sRollingHandlerConfig.getResources(),
-            k8sDelegateTaskParams, k8sTaskHelper.getExecutionLogCallback(k8sRollingDeployTaskParameters, Apply), true);
+    success = k8sTaskHelperBase.applyManifests(k8sRollingHandlerConfig.getClient(),
+        k8sRollingHandlerConfig.getResources(), k8sDelegateTaskParams,
+        k8sTaskHelper.getExecutionLogCallback(k8sRollingDeployTaskParameters, Apply), true, null);
     if (!success) {
       return getFailureResponse();
     }

--- a/260-delegate/src/test/java/software/wings/delegatetasks/k8s/taskhandler/K8sApplyTaskHandlerTest.java
+++ b/260-delegate/src/test/java/software/wings/delegatetasks/k8s/taskhandler/K8sApplyTaskHandlerTest.java
@@ -296,7 +296,7 @@ public class K8sApplyTaskHandlerTest extends WingsBaseTest {
         .init(any(K8sApplyTaskParameters.class), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class));
     verify(k8sTaskHelper, times(1)).fetchManifestFilesAndWriteToDirectory(any(), any(), any(), anyLong());
     verify(mockedK8sApplyBaseHandler, times(0)).prepare(any(), anyBoolean(), any());
-    verify(k8sTaskHelperBase, times(0)).applyManifests(any(), any(), any(), any(), anyBoolean());
+    verify(k8sTaskHelperBase, times(0)).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     verify(mockedK8sApplyBaseHandler, times(0)).steadyStateCheck(anyBoolean(), any(), any(), anyLong(), any(), any());
     verify(mockedK8sApplyBaseHandler, times(0)).wrapUp(any(), any(), any());
 
@@ -318,7 +318,7 @@ public class K8sApplyTaskHandlerTest extends WingsBaseTest {
 
     doReturn(true).when(k8sTaskHelper).restore(any(), any(), any(), any(), any());
     doReturn(true).when(mockedK8sApplyBaseHandler).prepare(any(), anyBoolean(), any());
-    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean());
+    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     doReturn(true)
         .when(mockedK8sApplyBaseHandler)
         .steadyStateCheck(anyBoolean(), any(), any(), anyLong(), any(), any());
@@ -337,7 +337,7 @@ public class K8sApplyTaskHandlerTest extends WingsBaseTest {
     verify(k8sTaskHelper, times(0)).fetchManifestFilesAndWriteToDirectory(any(), any(), any(), anyLong());
     verify(k8sTaskHelper, times(1)).restore(any(), any(), any(), any(), any());
     verify(mockedK8sApplyBaseHandler, times(1)).prepare(any(), anyBoolean(), any());
-    verify(k8sTaskHelperBase, times(1)).applyManifests(any(), any(), any(), any(), anyBoolean());
+    verify(k8sTaskHelperBase, times(1)).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     verify(mockedK8sApplyBaseHandler, times(1)).steadyStateCheck(anyBoolean(), any(), any(), anyLong(), any(), any());
     verify(mockedK8sApplyBaseHandler, times(1)).wrapUp(any(), any(), any());
 
@@ -454,8 +454,8 @@ public class K8sApplyTaskHandlerTest extends WingsBaseTest {
         .prepare(any(ExecutionLogCallback.class), anyBoolean(), any(K8sApplyHandlerConfig.class));
     doReturn(false)
         .when(k8sTaskHelperBase)
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
 
     final K8sTaskExecutionResponse response =
         k8sApplyTaskHandler.executeTask(K8sApplyTaskParameters.builder().releaseName("release-name").build(),
@@ -615,7 +615,7 @@ public class K8sApplyTaskHandlerTest extends WingsBaseTest {
     doReturn(true)
         .when(k8sTaskHelperBase)
         .applyManifests(nullable(Kubectl.class), any(), nullable(K8sDelegateTaskParams.class),
-            nullable(ExecutionLogCallback.class), anyBoolean());
+            nullable(ExecutionLogCallback.class), anyBoolean(), any());
     doReturn(true)
         .when(mockedK8sApplyBaseHandler)
         .steadyStateCheck(anyBoolean(), any(), nullable(K8sDelegateTaskParams.class), anyLong(),

--- a/260-delegate/src/test/java/software/wings/delegatetasks/k8s/taskhandler/K8sBlueGreenDeployTaskHandlerTest.java
+++ b/260-delegate/src/test/java/software/wings/delegatetasks/k8s/taskhandler/K8sBlueGreenDeployTaskHandlerTest.java
@@ -156,7 +156,7 @@ public class K8sBlueGreenDeployTaskHandlerTest extends CategoryTest {
     k8sBlueGreenHandlerConfig.setStageService(stageService());
     k8sBlueGreenHandlerConfig.setResources(
         new ArrayList<>(asList(primaryService(), deployment(), stageService(), configMap())));
-    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean());
+    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     doReturn(true).when(k8sTaskHelperBase).doStatusCheck(any(), any(), any(), any());
     doReturn("latest-rev").when(k8sTaskHelperBase).getLatestRevision(any(), eq(deployment().getResourceId()), any());
 
@@ -190,7 +190,7 @@ public class K8sBlueGreenDeployTaskHandlerTest extends CategoryTest {
     verify(k8sTaskHelperBase, times(2)).saveReleaseHistoryInConfigMap(any(), eq("releaseName-statusCheck"), any());
 
     deployTaskParams.setReleaseName("releaseName-apply");
-    doReturn(false).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean());
+    doReturn(false).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     response = spyHandler.executeTaskInternal(deployTaskParams, taskParams);
     assertThat(response.getCommandExecutionStatus()).isEqualTo(FAILURE);
     verify(k8sTaskHelperBase).saveReleaseHistoryInConfigMap(any(), eq("releaseName-apply"), any());
@@ -234,8 +234,8 @@ public class K8sBlueGreenDeployTaskHandlerTest extends CategoryTest {
     k8sBlueGreenHandlerConfig.setStageService(stageService());
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
     doReturn(true)
         .when(k8sTaskHelperBase)
         .doStatusCheck(any(Kubectl.class), any(KubernetesResourceId.class), any(K8sDelegateTaskParams.class),
@@ -256,7 +256,7 @@ public class K8sBlueGreenDeployTaskHandlerTest extends CategoryTest {
     verify(spyHandler, times(0)).init(any(), any(), any());
     verify(k8sTaskHelper, times(1)).getK8sTaskExecutionResponse(captor.capture(), eq(SUCCESS));
     verify(k8sTaskHelper, times(1)).restore(any(), any(), any(), any(), any());
-    verify(k8sTaskHelperBase, times(1)).applyManifests(any(), any(), any(), any(), anyBoolean());
+    verify(k8sTaskHelperBase, times(1)).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     final K8sBlueGreenDeployResponse k8sTaskResponse = captor.getValue();
     assertThat(k8sTaskResponse.getPrimaryServiceName()).isEqualTo(primaryService().getResourceId().getName());
     assertThat(k8sTaskResponse.getStageServiceName()).isEqualTo(stageService().getResourceId().getName());
@@ -299,7 +299,7 @@ public class K8sBlueGreenDeployTaskHandlerTest extends CategoryTest {
             .build());
     assertThat(k8sTaskExecutionResponse.getCommandExecutionStatus()).isEqualTo(FAILURE);
     verify(k8sTaskHelper, times(1)).restore(any(), any(), any(), any(), any());
-    verify(k8sTaskHelperBase, times(0)).applyManifests(any(), any(), any(), any(), anyBoolean());
+    verify(k8sTaskHelperBase, times(0)).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
   }
 
   @Test
@@ -330,7 +330,7 @@ public class K8sBlueGreenDeployTaskHandlerTest extends CategoryTest {
             .build());
 
     verify(k8sTaskHelper, times(0)).restore(any(), any(), any(), any(), any());
-    verify(k8sTaskHelperBase, times(0)).applyManifests(any(), any(), any(), any(), anyBoolean());
+    verify(k8sTaskHelperBase, times(0)).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     verify(spyHandler, times(1)).init(any(), any(), any());
     assertThat(response.getCommandExecutionStatus()).isEqualTo(SUCCESS);
     assertThat(((K8sBlueGreenDeployResponse) response.getK8sTaskResponse()).getResources())
@@ -782,8 +782,8 @@ public class K8sBlueGreenDeployTaskHandlerTest extends CategoryTest {
         any(K8sBlueGreenDeployTaskParameters.class), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class));
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
     doReturn(true)
         .when(k8sTaskHelperBase)
         .doStatusCheck(any(Kubectl.class), any(KubernetesResourceId.class), any(K8sDelegateTaskParams.class),
@@ -845,8 +845,8 @@ public class K8sBlueGreenDeployTaskHandlerTest extends CategoryTest {
         any(K8sBlueGreenDeployTaskParameters.class), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class));
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
     doReturn(false)
         .when(k8sTaskHelperBase)
         .doStatusCheck(any(Kubectl.class), any(KubernetesResourceId.class), any(K8sDelegateTaskParams.class),
@@ -915,7 +915,7 @@ public class K8sBlueGreenDeployTaskHandlerTest extends CategoryTest {
     k8sBlueGreenHandlerConfig.setStageService(stageService());
     k8sBlueGreenHandlerConfig.setResources(
         new ArrayList<>(asList(primaryService(), deployment(), stageService(), configMap())));
-    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean());
+    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     doReturn(true).when(k8sTaskHelperBase).doStatusCheck(any(), any(), any(), any());
     doReturn("latest-rev").when(k8sTaskHelperBase).getLatestRevision(any(), eq(deployment().getResourceId()), any());
 
@@ -942,7 +942,7 @@ public class K8sBlueGreenDeployTaskHandlerTest extends CategoryTest {
     verify(k8sTaskHelperBase, times(2)).saveReleaseHistoryInConfigMap(any(), eq("releaseName-statusCheck"), any());
 
     deployTaskParams.setReleaseName("releaseName-apply");
-    doReturn(false).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean());
+    doReturn(false).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     response = spyHandler.executeTaskInternal(deployTaskParams, taskParams);
     assertThat(response.getCommandExecutionStatus()).isEqualTo(FAILURE);
     verify(k8sTaskHelperBase).saveReleaseHistoryInConfigMap(any(), eq("releaseName-apply"), any());
@@ -956,7 +956,7 @@ public class K8sBlueGreenDeployTaskHandlerTest extends CategoryTest {
     doReturn(true).when(spyHandler).init(any(), any(), any());
     doReturn(true).when(k8sTaskHelper).fetchManifestFilesAndWriteToDirectory(any(), any(), any(), anyLong());
     doReturn(true).when(spyHandler).prepareForBlueGreen(any(), any(), any());
-    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean());
+    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     doReturn(true).when(k8sTaskHelperBase).doStatusCheck(any(), any(), any(), any());
     doReturn("latest-rev").when(k8sTaskHelperBase).getLatestRevision(any(), eq(deployment().getResourceId()), any());
     doReturn(executionLogCallback).when(k8sTaskHelper).getExecutionLogCallback(any(), any());

--- a/260-delegate/src/test/java/software/wings/delegatetasks/k8s/taskhandler/K8sCanaryDeployTaskHandlerTest.java
+++ b/260-delegate/src/test/java/software/wings/delegatetasks/k8s/taskhandler/K8sCanaryDeployTaskHandlerTest.java
@@ -110,7 +110,7 @@ public class K8sCanaryDeployTaskHandlerTest extends WingsBaseTest {
     deployment = K8sTestHelper.deployment();
 
     doReturn(true).when(k8sTaskHelper).fetchManifestFilesAndWriteToDirectory(any(), any(), any(), anyLong());
-    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean());
+    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     doReturn(true).when(k8sTaskHelperBase).doStatusCheck(any(), any(), any(), any());
     doReturn(Mockito.mock(ExecutionLogCallback.class)).when(k8sTaskHelper).getExecutionLogCallback(any(), any());
     doReturn(KubernetesConfig.builder().namespace("default").build())
@@ -297,7 +297,7 @@ public class K8sCanaryDeployTaskHandlerTest extends WingsBaseTest {
     assertThat(failureResponse.getCommandExecutionStatus()).isEqualTo(FAILURE);
 
     // apply manifests fails
-    doReturn(false).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean());
+    doReturn(false).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
 
     K8sTaskExecutionResponse taskExecutionResponse =
         handler.executeTask(K8sCanaryDeployTaskParameters.builder()
@@ -447,7 +447,7 @@ public class K8sCanaryDeployTaskHandlerTest extends WingsBaseTest {
     verify(k8sCanaryBaseHandler, times(1))
         .failAndSaveKubernetesRelease(handler.getCanaryHandlerConfig(), "release-name-1");
 
-    doReturn(false).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean());
+    doReturn(false).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     handler.executeTask(K8sCanaryDeployTaskParameters.builder()
                             .k8sDelegateManifestConfig(K8sDelegateManifestConfig.builder().build())
                             .releaseName("release-name-2")
@@ -514,7 +514,7 @@ public class K8sCanaryDeployTaskHandlerTest extends WingsBaseTest {
 
     verify(handler, times(1)).init(eq(k8sCanaryDeployTaskParameters), eq(k8sDelegateTaskParams), any());
     verify(handler, times(0)).prepareForCanary(any(), any(), any());
-    verify(k8sTaskHelperBase, times(0)).applyManifests(any(), any(), any(), any(), anyBoolean());
+    verify(k8sTaskHelperBase, times(0)).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     assertThat(response.getCommandExecutionStatus()).isEqualTo(CommandExecutionStatus.SUCCESS);
     assertThat(((K8sCanaryDeployResponse) response.getK8sTaskResponse()).getResources()).isEqualTo(kubernetesResources);
   }
@@ -555,7 +555,7 @@ public class K8sCanaryDeployTaskHandlerTest extends WingsBaseTest {
         .when(k8sTaskHelper)
         .restore(any(), any(), any(), any(), any());
     doReturn(true).when(handler).prepareForCanary(any(), any(), any());
-    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean());
+    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     doReturn(true).when(k8sTaskHelperBase).doStatusCheck(any(), any(), any(), any());
     doReturn(true).when(k8sTaskHelperBase).doStatusCheck(any(), any(), any(), any());
 
@@ -565,7 +565,7 @@ public class K8sCanaryDeployTaskHandlerTest extends WingsBaseTest {
     verify(handler, times(0)).init(eq(k8sCanaryDeployTaskParameters), eq(k8sDelegateTaskParams), any());
     verify(handler, times(1)).prepareForCanary(any(), any(), any());
     verify(k8sTaskHelper, times(1)).restore(any(), any(), any(), any(), any());
-    verify(k8sTaskHelperBase, times(1)).applyManifests(any(), any(), any(), any(), anyBoolean());
+    verify(k8sTaskHelperBase, times(1)).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     verify(k8sTaskHelperBase, times(1)).doStatusCheck(any(), any(), any(), any());
     verify(k8sCanaryBaseHandler, times(1)).wrapUp(any(), any(), any());
     assertThat(response.getCommandExecutionStatus()).isEqualTo(CommandExecutionStatus.SUCCESS);

--- a/260-delegate/src/test/java/software/wings/delegatetasks/k8s/taskhandler/K8sRollingDeployRollbackTaskHandlerTest.java
+++ b/260-delegate/src/test/java/software/wings/delegatetasks/k8s/taskhandler/K8sRollingDeployRollbackTaskHandlerTest.java
@@ -97,7 +97,7 @@ public class K8sRollingDeployRollbackTaskHandlerTest extends WingsBaseTest {
   public void testRollbackSuccess() throws Exception {
     doReturn(true)
         .when(k8sRollingRollbackBaseHandler)
-        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false);
+        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false, null);
     K8sTaskExecutionResponse response = k8sRollingDeployRollbackTaskHandler.executeTaskInternal(
         k8sRollingDeployRollbackTaskParameters, k8sDelegateTaskParams);
 
@@ -106,7 +106,7 @@ public class K8sRollingDeployRollbackTaskHandlerTest extends WingsBaseTest {
     assertThat(rollbackHandlerConfig.getClient()).isNotNull();
     verify(k8sRollingRollbackBaseHandler).init(rollbackHandlerConfig, releaseName, logCallback);
     verify(k8sRollingRollbackBaseHandler)
-        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false);
+        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false, null);
     verify(k8sRollingRollbackBaseHandler)
         .steadyStateCheck(rollbackHandlerConfig, k8sDelegateTaskParams, timeoutIntervalInMin, logCallback);
     verify(k8sRollingRollbackBaseHandler).postProcess(rollbackHandlerConfig, releaseName);
@@ -128,7 +128,7 @@ public class K8sRollingDeployRollbackTaskHandlerTest extends WingsBaseTest {
     assertThat(rollbackHandlerConfig.getClient()).isNotNull();
     verify(k8sRollingRollbackBaseHandler).init(rollbackHandlerConfig, releaseName, logCallback);
     verify(k8sRollingRollbackBaseHandler, never())
-        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false);
+        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false, null);
     verify(k8sRollingRollbackBaseHandler, never())
         .steadyStateCheck(rollbackHandlerConfig, k8sDelegateTaskParams, timeoutIntervalInMin, logCallback);
     verify(k8sRollingRollbackBaseHandler, never()).postProcess(rollbackHandlerConfig, releaseName);
@@ -157,7 +157,7 @@ public class K8sRollingDeployRollbackTaskHandlerTest extends WingsBaseTest {
   public void testRollbackRollbackFailed() throws Exception {
     doReturn(false)
         .when(k8sRollingRollbackBaseHandler)
-        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false);
+        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false, null);
 
     K8sTaskExecutionResponse response = k8sRollingDeployRollbackTaskHandler.executeTaskInternal(
         k8sRollingDeployRollbackTaskParameters, k8sDelegateTaskParams);
@@ -167,7 +167,7 @@ public class K8sRollingDeployRollbackTaskHandlerTest extends WingsBaseTest {
     assertThat(rollbackHandlerConfig.getClient()).isNotNull();
     verify(k8sRollingRollbackBaseHandler).init(rollbackHandlerConfig, releaseName, logCallback);
     verify(k8sRollingRollbackBaseHandler)
-        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false);
+        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false, null);
     verify(k8sRollingRollbackBaseHandler, never())
         .steadyStateCheck(rollbackHandlerConfig, k8sDelegateTaskParams, timeoutIntervalInMin, logCallback);
     verify(k8sRollingRollbackBaseHandler, never()).postProcess(rollbackHandlerConfig, releaseName);
@@ -190,7 +190,7 @@ public class K8sRollingDeployRollbackTaskHandlerTest extends WingsBaseTest {
 
     doReturn(true)
         .when(k8sRollingRollbackBaseHandler)
-        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false);
+        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false, null);
 
     doThrow(thrownException).when(k8sRollingRollbackBaseHandler).postProcess(rollbackHandlerConfig, releaseName);
 

--- a/260-delegate/src/test/java/software/wings/delegatetasks/k8s/taskhandler/K8sRollingDeployTaskHandlerTest.java
+++ b/260-delegate/src/test/java/software/wings/delegatetasks/k8s/taskhandler/K8sRollingDeployTaskHandlerTest.java
@@ -123,7 +123,7 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
         .when(k8sTaskHelperBase)
         .readManifestAndOverrideLocalSecrets(any(), any(), anyBoolean());
     doReturn(true).when(k8sTaskHelperBase).dryRunManifests(any(), any(), any(), any(), anyBoolean());
-    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean());
+    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     doReturn(true)
         .when(k8sTaskHelperBase)
         .doStatusCheckForAllResources(any(), any(), any(), any(), any(), anyBoolean());
@@ -209,8 +209,8 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
             any(K8sDelegateManifestConfig.class), any(), any(ExecutionLogCallback.class), anyLong());
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
     doReturn(helmChartInfo)
         .when(k8sTaskHelper)
         .getHelmChartDetails(manifestConfig, Paths.get(".", MANIFEST_FILES_DIR).toString());
@@ -264,8 +264,8 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
             any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
     handler.executeTaskInternal(K8sRollingDeployTaskParameters.builder()
                                     .k8sDelegateManifestConfig(K8sDelegateManifestConfig.builder().build())
                                     .releaseName("releaseName")
@@ -284,8 +284,8 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
             any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
     verify(k8sTaskHelperBase, times(1)).getReleaseHistoryData(any(), any());
     verify(k8sTaskHelperBase, times(1))
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
     verify(k8sRollingBaseHandler, times(1)).addLabelsInDeploymentSelectorForCanary(eq(false), eq(false), any(), any());
   }
 
@@ -314,8 +314,8 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
             any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
     handler.executeTaskInternal(K8sRollingDeployTaskParameters.builder()
                                     .k8sDelegateManifestConfig(K8sDelegateManifestConfig.builder().build())
                                     .releaseName("releaseName")
@@ -333,8 +333,8 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
         .dryRunManifests(
             any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
     verify(k8sTaskHelperBase, times(1))
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
     verify(handler, never()).prune(any(), any(), any());
     verify(k8sRollingBaseHandler, times(1)).addLabelsInDeploymentSelectorForCanary(eq(true), eq(true), any(), any());
   }
@@ -364,8 +364,8 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
             any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
 
     doReturn(true)
         .when(k8sTaskHelperBase)
@@ -437,8 +437,8 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
             any(K8sDelegateManifestConfig.class), any(), any(ExecutionLogCallback.class), anyLong());
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
     doReturn(true)
         .when(k8sTaskHelperBase)
         .doStatusCheckForAllResources(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(),
@@ -481,7 +481,7 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
 
     doReturn(true).when(handler).init(any(), any(), any());
     doReturn(true).when(k8sTaskHelper).fetchManifestFilesAndWriteToDirectory(any(), any(), any(), anyLong());
-    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean());
+    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     doReturn(true)
         .when(k8sTaskHelperBase)
         .doStatusCheckForAllResources(any(), any(), any(), any(), any(), anyBoolean());
@@ -523,7 +523,7 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
 
     doReturn(true).when(handler).init(any(), any(), any());
     doReturn(true).when(k8sTaskHelper).fetchManifestFilesAndWriteToDirectory(any(), any(), any(), anyLong());
-    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean());
+    doReturn(true).when(k8sTaskHelperBase).applyManifests(any(), any(), any(), any(), anyBoolean(), any());
     doReturn(false)
         .when(k8sTaskHelperBase)
         .doStatusCheckForAllResources(any(), any(), any(), any(), any(), anyBoolean());
@@ -572,7 +572,7 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
     ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
     verify(k8sTaskHelperBase, times(1))
         .applyManifests(any(Kubectl.class), captor.capture(), any(K8sDelegateTaskParams.class),
-            any(ExecutionLogCallback.class), anyBoolean());
+            any(ExecutionLogCallback.class), anyBoolean(), any());
     List<KubernetesResource> kubernetesResourceList = captor.getValue();
     assertThat(kubernetesResourceList.get(0).getResourceId().isVersioned()).isFalse();
 
@@ -587,7 +587,7 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
     captor = ArgumentCaptor.forClass(List.class);
     verify(k8sTaskHelperBase, times(2))
         .applyManifests(any(Kubectl.class), captor.capture(), any(K8sDelegateTaskParams.class),
-            any(ExecutionLogCallback.class), anyBoolean());
+            any(ExecutionLogCallback.class), anyBoolean(), any());
     kubernetesResourceList = captor.getValue();
     assertThat(kubernetesResourceList.get(0).getResourceId().isVersioned()).isFalse();
 
@@ -602,7 +602,7 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
     captor = ArgumentCaptor.forClass(List.class);
     verify(k8sTaskHelperBase, times(3))
         .applyManifests(any(Kubectl.class), captor.capture(), any(K8sDelegateTaskParams.class),
-            any(ExecutionLogCallback.class), anyBoolean());
+            any(ExecutionLogCallback.class), anyBoolean(), any());
     kubernetesResourceList = captor.getValue();
     List<String> resoucesName = kubernetesResourceList.stream()
                                     .map(resource -> resource.getResourceId().getName())
@@ -646,7 +646,7 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
     verify(k8sTaskHelperBase, times(1)).getReleaseHistoryData(any(), any());
     verify(k8sTaskHelperBase, times(1))
         .applyManifests(any(Kubectl.class), captor.capture(), any(K8sDelegateTaskParams.class),
-            any(ExecutionLogCallback.class), anyBoolean());
+            any(ExecutionLogCallback.class), anyBoolean(), any());
     List<KubernetesResource> kubernetesResourceList = captor.getValue();
 
     assertThat(kubernetesResourceList.get(0).getResourceId().isVersioned()).isFalse();
@@ -694,7 +694,7 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
     verify(k8sTaskHelperBase, times(1)).getReleaseHistoryData(any(), any());
     verify(k8sTaskHelperBase, times(1))
         .applyManifests(any(Kubectl.class), captor.capture(), any(K8sDelegateTaskParams.class),
-            any(ExecutionLogCallback.class), anyBoolean());
+            any(ExecutionLogCallback.class), anyBoolean(), any());
     List<KubernetesResource> kubernetesResourceList = captor.getValue();
 
     assertThat(kubernetesResourceList.get(0).getResourceId().isVersioned()).isFalse();
@@ -741,8 +741,8 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
 
     verify(handler, times(1)).init(any(), any(), any());
     verify(k8sTaskHelperBase, times(0))
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
   }
 
   @Test
@@ -901,8 +901,8 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
         any(K8sRollingDeployTaskParameters.class), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class));
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
     doReturn(helmChartInfo)
         .when(k8sTaskHelper)
         .getHelmChartDetails(manifestConfig, Paths.get(".", MANIFEST_FILES_DIR).toString());
@@ -966,8 +966,8 @@ public class K8sRollingDeployTaskHandlerTest extends WingsBaseTest {
         any(K8sRollingDeployTaskParameters.class), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class));
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(
-            any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), any(), any(K8sDelegateTaskParams.class), any(ExecutionLogCallback.class),
+            anyBoolean(), any());
     doReturn(helmChartInfo)
         .when(k8sTaskHelper)
         .getHelmChartDetails(manifestConfig, Paths.get(".", MANIFEST_FILES_DIR).toString());

--- a/260-delegate/src/test/resources/kryo-registrations.txt
+++ b/260-delegate/src/test/resources/kryo-registrations.txt
@@ -1867,6 +1867,8 @@
 80310:software.wings.helpers.ext.azure.devops.AzureDevopsProjects
 80311:io.harness.artifactory.ArtifactoryImagePath
 80312:io.harness.ngtriggers.WebhookSecretData
+80313:io.harness.k8s.K8sSubCommandType
+80314:io.harness.k8s.K8sCliCommandType
 81001:io.harness.ami.AMITagsResponse
 83071:io.harness.delegate.beans.connector.awsconnector.AwsListEC2InstancesTaskParamsRequest
 83072:io.harness.delegate.beans.connector.awsconnector.AwsListEC2InstancesTaskResponse
@@ -2358,6 +2360,7 @@
 600004:io.harness.ng.core.dto.secrets.KerberosWinRmConfigDTO
 600005:io.harness.ng.core.dto.secrets.WinRmAuthDTO
 600010:io.harness.delegate.beans.secrets.WinRmConfigValidationTaskResponse
+601234:io.harness.delegate.task.k8s.K8sCommandFlag
 643283:io.harness.secretmanagerclient.dto.awskms.AwsKmsConfigDTO
 643284:io.harness.secretmanagerclient.dto.awskms.AwsKmsConfigUpdateDTO
 643285:io.harness.delegate.beans.connector.awskmsconnector.AwsKmsValidationParams

--- a/400-rest/src/test/resources/manager-kryo-registrations.txt
+++ b/400-rest/src/test/resources/manager-kryo-registrations.txt
@@ -2200,6 +2200,8 @@
 80310:software.wings.helpers.ext.azure.devops.AzureDevopsProjects
 80311:io.harness.artifactory.ArtifactoryImagePath
 80312:io.harness.ngtriggers.WebhookSecretData
+80313:io.harness.k8s.K8sSubCommandType
+80314:io.harness.k8s.K8sCliCommandType
 81001:io.harness.ami.AMITagsResponse
 83071:io.harness.delegate.beans.connector.awsconnector.AwsListEC2InstancesTaskParamsRequest
 83072:io.harness.delegate.beans.connector.awsconnector.AwsListEC2InstancesTaskResponse
@@ -2742,6 +2744,7 @@
 600004:io.harness.ng.core.dto.secrets.KerberosWinRmConfigDTO
 600005:io.harness.ng.core.dto.secrets.WinRmAuthDTO
 600010:io.harness.delegate.beans.secrets.WinRmConfigValidationTaskResponse
+601234:io.harness.delegate.task.k8s.K8sCommandFlag
 643283:io.harness.secretmanagerclient.dto.awskms.AwsKmsConfigDTO
 643284:io.harness.secretmanagerclient.dto.awskms.AwsKmsConfigUpdateDTO
 643285:io.harness.delegate.beans.connector.awskmsconnector.AwsKmsValidationParams

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/k8s/K8sApplyRequestHandler.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/k8s/K8sApplyRequestHandler.java
@@ -108,7 +108,7 @@ public class K8sApplyRequestHandler extends K8sRequestHandler {
     k8sTaskHelperBase.applyManifests(k8sApplyHandlerConfig.getClient(), k8sApplyHandlerConfig.getResources(),
         k8sDelegateTaskParams,
         k8sTaskHelperBase.getLogCallback(logStreamingTaskClient, Apply, true, commandUnitsProgress), true,
-        isErrorFrameworkSupported());
+        isErrorFrameworkSupported(), k8sApplyRequest.getK8sCommandFlags());
     final LogCallback waitForSteadyStateLogCallback =
         k8sTaskHelperBase.getLogCallback(logStreamingTaskClient, WaitForSteadyState, true, commandUnitsProgress);
 

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/k8s/K8sRollingRollbackRequestHandler.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/k8s/K8sRollingRollbackRequestHandler.java
@@ -31,6 +31,7 @@ import io.harness.delegate.beans.logstreaming.ILogStreamingTaskClient;
 import io.harness.delegate.k8s.K8sRollingRollbackBaseHandler.ResourceRecreationStatus;
 import io.harness.delegate.k8s.beans.K8sRollingRollbackHandlerConfig;
 import io.harness.delegate.task.k8s.ContainerDeploymentDelegateBaseHelper;
+import io.harness.delegate.task.k8s.K8sCommandFlag;
 import io.harness.delegate.task.k8s.K8sDeployRequest;
 import io.harness.delegate.task.k8s.K8sDeployResponse;
 import io.harness.delegate.task.k8s.K8sRollingDeployRollbackResponse;
@@ -74,14 +75,14 @@ public class K8sRollingRollbackRequestHandler extends K8sRequestHandler {
         (K8sRollingRollbackDeployRequest) k8sDeployRequest;
     LogCallback initLogCallback =
         k8sTaskHelperBase.getLogCallback(logStreamingTaskClient, Init, true, commandUnitsProgress);
-
+    K8sCommandFlag k8sCommandFlag = k8sRollingRollbackDeployRequest.getK8sCommandFlag();
     init(k8sRollingRollbackDeployRequest, k8sDelegateTaskParams, initLogCallback);
 
     ResourceRecreationStatus resourceRecreationStatus = NO_RESOURCE_CREATED;
     if (k8sRollingRollbackDeployRequest.isPruningEnabled()) {
       resourceRecreationStatus = recreatePrunedResources(rollbackHandlerConfig,
           k8sRollingRollbackDeployRequest.getReleaseNumber(), k8sRollingRollbackDeployRequest.getPrunedResourceIds(),
-          k8sDelegateTaskParams, logStreamingTaskClient, commandUnitsProgress);
+          k8sDelegateTaskParams, logStreamingTaskClient, commandUnitsProgress, k8sCommandFlag);
 
       LogCallback deleteResourcesLogCallback = k8sTaskHelperBase.getLogCallback(
           logStreamingTaskClient, DeleteFailedReleaseResources, true, commandUnitsProgress);
@@ -93,7 +94,7 @@ public class K8sRollingRollbackRequestHandler extends K8sRequestHandler {
     rollbackBaseHandler.rollback(rollbackHandlerConfig, k8sDelegateTaskParams,
         k8sRollingRollbackDeployRequest.getReleaseNumber(),
         k8sTaskHelperBase.getLogCallback(logStreamingTaskClient, Rollback, true, commandUnitsProgress),
-        recreatedResourceIds, true);
+        recreatedResourceIds, true, k8sCommandFlag);
 
     LogCallback waitForSteadyStateLogCallback =
         k8sTaskHelperBase.getLogCallback(logStreamingTaskClient, WaitForSteadyState, true, commandUnitsProgress);
@@ -140,14 +141,15 @@ public class K8sRollingRollbackRequestHandler extends K8sRequestHandler {
 
   private ResourceRecreationStatus recreatePrunedResources(K8sRollingRollbackHandlerConfig rollbackHandlerConfig,
       Integer releaseNumber, List<KubernetesResourceId> prunedResources, K8sDelegateTaskParams k8sDelegateTaskParams,
-      ILogStreamingTaskClient logStreamingTaskClient, CommandUnitsProgress commandUnitsProgress) {
+      ILogStreamingTaskClient logStreamingTaskClient, CommandUnitsProgress commandUnitsProgress,
+      K8sCommandFlag commandFlags) {
     LogCallback recreateResourcesCallback =
         k8sTaskHelperBase.getLogCallback(logStreamingTaskClient, RecreatePrunedResource, true, commandUnitsProgress);
 
     ResourceRecreationStatus resourceRecreationStatus = NO_RESOURCE_CREATED;
     try {
-      resourceRecreationStatus = rollbackBaseHandler.recreatePrunedResources(
-          rollbackHandlerConfig, releaseNumber, prunedResources, recreateResourcesCallback, k8sDelegateTaskParams);
+      resourceRecreationStatus = rollbackBaseHandler.recreatePrunedResources(rollbackHandlerConfig, releaseNumber,
+          prunedResources, recreateResourcesCallback, k8sDelegateTaskParams, commandFlags);
       rollbackBaseHandler.logResourceRecreationStatus(resourceRecreationStatus, recreateResourcesCallback);
     } catch (Exception e) {
       resourceRecreationStatus = RESOURCE_CREATION_FAILED;

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/k8s/K8sTaskHelperBase.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/k8s/K8sTaskHelperBase.java
@@ -866,14 +866,15 @@ public class K8sTaskHelperBase {
   }
 
   public boolean applyManifests(Kubectl client, List<KubernetesResource> resources,
-      K8sDelegateTaskParams k8sDelegateTaskParams, LogCallback executionLogCallback, boolean denoteOverallSuccess)
-      throws Exception {
-    return applyManifests(client, resources, k8sDelegateTaskParams, executionLogCallback, denoteOverallSuccess, false);
+      K8sDelegateTaskParams k8sDelegateTaskParams, LogCallback executionLogCallback, boolean denoteOverallSuccess,
+      String commandFlags) throws Exception {
+    return applyManifests(
+        client, resources, k8sDelegateTaskParams, executionLogCallback, denoteOverallSuccess, false, commandFlags);
   }
 
   public boolean applyManifests(Kubectl client, List<KubernetesResource> resources,
       K8sDelegateTaskParams k8sDelegateTaskParams, LogCallback executionLogCallback, boolean denoteOverallSuccess,
-      boolean isErrorFrameworkEnabled) throws Exception {
+      boolean isErrorFrameworkEnabled, String commandFlags) throws Exception {
     FileIo.writeUtf8StringToFile(
         k8sDelegateTaskParams.getWorkingDirectory() + "/manifests.yaml", ManifestHelper.toYaml(resources));
 
@@ -885,7 +886,8 @@ public class K8sTaskHelperBase {
             .map(resource -> resource.getMetadataAnnotationValue(KUBERNETES_CHANGE_CAUSE_ANNOTATION))
             .noneMatch(Objects::nonNull);
 
-    final ApplyCommand applyCommand = overriddenClient.apply().filename("manifests.yaml").record(recordCommand);
+    final ApplyCommand applyCommand =
+        overriddenClient.apply().filename("manifests.yaml").record(recordCommand).commandFlags(commandFlags);
     ProcessResponse response = runK8sExecutable(k8sDelegateTaskParams, executionLogCallback, applyCommand);
     ProcessResult result = response.getProcessResult();
     if (result.getExitValue() != 0) {

--- a/930-delegate-tasks/src/main/java/software/wings/delegatetasks/k8s/taskhandler/K8sCanaryDeployTaskHandler.java
+++ b/930-delegate-tasks/src/main/java/software/wings/delegatetasks/k8s/taskhandler/K8sCanaryDeployTaskHandler.java
@@ -144,9 +144,8 @@ public class K8sCanaryDeployTaskHandler extends K8sTaskHandler {
     if (!success) {
       return getFailureResponse();
     }
-
     success = k8sTaskHelperBase.applyManifests(canaryHandlerConfig.getClient(), canaryHandlerConfig.getResources(),
-        k8sDelegateTaskParams, getLogCallBack(k8sCanaryDeployTaskParameters, Apply), true);
+        k8sDelegateTaskParams, getLogCallBack(k8sCanaryDeployTaskParameters, Apply), true, null);
     if (!success) {
       k8sCanaryBaseHandler.failAndSaveKubernetesRelease(
           canaryHandlerConfig, k8sCanaryDeployTaskParameters.getReleaseName());

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sApplyRequestHandlerTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sApplyRequestHandlerTest.java
@@ -136,7 +136,8 @@ public class K8sApplyRequestHandlerTest extends CategoryTest {
     doReturn(true).when(k8sApplyBaseHandler).prepare(logCallback, false, k8sApplyHandlerConfig, true);
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true));
+        .applyManifests(
+            any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true), eq(null));
     doReturn(true)
         .when(k8sApplyBaseHandler)
         .steadyStateCheck(false, namespace, delegateTaskParams, timeoutIntervalInMillis, logCallback,
@@ -153,7 +154,8 @@ public class K8sApplyRequestHandlerTest extends CategoryTest {
             eq(false));
     verify(k8sApplyBaseHandler, times(1)).prepare(eq(logCallback), eq(false), eq(k8sApplyHandlerConfig), eq(true));
     verify(k8sTaskHelperBase, times(1))
-        .applyManifests(any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true));
+        .applyManifests(
+            any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true), eq(null));
     verify(k8sApplyBaseHandler, times(1))
         .steadyStateCheck(false, namespace, delegateTaskParams, timeoutIntervalInMillis, logCallback,
             k8sApplyHandlerConfig, true, true);
@@ -199,7 +201,8 @@ public class K8sApplyRequestHandlerTest extends CategoryTest {
     doReturn(true).when(k8sApplyBaseHandler).prepare(logCallback, false, k8sApplyHandlerConfig, true);
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true));
+        .applyManifests(
+            any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true), eq(null));
     doReturn(true)
         .when(k8sApplyBaseHandler)
         .steadyStateCheck(false, namespace, delegateTaskParams, timeoutIntervalInMillis, logCallback,
@@ -219,7 +222,8 @@ public class K8sApplyRequestHandlerTest extends CategoryTest {
             any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), anyBoolean());
     verify(k8sApplyBaseHandler, times(1)).prepare(eq(logCallback), eq(false), eq(k8sApplyHandlerConfig), eq(true));
     verify(k8sTaskHelperBase, times(1))
-        .applyManifests(any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true));
+        .applyManifests(
+            any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true), eq(null));
     verify(k8sApplyBaseHandler, times(1))
         .steadyStateCheck(false, namespace, delegateTaskParams, timeoutIntervalInMillis, logCallback,
             k8sApplyHandlerConfig, true, true);
@@ -278,7 +282,8 @@ public class K8sApplyRequestHandlerTest extends CategoryTest {
             any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), anyBoolean());
     verify(k8sApplyBaseHandler, times(0)).prepare(eq(logCallback), eq(false), eq(k8sApplyHandlerConfig), eq(true));
     verify(k8sTaskHelperBase, times(0))
-        .applyManifests(any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true));
+        .applyManifests(
+            any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true), eq(null));
     verify(k8sApplyBaseHandler, times(0))
         .steadyStateCheck(false, namespace, delegateTaskParams, timeoutIntervalInMillis, logCallback,
             k8sApplyHandlerConfig, true, false);
@@ -333,7 +338,8 @@ public class K8sApplyRequestHandlerTest extends CategoryTest {
             any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), anyBoolean());
     verify(k8sApplyBaseHandler, times(0)).prepare(eq(logCallback), eq(false), eq(k8sApplyHandlerConfig), eq(true));
     verify(k8sTaskHelperBase, times(0))
-        .applyManifests(any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true));
+        .applyManifests(
+            any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true), eq(null));
     verify(k8sApplyBaseHandler, times(0))
         .steadyStateCheck(false, namespace, delegateTaskParams, timeoutIntervalInMillis, logCallback,
             k8sApplyHandlerConfig, true, false);
@@ -432,7 +438,7 @@ public class K8sApplyRequestHandlerTest extends CategoryTest {
             eq(false));
     verify(k8sApplyBaseHandler, times(1)).prepare(eq(logCallback), eq(false), eq(k8sApplyHandlerConfig), eq(true));
     verify(k8sTaskHelperBase, times(0))
-        .applyManifests(any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true));
+        .applyManifests(any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(null));
     verify(k8sApplyBaseHandler, times(0))
         .steadyStateCheck(false, namespace, delegateTaskParams, timeoutIntervalInMillis, logCallback,
             k8sApplyHandlerConfig, true, false);
@@ -475,7 +481,8 @@ public class K8sApplyRequestHandlerTest extends CategoryTest {
     RuntimeException exception = new RuntimeException("Failed to apply manifests");
     doThrow(exception)
         .when(k8sTaskHelperBase)
-        .applyManifests(any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true));
+        .applyManifests(
+            any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true), eq(null));
 
     assertThatThrownBy(()
                            -> requestHandler.executeTaskInternal(
@@ -488,7 +495,8 @@ public class K8sApplyRequestHandlerTest extends CategoryTest {
             eq(false));
     verify(k8sApplyBaseHandler, times(1)).prepare(eq(logCallback), eq(false), eq(k8sApplyHandlerConfig), eq(true));
     verify(k8sTaskHelperBase, times(1))
-        .applyManifests(any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true));
+        .applyManifests(
+            any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true), eq(null));
     verify(k8sApplyBaseHandler, times(0))
         .steadyStateCheck(false, namespace, delegateTaskParams, timeoutIntervalInMillis, logCallback,
             k8sApplyHandlerConfig, true, false);
@@ -530,7 +538,8 @@ public class K8sApplyRequestHandlerTest extends CategoryTest {
     doReturn(true).when(k8sApplyBaseHandler).prepare(logCallback, false, k8sApplyHandlerConfig, true);
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true));
+        .applyManifests(
+            any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true), eq(null));
     RuntimeException exception = new RuntimeException("Failed to check the status of the deployment");
     doThrow(exception)
         .when(k8sApplyBaseHandler)
@@ -548,7 +557,8 @@ public class K8sApplyRequestHandlerTest extends CategoryTest {
             eq(false));
     verify(k8sApplyBaseHandler, times(1)).prepare(eq(logCallback), eq(false), eq(k8sApplyHandlerConfig), eq(true));
     verify(k8sTaskHelperBase, times(1))
-        .applyManifests(any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true));
+        .applyManifests(
+            any(Kubectl.class), eq(resources), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true), eq(null));
     verify(k8sApplyBaseHandler, times(1))
         .steadyStateCheck(false, namespace, delegateTaskParams, timeoutIntervalInMillis, logCallback,
             k8sApplyHandlerConfig, true, true);

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sBGRequestHandlerTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sBGRequestHandlerTest.java
@@ -130,7 +130,7 @@ public class K8sBGRequestHandlerTest extends CategoryTest {
     doReturn(true)
         .when(k8sTaskHelperBase)
         .applyManifests(any(Kubectl.class), anyListOf(KubernetesResource.class), eq(k8sDelegateTaskParams),
-            eq(logCallback), anyBoolean());
+            eq(logCallback), anyBoolean(), eq(null));
     doReturn(true)
         .when(k8sTaskHelperBase)
         .doStatusCheck(any(Kubectl.class), any(KubernetesResourceId.class), eq(k8sDelegateTaskParams), eq(logCallback));
@@ -306,7 +306,7 @@ public class K8sBGRequestHandlerTest extends CategoryTest {
         .saveReleaseHistoryInConfigMap(any(KubernetesConfig.class), anyString(), anyString());
     verify(k8sTaskHelperBase, never())
         .applyManifests(any(Kubectl.class), anyListOf(KubernetesResource.class), any(K8sDelegateTaskParams.class),
-            any(LogCallback.class), anyBoolean());
+            any(LogCallback.class), anyBoolean(), eq(null));
   }
 
   @Test
@@ -319,6 +319,7 @@ public class K8sBGRequestHandlerTest extends CategoryTest {
             .skipResourceVersioning(true)
             .manifestDelegateConfig(KustomizeManifestDelegateConfig.builder().build())
             .releaseName("releaseName")
+            .k8sCommandFlag(null)
             .build();
     final RuntimeException exception = new RuntimeException("failed");
 
@@ -332,7 +333,7 @@ public class K8sBGRequestHandlerTest extends CategoryTest {
     doThrow(exception)
         .when(k8sTaskHelperBase)
         .applyManifests(any(Kubectl.class), anyListOf(KubernetesResource.class), eq(k8sDelegateTaskParams),
-            eq(logCallback), eq(true), eq(true));
+            eq(logCallback), eq(true), eq(true), any());
 
     assertThatThrownBy(()
                            -> k8sBGRequestHandler.executeTaskInternal(
@@ -346,7 +347,7 @@ public class K8sBGRequestHandlerTest extends CategoryTest {
         .saveReleaseHistoryInConfigMap(any(KubernetesConfig.class), eq("releaseName"), anyString());
     verify(k8sTaskHelperBase)
         .applyManifests(any(Kubectl.class), anyListOf(KubernetesResource.class), eq(k8sDelegateTaskParams),
-            eq(logCallback), eq(true), eq(true));
+            eq(logCallback), eq(true), eq(true), any());
   }
 
   @Test
@@ -373,7 +374,7 @@ public class K8sBGRequestHandlerTest extends CategoryTest {
     doReturn(true)
         .when(k8sTaskHelperBase)
         .applyManifests(any(Kubectl.class), anyListOf(KubernetesResource.class), eq(k8sDelegateTaskParams),
-            eq(logCallback), eq(true), eq(true));
+            eq(logCallback), eq(true), eq(true), eq(null));
     doReturn(k8sClient).when(k8sTaskHelperBase).getKubernetesClient(anyBoolean());
     doThrow(thrownException).when(k8sClient).performSteadyStateCheck(any(K8sSteadyStateDTO.class));
     assertThatThrownBy(()

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sCanaryRequestHandlerTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sCanaryRequestHandlerTest.java
@@ -124,7 +124,7 @@ public class K8sCanaryRequestHandlerTest extends CategoryTest {
     doReturn(true)
         .when(k8sTaskHelperBase)
         .applyManifests(any(Kubectl.class), anyListOf(KubernetesResource.class), any(K8sDelegateTaskParams.class),
-            eq(logCallback), anyBoolean());
+            eq(logCallback), anyBoolean(), eq(null));
     k8sCanaryHandlerConfig = k8sCanaryRequestHandler.getK8sCanaryHandlerConfig();
     k8sCanaryHandlerConfig.setKubernetesConfig(kubernetesConfig);
     k8sCanaryHandlerConfig.setManifestFilesDirectory(manifestFileDirectory);
@@ -505,6 +505,7 @@ public class K8sCanaryRequestHandlerTest extends CategoryTest {
                                                .valuesYamlList(singletonList("file"))
                                                .instanceUnitType(NGInstanceUnitType.COUNT)
                                                .instances(3)
+                                               .k8sCommandFlag(null)
                                                .k8sInfraDelegateConfig(k8sInfraDelegateConfig)
                                                .build();
     final K8sDelegateTaskParams delegateTaskParams =
@@ -526,7 +527,7 @@ public class K8sCanaryRequestHandlerTest extends CategoryTest {
       doThrow(applyThrowable)
           .when(k8sTaskHelperBase)
           .applyManifests(
-              any(Kubectl.class), eq(emptyList()), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true));
+              any(Kubectl.class), eq(emptyList()), eq(delegateTaskParams), eq(logCallback), eq(true), eq(true), any());
     } else if (statusCheckThrowable != null) {
       doThrow(statusCheckThrowable).when(k8sClient).performSteadyStateCheck(any(K8sSteadyStateDTO.class));
     }

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sDeleteRequestHandlerTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sDeleteRequestHandlerTest.java
@@ -102,7 +102,7 @@ public class K8sDeleteRequestHandlerTest extends CategoryTest {
     doReturn(true)
         .when(k8sTaskHelperBase)
         .applyManifests(any(Kubectl.class), anyListOf(KubernetesResource.class), any(K8sDelegateTaskParams.class),
-            eq(logCallback), anyBoolean());
+            eq(logCallback), anyBoolean(), any());
     doReturn(K8sDeployResponse.builder().commandExecutionStatus(SUCCESS).build())
         .when(k8sDeleteBaseHandler)
         .getSuccessResponse();

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sRollingRollbackBaseHandlerTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sRollingRollbackBaseHandlerTest.java
@@ -58,8 +58,10 @@ import io.harness.delegate.clienttools.ClientTool;
 import io.harness.delegate.clienttools.InstallUtils;
 import io.harness.delegate.k8s.K8sRollingRollbackBaseHandler.ResourceRecreationStatus;
 import io.harness.delegate.k8s.beans.K8sRollingRollbackHandlerConfig;
+import io.harness.delegate.task.k8s.K8sCommandFlag;
 import io.harness.delegate.task.k8s.K8sTaskHelperBase;
 import io.harness.exception.InvalidRequestException;
+import io.harness.k8s.K8sSubCommandType;
 import io.harness.k8s.kubectl.Kubectl;
 import io.harness.k8s.kubectl.RolloutUndoCommand;
 import io.harness.k8s.model.K8sDelegateTaskParams;
@@ -73,6 +75,7 @@ import io.harness.logging.LogCallback;
 import io.harness.rule.Owner;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -163,7 +166,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     PowerMockito.when(InstallUtils.getLatestVersionPath(ClientTool.OC)).thenReturn("oc");
 
     boolean rollback = k8sRollingRollbackBaseHandler.rollback(
-        rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false);
+        rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), false, null);
     mock.close();
     assertThat(rollback).isTrue();
   }
@@ -183,7 +186,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     assertThat(rollbackHandlerConfig.isNoopRollBack()).isTrue();
 
     boolean result = k8sRollingRollbackBaseHandler.rollback(
-        rollbackHandlerConfig, k8sDelegateTaskParams, null, logCallback, emptySet(), false);
+        rollbackHandlerConfig, k8sDelegateTaskParams, null, logCallback, emptySet(), false, null);
     assertThat(result).isTrue();
     verify(logCallback).saveExecutionLog("No previous release found. Skipping rollback.");
 
@@ -213,7 +216,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     k8sRollingRollbackBaseHandler.init(rollbackHandlerConfig, "releaseName", logCallback);
 
     boolean result = k8sRollingRollbackBaseHandler.rollback(
-        rollbackHandlerConfig, k8sDelegateTaskParams, 2, logCallback, emptySet(), false);
+        rollbackHandlerConfig, k8sDelegateTaskParams, 2, logCallback, emptySet(), false, null);
     assertThat(result).isTrue();
 
     k8sRollingRollbackBaseHandler.steadyStateCheck(rollbackHandlerConfig, k8sDelegateTaskParams, 10, logCallback);
@@ -243,7 +246,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
         prepareRollbackCustomWorkloads(previousCustomResource, currentCustomResource);
 
     boolean rollback = k8sRollingRollbackBaseHandler.rollback(
-        rollbackHandlerConfig, k8sDelegateTaskParams, 2, logCallback, emptySet(), false);
+        rollbackHandlerConfig, k8sDelegateTaskParams, 2, logCallback, emptySet(), false, null);
     assertThat(rollback).isTrue();
 
     ArgumentCaptor<List> previousCustomWorkloadsCaptor = ArgumentCaptor.forClass(List.class);
@@ -255,7 +258,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
 
     verify(k8sTaskHelperBase, times(1))
         .applyManifests(any(Kubectl.class), previousCustomWorkloadsCaptor.capture(), any(K8sDelegateTaskParams.class),
-            any(LogCallback.class), anyBoolean(), eq(false));
+            any(LogCallback.class), anyBoolean(), eq(false), any());
 
     List<KubernetesResource> previousCustomWorkloads = previousCustomWorkloadsCaptor.getValue();
     assertThat(previousCustomWorkloads).isNotEmpty();
@@ -276,7 +279,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
         prepareRollbackCustomWorkloads(previousCustomResource, currentCustomResource);
 
     boolean rollback = k8sRollingRollbackBaseHandler.rollback(
-        rollbackHandlerConfig, k8sDelegateTaskParams, 2, logCallback, emptySet(), false);
+        rollbackHandlerConfig, k8sDelegateTaskParams, 2, logCallback, emptySet(), false, null);
     assertThat(rollback).isTrue();
 
     ArgumentCaptor<List> previousCustomWorkloadsCaptor = ArgumentCaptor.forClass(List.class);
@@ -286,7 +289,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
 
     verify(k8sTaskHelperBase, times(1))
         .applyManifests(any(Kubectl.class), previousCustomWorkloadsCaptor.capture(), any(K8sDelegateTaskParams.class),
-            any(LogCallback.class), anyBoolean(), eq(false));
+            any(LogCallback.class), anyBoolean(), eq(false), any());
 
     List<KubernetesResource> previousCustomWorkloads = previousCustomWorkloadsCaptor.getValue();
     assertThat(previousCustomWorkloads).isNotEmpty();
@@ -314,7 +317,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     rollbackHandlerConfig.setRelease(release);
     rollbackHandlerConfig.setClient(Kubectl.client("kubectl", "config-path"));
     when(k8sTaskHelperBase.applyManifests(any(Kubectl.class), anyList(), any(K8sDelegateTaskParams.class),
-             any(LogCallback.class), anyBoolean(), eq(false)))
+             any(LogCallback.class), anyBoolean(), eq(false), anyString()))
         .thenReturn(true);
 
     return rollbackHandlerConfig;
@@ -331,7 +334,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
 
   private void testRollBackReleaseIsNull() throws Exception {
     final boolean success = k8sRollingRollbackBaseHandler.rollback(new K8sRollingRollbackHandlerConfig(),
-        K8sDelegateTaskParams.builder().build(), null, logCallback, emptySet(), false);
+        K8sDelegateTaskParams.builder().build(), null, logCallback, emptySet(), false, null);
 
     assertThat(success).isTrue();
   }
@@ -340,7 +343,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     K8sRollingRollbackHandlerConfig rollbackHandlerConfig = new K8sRollingRollbackHandlerConfig();
     rollbackHandlerConfig.setRelease(new K8sLegacyRelease());
     final boolean success = k8sRollingRollbackBaseHandler.rollback(
-        rollbackHandlerConfig, K8sDelegateTaskParams.builder().build(), 2, logCallback, emptySet(), false);
+        rollbackHandlerConfig, K8sDelegateTaskParams.builder().build(), 2, logCallback, emptySet(), false, null);
     assertThat(success).isTrue();
   }
 
@@ -363,7 +366,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     rollbackHandlerConfig.setReleaseHistory(releaseHistory);
 
     final boolean success = k8sRollingRollbackBaseHandler.rollback(
-        rollbackHandlerConfig, K8sDelegateTaskParams.builder().build(), 2, logCallback, emptySet(), false);
+        rollbackHandlerConfig, K8sDelegateTaskParams.builder().build(), 2, logCallback, emptySet(), false, null);
 
     ArgumentCaptor<RolloutUndoCommand> captor = ArgumentCaptor.forClass(RolloutUndoCommand.class);
     verify(k8sRollingRollbackBaseHandler, times(1)).runK8sExecutable(any(), any(), captor.capture());
@@ -393,7 +396,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     PowerMockito.when(InstallUtils.getLatestVersionPath(ClientTool.OC)).thenReturn("oc");
 
     final boolean success = k8sRollingRollbackBaseHandler.rollback(rollbackHandlerConfig,
-        K8sDelegateTaskParams.builder().kubeconfigPath("kubeconfig").build(), 2, logCallback, emptySet(), false);
+        K8sDelegateTaskParams.builder().kubeconfigPath("kubeconfig").build(), 2, logCallback, emptySet(), false, null);
     mock.close();
 
     ArgumentCaptor<RolloutUndoCommand> captor = ArgumentCaptor.forClass(RolloutUndoCommand.class);
@@ -428,7 +431,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     rollbackHandlerConfig.setRelease(release);
 
     boolean rollback = k8sRollingRollbackBaseHandler.rollback(
-        rollbackHandlerConfig, k8sDelegateTaskParams, 0, logCallback, emptySet(), false);
+        rollbackHandlerConfig, k8sDelegateTaskParams, 0, logCallback, emptySet(), false, null);
     assertThat(rollback).isTrue();
     ArgumentCaptor<String> logCaptor = ArgumentCaptor.forClass(String.class);
     verify(logCallback, times(1)).saveExecutionLog(logCaptor.capture());
@@ -452,7 +455,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     when(releaseHistory.getPreviousRollbackEligibleRelease(anyInt())).thenReturn(null);
 
     boolean rollback = k8sRollingRollbackBaseHandler.rollback(
-        rollbackHandlerConfig, k8sDelegateTaskParams, 1, logCallback, emptySet(), false);
+        rollbackHandlerConfig, k8sDelegateTaskParams, 1, logCallback, emptySet(), false, null);
     assertThat(rollback).isTrue();
     ArgumentCaptor<String> logCaptor = ArgumentCaptor.forClass(String.class);
     verify(logCallback).saveExecutionLog(logCaptor.capture());
@@ -484,7 +487,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     when(releaseHistory.getPreviousRollbackEligibleRelease(anyInt())).thenReturn(previousEligibleRelease);
 
     boolean rollback = k8sRollingRollbackBaseHandler.rollback(
-        rollbackHandlerConfig, k8sDelegateTaskParams, 1, logCallback, emptySet(), false);
+        rollbackHandlerConfig, k8sDelegateTaskParams, 1, logCallback, emptySet(), false, null);
     assertThat(rollback).isTrue();
     ArgumentCaptor<String> logCaptor = ArgumentCaptor.forClass(String.class);
     verify(logCallback, times(2)).saveExecutionLog(logCaptor.capture());
@@ -509,7 +512,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     rollbackHandlerConfig.setReleaseHistory(releaseHistory);
 
     final boolean success = k8sRollingRollbackBaseHandler.rollback(
-        rollbackHandlerConfig, K8sDelegateTaskParams.builder().build(), 2, logCallback, emptySet(), false);
+        rollbackHandlerConfig, K8sDelegateTaskParams.builder().build(), 2, logCallback, emptySet(), false, null);
     assertThat(success).isFalse();
 
     ArgumentCaptor<RolloutUndoCommand> captor = ArgumentCaptor.forClass(RolloutUndoCommand.class);
@@ -552,7 +555,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     // no pruned resource
     K8sRollingRollbackHandlerConfig rollbackHandlerConfig = new K8sRollingRollbackHandlerConfig();
     assertThat(k8sRollingRollbackBaseHandler.recreatePrunedResources(
-                   rollbackHandlerConfig, 1, emptyList(), logCallback, k8sDelegateTaskParams))
+                   rollbackHandlerConfig, 1, emptyList(), logCallback, k8sDelegateTaskParams, null))
         .isEqualTo(ResourceRecreationStatus.NO_RESOURCE_CREATED);
     verify(releaseHistory, never()).getPreviousRollbackEligibleRelease(anyInt());
   }
@@ -565,7 +568,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     K8sRollingRollbackHandlerConfig rollbackHandlerConfig = new K8sRollingRollbackHandlerConfig();
     rollbackHandlerConfig.setReleaseHistory(null);
     assertThat(k8sRollingRollbackBaseHandler.recreatePrunedResources(rollbackHandlerConfig, 1,
-                   ImmutableList.of(KubernetesResourceId.builder().build()), logCallback, k8sDelegateTaskParams))
+                   ImmutableList.of(KubernetesResourceId.builder().build()), logCallback, k8sDelegateTaskParams, null))
         .isEqualTo(ResourceRecreationStatus.NO_RESOURCE_CREATED);
     verify(releaseHistory, never()).getPreviousRollbackEligibleRelease(anyInt());
   }
@@ -589,7 +592,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
     rollbackHandlerConfig.setReleaseHistory(releaseHistory);
     doReturn(null).when(releaseHistory).getPreviousRollbackEligibleRelease(anyInt());
     assertThat(k8sRollingRollbackBaseHandler.recreatePrunedResources(rollbackHandlerConfig, 1,
-                   ImmutableList.of(KubernetesResourceId.builder().build()), logCallback, k8sDelegateTaskParams))
+                   ImmutableList.of(KubernetesResourceId.builder().build()), logCallback, k8sDelegateTaskParams, null))
         .isEqualTo(ResourceRecreationStatus.NO_RESOURCE_CREATED);
     verify(releaseHistory, times(1)).getPreviousRollbackEligibleRelease(anyInt());
   }
@@ -609,7 +612,7 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
 
     assertThat(k8sRollingRollbackBaseHandler.recreatePrunedResources(rollbackHandlerConfig, 1,
                    ImmutableList.of(KubernetesResourceId.builder().name("resource1").build()), logCallback,
-                   k8sDelegateTaskParams))
+                   k8sDelegateTaskParams, null))
         .isEqualTo(ResourceRecreationStatus.NO_RESOURCE_CREATED);
     verify(releaseHistory, times(1)).getPreviousRollbackEligibleRelease(anyInt());
   }
@@ -633,21 +636,23 @@ public class K8sRollingRollbackBaseHandlerTest extends CategoryTest {
         KubernetesResource.builder().spec("spec0").resourceId(resourceIds.get(0)).build());
     resourcesInPreviousSuccessfulRelease.add(
         KubernetesResource.builder().spec("spec1").resourceId(resourceIds.get(1)).build());
-
+    K8sCommandFlag k8sCommandFlagExpected =
+        K8sCommandFlag.builder().valueMap(ImmutableMap.of(K8sSubCommandType.APPLY, "--server-side")).build();
     K8sLegacyRelease previousSuccessfulRelease =
         K8sLegacyRelease.builder().resourcesWithSpec(resourcesInPreviousSuccessfulRelease).build();
     doReturn(previousSuccessfulRelease).when(releaseHistory).getPreviousRollbackEligibleRelease(anyInt());
     doReturn(true)
         .when(k8sTaskHelperBase)
-        .applyManifests(any(), anyList(), any(K8sDelegateTaskParams.class), any(LogCallback.class), anyBoolean());
+        .applyManifests(
+            any(), anyList(), any(K8sDelegateTaskParams.class), any(LogCallback.class), anyBoolean(), any());
 
     assertThat(k8sRollingRollbackBaseHandler.recreatePrunedResources(
-                   rollbackHandlerConfig, 1, resourceIds, logCallback, k8sDelegateTaskParams))
+                   rollbackHandlerConfig, 1, resourceIds, logCallback, k8sDelegateTaskParams, k8sCommandFlagExpected))
         .isEqualTo(ResourceRecreationStatus.RESOURCE_CREATION_SUCCESSFUL);
     verify(releaseHistory, times(1)).getPreviousRollbackEligibleRelease(anyInt());
     verify(k8sTaskHelperBase, times(1))
-        .applyManifests(
-            any(Kubectl.class), anyList(), any(K8sDelegateTaskParams.class), any(LogCallback.class), anyBoolean());
+        .applyManifests(any(Kubectl.class), anyList(), any(K8sDelegateTaskParams.class), any(LogCallback.class),
+            anyBoolean(), any(String.class));
   }
 
   @Test

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sRollingRollbackRequestHandlerTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sRollingRollbackRequestHandlerTest.java
@@ -13,6 +13,7 @@ import static io.harness.delegate.k8s.K8sRollingRollbackBaseHandler.ResourceRecr
 import static io.harness.rule.OwnerRule.ABHINAV2;
 import static io.harness.rule.OwnerRule.ABOSII;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,6 +36,7 @@ import io.harness.category.element.UnitTests;
 import io.harness.delegate.beans.logstreaming.ILogStreamingTaskClient;
 import io.harness.delegate.k8s.beans.K8sRollingRollbackHandlerConfig;
 import io.harness.delegate.task.k8s.ContainerDeploymentDelegateBaseHelper;
+import io.harness.delegate.task.k8s.K8sCommandFlag;
 import io.harness.delegate.task.k8s.K8sDeployRequest;
 import io.harness.delegate.task.k8s.K8sDeployResponse;
 import io.harness.delegate.task.k8s.K8sInfraDelegateConfig;
@@ -111,7 +113,7 @@ public class K8sRollingRollbackRequestHandlerTest extends CategoryTest {
     assertThat(rollbackHandlerConfig.getClient()).isNotNull();
     verify(k8sRollingRollbackBaseHandler).init(rollbackHandlerConfig, releaseName, logCallback);
     verify(k8sRollingRollbackBaseHandler)
-        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), true);
+        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), true, null);
     verify(k8sRollingRollbackBaseHandler)
         .steadyStateCheck(rollbackHandlerConfig, k8sDelegateTaskParams, timeoutIntervalInMin, logCallback);
     verify(k8sRollingRollbackBaseHandler).postProcess(rollbackHandlerConfig, releaseName);
@@ -133,7 +135,7 @@ public class K8sRollingRollbackRequestHandlerTest extends CategoryTest {
     assertThat(rollbackHandlerConfig.getClient()).isNotNull();
     verify(k8sRollingRollbackBaseHandler).init(rollbackHandlerConfig, releaseName, logCallback);
     verify(k8sRollingRollbackBaseHandler, never())
-        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), true);
+        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), true, null);
     verify(k8sRollingRollbackBaseHandler, never())
         .steadyStateCheck(rollbackHandlerConfig, k8sDelegateTaskParams, timeoutIntervalInMin, logCallback);
     verify(k8sRollingRollbackBaseHandler, never()).postProcess(rollbackHandlerConfig, releaseName);
@@ -146,7 +148,7 @@ public class K8sRollingRollbackRequestHandlerTest extends CategoryTest {
     RuntimeException thrownException = new RuntimeException("error");
     doThrow(thrownException)
         .when(k8sRollingRollbackBaseHandler)
-        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), true);
+        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), true, null);
 
     assertThatThrownBy(()
                            -> k8sRollingRollbackRequestHandler.executeTaskInternal(
@@ -157,7 +159,7 @@ public class K8sRollingRollbackRequestHandlerTest extends CategoryTest {
     assertThat(rollbackHandlerConfig.getClient()).isNotNull();
     verify(k8sRollingRollbackBaseHandler).init(rollbackHandlerConfig, releaseName, logCallback);
     verify(k8sRollingRollbackBaseHandler)
-        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), true);
+        .rollback(rollbackHandlerConfig, k8sDelegateTaskParams, releaseNumber, logCallback, emptySet(), true, null);
     verify(k8sRollingRollbackBaseHandler, never())
         .steadyStateCheck(rollbackHandlerConfig, k8sDelegateTaskParams, timeoutIntervalInMin, logCallback);
     verify(k8sRollingRollbackBaseHandler, never()).postProcess(rollbackHandlerConfig, releaseName);
@@ -191,7 +193,7 @@ public class K8sRollingRollbackRequestHandlerTest extends CategoryTest {
     doThrow(new KubernetesTaskException("error"))
         .when(k8sRollingRollbackBaseHandler)
         .recreatePrunedResources(any(K8sRollingRollbackHandlerConfig.class), anyInt(),
-            anyListOf(KubernetesResourceId.class), any(LogCallback.class), any(K8sDelegateTaskParams.class));
+            anyListOf(KubernetesResourceId.class), any(LogCallback.class), any(K8sDelegateTaskParams.class), any());
 
     k8sRollingRollbackRequestHandler.executeTaskInternal(
         deployRequest, k8sDelegateTaskParams, logStreamingTaskClient, null);
@@ -205,6 +207,8 @@ public class K8sRollingRollbackRequestHandlerTest extends CategoryTest {
   public void testPrunedResourceIdsRecreated() throws Exception {
     List<KubernetesResourceId> prunedResourceIds =
         singletonList(KubernetesResourceId.builder().name("dummy_name").build());
+    K8sCommandFlag k8sCommandFlag = K8sCommandFlag.builder().build();
+    k8sCommandFlag.setValueMap(emptyMap());
     K8sRollingRollbackDeployRequest deployRequest = K8sRollingRollbackDeployRequest.builder()
                                                         .timeoutIntervalInMin(timeoutIntervalInMin)
                                                         .releaseNumber(1)
@@ -212,11 +216,12 @@ public class K8sRollingRollbackRequestHandlerTest extends CategoryTest {
                                                         .k8sInfraDelegateConfig(mock(K8sInfraDelegateConfig.class))
                                                         .prunedResourceIds(prunedResourceIds)
                                                         .releaseNumber(1)
+                                                        .k8sCommandFlag(k8sCommandFlag)
                                                         .build();
     doReturn(RESOURCE_CREATION_SUCCESSFUL)
         .when(k8sRollingRollbackBaseHandler)
         .recreatePrunedResources(any(K8sRollingRollbackHandlerConfig.class), anyInt(),
-            anyListOf(KubernetesResourceId.class), any(LogCallback.class), any(K8sDelegateTaskParams.class));
+            anyListOf(KubernetesResourceId.class), any(LogCallback.class), any(K8sDelegateTaskParams.class), any());
 
     doReturn(new HashSet<>(prunedResourceIds))
         .when(k8sRollingRollbackBaseHandler)
@@ -226,6 +231,6 @@ public class K8sRollingRollbackRequestHandlerTest extends CategoryTest {
         deployRequest, k8sDelegateTaskParams, logStreamingTaskClient, null);
     verify(k8sRollingRollbackBaseHandler)
         .rollback(any(K8sRollingRollbackHandlerConfig.class), any(K8sDelegateTaskParams.class), anyInt(),
-            any(LogCallback.class), eq(new HashSet<>(prunedResourceIds)), anyBoolean());
+            any(LogCallback.class), eq(new HashSet<>(prunedResourceIds)), anyBoolean(), eq(k8sCommandFlag));
   }
 }

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/k8s/K8sTaskHelperBaseTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/k8s/K8sTaskHelperBaseTest.java
@@ -676,7 +676,7 @@ public class K8sTaskHelperBaseTest extends CategoryTest {
                                                       .build();
     Kubectl client = Kubectl.client("kubectl", "config-path");
 
-    spyK8sTaskHelperBase.applyManifests(client, emptyList(), k8sDelegateTaskParams, executionLogCallback, true);
+    spyK8sTaskHelperBase.applyManifests(client, emptyList(), k8sDelegateTaskParams, executionLogCallback, true, null);
 
     ArgumentCaptor<ApplyCommand> captor = ArgumentCaptor.forClass(ApplyCommand.class);
     verify(spyK8sTaskHelperBase, times(1)).runK8sExecutable(any(), any(), captor.capture());
@@ -692,7 +692,7 @@ public class K8sTaskHelperBaseTest extends CategoryTest {
                    .spec("")
                    .resourceId(KubernetesResourceId.builder().kind("Route").build())
                    .build()),
-        k8sDelegateTaskParams, executionLogCallback, true);
+        k8sDelegateTaskParams, executionLogCallback, true, null);
     mock.close();
     verify(spyK8sTaskHelperBase, times(1)).runK8sExecutable(any(), any(), captor.capture());
     assertThat(captor.getValue().command())
@@ -724,7 +724,7 @@ public class K8sTaskHelperBaseTest extends CategoryTest {
                                                  .spec("")
                                                  .resourceId(KubernetesResourceId.builder().kind("Deployment").build())
                                                  .build()),
-                               k8sDelegateTaskParams, executionLogCallback, true, true))
+                               k8sDelegateTaskParams, executionLogCallback, true, true, null))
         .matches(throwable -> {
           KubernetesCliTaskRuntimeException taskException = (KubernetesCliTaskRuntimeException) throwable;
           assertThat(taskException.getProcessResponse().getProcessResult().outputUTF8())
@@ -2593,7 +2593,8 @@ public class K8sTaskHelperBaseTest extends CategoryTest {
                                                       .build();
     Kubectl client = Kubectl.client("kubectl", "config-path");
 
-    spyK8sTaskHelper.applyManifests(client, singletonList(resource), k8sDelegateTaskParams, executionLogCallback, true);
+    spyK8sTaskHelper.applyManifests(
+        client, singletonList(resource), k8sDelegateTaskParams, executionLogCallback, true, null);
     ArgumentCaptor<ApplyCommand> captor = ArgumentCaptor.forClass(ApplyCommand.class);
     verify(spyK8sTaskHelper, times(1)).runK8sExecutable(any(), any(), captor.capture());
 

--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/k8s/K8sApplyRequest.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/k8s/K8sApplyRequest.java
@@ -43,7 +43,7 @@ public class K8sApplyRequest implements K8sDeployRequest {
   boolean useLatestKustomizeVersion;
   boolean useNewKubectlVersion;
   boolean useK8sApiForSteadyStateCheck;
-
+  String k8sCommandFlags;
   @Override
   public List<String> getOpenshiftParamList() {
     return Collections.emptyList();

--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/k8s/K8sBGDeployRequest.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/k8s/K8sBGDeployRequest.java
@@ -42,4 +42,5 @@ public class K8sBGDeployRequest implements K8sDeployRequest {
   boolean useNewKubectlVersion;
   boolean pruningEnabled;
   boolean useK8sApiForSteadyStateCheck;
+  K8sCommandFlag k8sCommandFlag;
 }

--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/k8s/K8sCanaryDeployRequest.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/k8s/K8sCanaryDeployRequest.java
@@ -45,4 +45,5 @@ public class K8sCanaryDeployRequest implements K8sDeployRequest {
   boolean useNewKubectlVersion;
   boolean cleanUpIncompleteCanaryDeployRelease;
   boolean useK8sApiForSteadyStateCheck;
+  K8sCommandFlag k8sCommandFlag;
 }

--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/k8s/K8sCommandFlag.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/k8s/K8sCommandFlag.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.delegate.task.k8s;
+
+import static io.harness.expression.Expression.ALLOW_SECRETS;
+
+import io.harness.expression.Expression;
+import io.harness.k8s.K8sSubCommandType;
+import io.harness.reflection.ExpressionReflectionUtils.NestedAnnotationResolver;
+
+import java.util.Map;
+import javax.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class K8sCommandFlag implements NestedAnnotationResolver {
+  @NotNull @Expression(ALLOW_SECRETS) private Map<K8sSubCommandType, String> valueMap;
+}

--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/k8s/K8sRollingDeployRequest.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/k8s/K8sRollingDeployRequest.java
@@ -45,4 +45,5 @@ public class K8sRollingDeployRequest implements K8sDeployRequest {
   boolean skipAddingTrackSelectorToDeployment;
   boolean pruningEnabled;
   boolean useK8sApiForSteadyStateCheck;
+  K8sCommandFlag k8sCommandFlag;
 }

--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/k8s/K8sRollingRollbackDeployRequest.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/k8s/K8sRollingRollbackDeployRequest.java
@@ -33,6 +33,7 @@ public class K8sRollingRollbackDeployRequest implements K8sDeployRequest {
   boolean useNewKubectlVersion;
   boolean pruningEnabled;
   List<KubernetesResourceId> prunedResourceIds;
+  K8sCommandFlag k8sCommandFlag;
 
   @Override
   public List<String> getValuesYamlList() {

--- a/950-delegate-tasks-beans/src/main/java/io/harness/serializer/kryo/DelegateTasksBeansKryoRegister.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/serializer/kryo/DelegateTasksBeansKryoRegister.java
@@ -635,6 +635,7 @@ import io.harness.delegate.task.k8s.K8sBGDeployResponse;
 import io.harness.delegate.task.k8s.K8sCanaryDeleteRequest;
 import io.harness.delegate.task.k8s.K8sCanaryDeployRequest;
 import io.harness.delegate.task.k8s.K8sCanaryDeployResponse;
+import io.harness.delegate.task.k8s.K8sCommandFlag;
 import io.harness.delegate.task.k8s.K8sDeleteRequest;
 import io.harness.delegate.task.k8s.K8sDeployRequest;
 import io.harness.delegate.task.k8s.K8sDeployResponse;
@@ -2015,5 +2016,6 @@ public class DelegateTasksBeansKryoRegister implements KryoRegistrar {
     kryo.register(EcsS3FetchFileConfig.class, 573565);
     kryo.register(EcsS3FetchRunTaskRequest.class, 573566);
     kryo.register(EcsS3FetchRunTaskResponse.class, 573567);
+    kryo.register(K8sCommandFlag.class, 601234);
   }
 }

--- a/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
+++ b/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
@@ -515,7 +515,8 @@ public enum FeatureName {
       HarnessTeam.CDP),
   DISABLE_WINRM_COMMAND_ENCODING_NG(
       "To disable Base64 encoding done to WinRM command script which is sent to remote server for execution",
-      HarnessTeam.CDP);
+      HarnessTeam.CDP),
+  NG_K8_COMMAND_FLAGS("Added Support for adding Command flags to commands", HarnessTeam.CDP);
 
   @Deprecated
   FeatureName() {

--- a/960-api-services/src/main/java/io/harness/k8s/K8sCommandFlagsUtils.java
+++ b/960-api-services/src/main/java/io/harness/k8s/K8sCommandFlagsUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.k8s;
+
+import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
+
+import io.harness.data.structure.EmptyPredicate;
+
+import java.util.Map;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class K8sCommandFlagsUtils {
+  public String applyK8sCommandFlags(String commandType, Map<K8sSubCommandType, String> commandFlags) {
+    String flags = "";
+    if (isNotEmpty(commandFlags)) {
+      K8sSubCommandType subCommandType = K8sSubCommandType.getSubCommandType(commandType);
+      flags = commandFlags.getOrDefault(subCommandType, "");
+      if (EmptyPredicate.isEmpty(flags)) {
+        flags = "";
+      }
+    }
+
+    return flags;
+  }
+}

--- a/960-api-services/src/main/java/io/harness/k8s/kubectl/ApplyCommand.java
+++ b/960-api-services/src/main/java/io/harness/k8s/kubectl/ApplyCommand.java
@@ -7,6 +7,7 @@
 
 package io.harness.k8s.kubectl;
 
+import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
 import static io.harness.k8s.kubectl.Utils.encloseWithQuotesIfNeeded;
 
 import io.harness.annotations.dev.HarnessTeam;
@@ -23,11 +24,10 @@ public class ApplyCommand extends AbstractExecutable {
   private boolean record;
   private String output;
   private boolean dryRunClient;
-
+  private String commandFlags;
   public ApplyCommand(Kubectl client) {
     this.client = client;
   }
-
   public ApplyCommand filename(String filename) {
     this.filename = filename;
     return this;
@@ -58,6 +58,11 @@ public class ApplyCommand extends AbstractExecutable {
     return this;
   }
 
+  public ApplyCommand commandFlags(String commandFlags) {
+    this.commandFlags = commandFlags;
+    return this;
+  }
+
   @Override
   public String command() {
     StringBuilder command = new StringBuilder();
@@ -82,11 +87,12 @@ public class ApplyCommand extends AbstractExecutable {
     if (this.record) {
       command.append(Kubectl.flag(Flag.record));
     }
-
+    if (isNotEmpty(this.commandFlags)) {
+      command.append(Kubectl.flag(this.commandFlags));
+    }
     if (this.output != null) {
       command.append(Kubectl.option(Option.output, output));
     }
-
     return command.toString().trim();
   }
 }

--- a/960-api-services/src/main/java/io/harness/k8s/kubectl/Kubectl.java
+++ b/960-api-services/src/main/java/io/harness/k8s/kubectl/Kubectl.java
@@ -91,6 +91,10 @@ public class Kubectl {
     return "--" + type.toString() + " ";
   }
 
+  public static String flag(String flag) {
+    return flag + " ";
+  }
+
   public static String flag(Flag type, boolean value) {
     return "--" + type.toString() + "=" + value + " ";
   }

--- a/970-api-services-beans/src/main/java/io/harness/k8s/K8sCliCommandType.java
+++ b/970-api-services-beans/src/main/java/io/harness/k8s/K8sCliCommandType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.k8s;
+
+public enum K8sCliCommandType { APPLY; }

--- a/970-api-services-beans/src/main/java/io/harness/k8s/K8sSubCommandType.java
+++ b/970-api-services-beans/src/main/java/io/harness/k8s/K8sSubCommandType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.k8s;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import lombok.Getter;
+
+@Getter
+public enum K8sSubCommandType {
+  APPLY(ImmutableSet.of(K8sCliCommandType.APPLY.name()));
+
+  private final Set<String> commandTypes;
+
+  K8sSubCommandType(Set<String> commandTypes) {
+    this.commandTypes = commandTypes;
+  }
+
+  public static K8sSubCommandType getSubCommandType(String commandType) {
+    for (K8sSubCommandType subCommandType : K8sSubCommandType.values()) {
+      if (subCommandType.getCommandTypes().contains(commandType)) {
+        return subCommandType;
+      }
+    }
+    return null;
+  }
+}

--- a/970-api-services-beans/src/main/java/io/harness/serializer/kryo/ApiServiceBeansKryoRegister.java
+++ b/970-api-services-beans/src/main/java/io/harness/serializer/kryo/ApiServiceBeansKryoRegister.java
@@ -87,6 +87,8 @@ import io.harness.jira.JiraStatusNG;
 import io.harness.jira.JiraTimeTrackingFieldNG;
 import io.harness.jira.JiraUpdateIssueRequestNG;
 import io.harness.jira.JiraUserData;
+import io.harness.k8s.K8sCliCommandType;
+import io.harness.k8s.K8sSubCommandType;
 import io.harness.k8s.model.HelmVersion;
 import io.harness.k8s.model.ImageDetails;
 import io.harness.k8s.model.IstioDestinationWeight;
@@ -474,5 +476,7 @@ public class ApiServiceBeansKryoRegister implements KryoRegistrar {
     kryo.register(WebhookSecretData.class, 80312);
     kryo.register(AMITagsResponse.class, 81001);
     kryo.register(NexusRepositories.class, 9000312);
+    kryo.register(K8sSubCommandType.class, 80313);
+    kryo.register(K8sCliCommandType.class, 80314);
   }
 }


### PR DESCRIPTION
## Describe your changes
Adding Command Flags to Kuberenetes Steps to apply stage. This will help in passing commandflags as per need and wouldn't restrain customer to use only selected.
There may be feature flags which are not supported in client delegate kubectl so bump up the version.

## Testing
Apply
![Screenshot 2022-11-30 at 10 50 51 AM (2)](https://user-images.githubusercontent.com/106597485/204715934-a43032dc-8a90-45be-882f-b68cd2facf81.png)

Canary
![Screenshot 2022-11-30 at 12 27 22 PM (2)](https://user-images.githubusercontent.com/106597485/204728638-9a87477a-2494-4d8f-8823-6e94097fc8c4.png)


Rolling
![Screenshot 2022-11-30 at 12 28 12 PM (2)](https://user-images.githubusercontent.com/106597485/204728717-b4f8c191-546a-4bea-b25d-cc9e762c771d.png)


BlueGreen
![Screenshot 2022-11-30 at 10 48 33 AM (2)](https://user-images.githubusercontent.com/106597485/204715875-7d596d46-b9e6-402c-8c4a-b211ee485d11.png)

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/40347)
<!-- Reviewable:end -->
