### PR TITLE
Set HOME env for hosted vm builds with containerless steps

### DIFF
--- a/332-ci-manager/service/src/main/java/io/harness/ci/execution/commonconstants/CIExecutionConstants.java
+++ b/332-ci-manager/service/src/main/java/io/harness/ci/execution/commonconstants/CIExecutionConstants.java
@@ -31,6 +31,7 @@ public class CIExecutionConstants {
 
   public static final String STEP_VOLUME = "harness";
   public static final String STEP_MOUNT_PATH = "/harness";
+  public static final String HOME_DIR = "/harness";
   public static final String OSX_STEP_MOUNT_PATH = "/tmp/harness";
   public static final String OSX_ADDON_MOUNT_PATH = "/tmp/addon";
   public static final String STEP_WORK_DIR = STEP_MOUNT_PATH;

--- a/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmActionStepSerializer.java
+++ b/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmActionStepSerializer.java
@@ -8,16 +8,15 @@
 package io.harness.ci.serializer.vm;
 
 import static io.harness.beans.serializer.RunTimeInputHandler.resolveMapParameter;
+import static io.harness.ci.commonconstants.CIExecutionConstants.HOME_DIR;
 
 import io.harness.beans.serializer.RunTimeInputHandler;
 import io.harness.beans.steps.stepinfo.ActionStepInfo;
 import io.harness.beans.sweepingoutputs.StageInfraDetails;
-import io.harness.ci.config.CIExecutionServiceConfig;
 import io.harness.ci.serializer.SerializerUtils;
 import io.harness.delegate.beans.ci.vm.steps.VmRunStep;
 import io.harness.exception.ngexception.CIStageExecutionException;
 
-import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -25,8 +24,6 @@ import java.util.Map;
 
 @Singleton
 public class VmActionStepSerializer {
-  @Inject CIExecutionServiceConfig ciExecutionServiceConfig;
-
   public VmRunStep serialize(ActionStepInfo actionStepInfo, String identifier, StageInfraDetails stageInfraDetails) {
     if (stageInfraDetails.getType() != StageInfraDetails.Type.DLITE_VM) {
       throw new CIStageExecutionException("Action step is only applicable for builds on cloud infrastructure");
@@ -41,6 +38,7 @@ public class VmActionStepSerializer {
       env = new HashMap<>();
     }
     env.put("PLUGIN_WITH", SerializerUtils.convertMapToJsonString(with));
+    env.put("HOME", HOME_DIR);
 
     return VmRunStep.builder()
         .entrypoint(Arrays.asList("plugin", "-kind", "action", "-name"))

--- a/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmBackgroundStepSerializer.java
+++ b/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmBackgroundStepSerializer.java
@@ -8,10 +8,12 @@
 package io.harness.ci.serializer.vm;
 
 import static io.harness.beans.serializer.RunTimeInputHandler.resolveMapParameter;
+import static io.harness.ci.commonconstants.CIExecutionConstants.HOME_DIR;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 
 import io.harness.beans.serializer.RunTimeInputHandler;
 import io.harness.beans.steps.stepinfo.BackgroundStepInfo;
+import io.harness.beans.sweepingoutputs.StageInfraDetails;
 import io.harness.beans.yaml.extended.reports.JUnitTestReport;
 import io.harness.beans.yaml.extended.reports.UnitTestReportType;
 import io.harness.ci.buildstate.ConnectorUtils;
@@ -26,6 +28,7 @@ import io.harness.pms.execution.utils.AmbianceUtils;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
@@ -34,7 +37,8 @@ import org.apache.commons.lang3.StringUtils;
 public class VmBackgroundStepSerializer {
   @Inject ConnectorUtils connectorUtils;
 
-  public VmBackgroundStep serialize(BackgroundStepInfo backgroundStepInfo, Ambiance ambiance, String identifier) {
+  public VmBackgroundStep serialize(BackgroundStepInfo backgroundStepInfo, StageInfraDetails stageInfraDetails,
+      Ambiance ambiance, String identifier) {
     String command = RunTimeInputHandler.resolveStringParameter(
         "Command", "Background", identifier, backgroundStepInfo.getCommand(), false);
     String image = RunTimeInputHandler.resolveStringParameter(
@@ -56,6 +60,12 @@ public class VmBackgroundStepSerializer {
 
     Map<String, String> envVars =
         resolveMapParameter("envVariables", "Background", identifier, backgroundStepInfo.getEnvVariables(), false);
+    if (isEmpty(image) && stageInfraDetails.getType() == StageInfraDetails.Type.DLITE_VM) {
+      if (envVars == null) {
+        envVars = new HashMap<>();
+      }
+      envVars.put("HOME", HOME_DIR);
+    }
 
     if (!isEmpty(command)) {
       String earlyExitCommand = SerializerUtils.getEarlyExitCommand(backgroundStepInfo.getShell());

--- a/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmBitriseStepSerializer.java
+++ b/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmBitriseStepSerializer.java
@@ -8,17 +8,16 @@
 package io.harness.ci.serializer.vm;
 
 import static io.harness.beans.serializer.RunTimeInputHandler.resolveMapParameter;
+import static io.harness.ci.commonconstants.CIExecutionConstants.HOME_DIR;
 import static io.harness.ci.commonconstants.CIExecutionConstants.PLUGIN_ENV_PREFIX;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 
 import io.harness.beans.serializer.RunTimeInputHandler;
 import io.harness.beans.steps.stepinfo.BitriseStepInfo;
 import io.harness.beans.sweepingoutputs.StageInfraDetails;
-import io.harness.ci.config.CIExecutionServiceConfig;
 import io.harness.delegate.beans.ci.vm.steps.VmRunStep;
 import io.harness.exception.ngexception.CIStageExecutionException;
 
-import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -26,8 +25,6 @@ import java.util.Map;
 
 @Singleton
 public class VmBitriseStepSerializer {
-  @Inject CIExecutionServiceConfig ciExecutionServiceConfig;
-
   public VmRunStep serialize(BitriseStepInfo bitriseStepInfo, String identifier, StageInfraDetails stageInfraDetails) {
     if (stageInfraDetails.getType() != StageInfraDetails.Type.DLITE_VM) {
       throw new CIStageExecutionException("Bitrise step is only applicable for builds on cloud infrastructure");
@@ -40,6 +37,7 @@ public class VmBitriseStepSerializer {
     if (env == null) {
       env = new HashMap<>();
     }
+    env.put("HOME", HOME_DIR);
 
     if (!isEmpty(with)) {
       for (Map.Entry<String, String> entry : with.entrySet()) {

--- a/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmPluginCompatibleStepSerializer.java
+++ b/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmPluginCompatibleStepSerializer.java
@@ -7,6 +7,8 @@
 
 package io.harness.ci.serializer.vm;
 
+import static io.harness.ci.commonconstants.CIExecutionConstants.HOME_DIR;
+
 import io.harness.beans.plugin.compatible.PluginCompatibleStep;
 import io.harness.beans.sweepingoutputs.StageInfraDetails;
 import io.harness.beans.sweepingoutputs.StageInfraDetails.Type;
@@ -29,6 +31,7 @@ import io.harness.yaml.core.timeout.Timeout;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.HashMap;
 import java.util.Map;
 
 @Singleton
@@ -42,9 +45,14 @@ public class VmPluginCompatibleStepSerializer {
       StageInfraDetails stageInfraDetails, String identifier, ParameterField<Timeout> parameterFieldTimeout,
       String stepName) {
     long timeout = TimeoutUtils.getTimeoutInSeconds(parameterFieldTimeout, pluginCompatibleStep.getDefaultTimeout());
-    StageInfraDetails.Type type = stageInfraDetails.getType();
     Map<String, String> envVars = pluginSettingUtils.getPluginCompatibleEnvVariables(
         pluginCompatibleStep, identifier, timeout, ambiance, Type.VM);
+    if (stageInfraDetails.getType() == Type.DLITE_VM) {
+      if (envVars == null) {
+        envVars = new HashMap<>();
+      }
+      envVars.put("HOME", HOME_DIR);
+    }
     String image = CIStepInfoUtils.getPluginCustomStepImage(
         pluginCompatibleStep, ciExecutionConfigService, Type.VM, AmbianceUtils.getAccountId(ambiance));
     NGAccess ngAccess = AmbianceUtils.getNgAccess(ambiance);

--- a/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmPluginStepSerializer.java
+++ b/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmPluginStepSerializer.java
@@ -9,6 +9,7 @@ package io.harness.ci.serializer.vm;
 
 import static io.harness.beans.serializer.RunTimeInputHandler.resolveJsonNodeMapParameter;
 import static io.harness.ci.commonconstants.CIExecutionConstants.GIT_CLONE_STEP_ID;
+import static io.harness.ci.commonconstants.CIExecutionConstants.HOME_DIR;
 import static io.harness.ci.commonconstants.CIExecutionConstants.PLUGIN_ENV_PREFIX;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
@@ -99,6 +100,9 @@ public class VmPluginStepSerializer {
   private VmPluginStep convertContainerStep(Ambiance ambiance, String identifier, String image,
       String connectorIdentifier, Map<String, String> envVars, long timeout, StageInfraDetails stageInfraDetails,
       PluginStepInfo pluginStepInfo) {
+    if (stageInfraDetails.getType() == StageInfraDetails.Type.DLITE_VM && pluginStepInfo.isHarnessManagedImage()) {
+      envVars.put("HOME", HOME_DIR);
+    }
     VmPluginStepBuilder pluginStepBuilder =
         VmPluginStep.builder().image(image).envVariables(envVars).timeoutSecs(timeout);
 
@@ -132,6 +136,7 @@ public class VmPluginStepSerializer {
 
   private VmRunStep convertContainerlessStep(
       String identifier, String uses, Map<String, String> envVars, long timeout, PluginStepInfo pluginStepInfo) {
+    envVars.put("HOME", HOME_DIR);
     VmRunStepBuilder stepBuilder = VmRunStep.builder()
                                        .entrypoint(Arrays.asList("plugin", "-kind", "harness", "-repo"))
                                        .command(uses)

--- a/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmStepSerializer.java
+++ b/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmStepSerializer.java
@@ -31,7 +31,7 @@ import java.util.Set;
 public class VmStepSerializer {
   @Inject VmPluginCompatibleStepSerializer vmPluginCompatibleStepSerializer;
   @Inject VmPluginStepSerializer vmPluginStepSerializer;
-  @Inject VmRunStepSerializer vmRunStepSerializer;
+  @Inject BitriseSerializer BitriseSerializer;
   @Inject VmRunTestStepSerializer vmRunTestStepSerializer;
   @Inject VmBackgroundStepSerializer vmBackgroundStepSerializer;
   @Inject VmActionStepSerializer vmActionStepSerializer;
@@ -49,12 +49,13 @@ public class VmStepSerializer {
     switch (stepInfo.getNonYamlInfo().getStepInfoType()) {
       case RUN:
         return vmRunStepSerializer.serialize(
-            (RunStepInfo) stepInfo, ambiance, identifier, parameterFieldTimeout, stepName);
+            (RunStepInfo) stepInfo, stageInfraDetails, ambiance, identifier, parameterFieldTimeout, stepName);
       case BACKGROUND:
-        return vmBackgroundStepSerializer.serialize((BackgroundStepInfo) stepInfo, ambiance, identifier);
+        return vmBackgroundStepSerializer.serialize(
+            (BackgroundStepInfo) stepInfo, stageInfraDetails, ambiance, identifier);
       case RUN_TESTS:
         return vmRunTestStepSerializer.serialize(
-            (RunTestsStepInfo) stepInfo, identifier, parameterFieldTimeout, stepName, ambiance);
+            (RunTestsStepInfo) stepInfo, stageInfraDetails, identifier, parameterFieldTimeout, stepName, ambiance);
       case PLUGIN:
         return vmPluginStepSerializer.serialize(
             (PluginStepInfo) stepInfo, stageInfraDetails, identifier, parameterFieldTimeout, stepName, ambiance);

--- a/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmStepSerializer.java
+++ b/332-ci-manager/service/src/main/java/io/harness/ci/execution/serializer/vm/VmStepSerializer.java
@@ -31,7 +31,7 @@ import java.util.Set;
 public class VmStepSerializer {
   @Inject VmPluginCompatibleStepSerializer vmPluginCompatibleStepSerializer;
   @Inject VmPluginStepSerializer vmPluginStepSerializer;
-  @Inject BitriseSerializer BitriseSerializer;
+  @Inject VmRunStepSerializer vmRunStepSerializer;
   @Inject VmRunTestStepSerializer vmRunTestStepSerializer;
   @Inject VmBackgroundStepSerializer vmBackgroundStepSerializer;
   @Inject VmActionStepSerializer vmActionStepSerializer;


### PR DESCRIPTION
## Describe your changes
Major goal for this change is allowing caching to work without user knowing HOME env values. Cached data is majorly stored in $HOME directory. So, if a user run build directly on host and then use cache step, user should be able to use ~ for paths to cache.

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/40369)
<!-- Reviewable:end -->
