### PR TITLE
fix: [CCM-9035]: Fix broken UT in develop 400-rest/FeatureNameTest

### DIFF
--- a/400-rest/src/test/java/software/wings/features/FeatureNameTest.java
+++ b/400-rest/src/test/java/software/wings/features/FeatureNameTest.java
@@ -452,6 +452,7 @@ public class FeatureNameTest extends WingsBaseTest {
     featureNameOrdinalMapping.put(418, "SPG_WFE_OPTIMIZE_WORKFLOW_LISTING");
     featureNameOrdinalMapping.put(419, "SPG_OPTIMIZE_PIPELINE_QUERY_ON_AUTH");
     featureNameOrdinalMapping.put(420, "SPG_NG_CUSTOM_WEBHOOK_AUTHORIZATION");
+    featureNameOrdinalMapping.put(421, "CCM_ENABLE_CLOUD_ASSET_GOVERNANCE_UI");
 
     featureNameConstantMapping =
         featureNameOrdinalMapping.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));

--- a/400-rest/src/test/java/software/wings/features/FeatureNameTest.java
+++ b/400-rest/src/test/java/software/wings/features/FeatureNameTest.java
@@ -461,10 +461,10 @@ public class FeatureNameTest extends WingsBaseTest {
   @Owner(developers = ASHISHSANODIA)
   @Category(UnitTests.class)
   public void testMappingExistsForAllEnumConstants() {
-    Arrays.stream(FeatureName.values()).forEach(taskType -> {
-      if (!taskType.name().equals(featureNameOrdinalMapping.get(taskType.ordinal()))) {
-        Assertions.fail(String.format("Not all constants from enum [%s] mapped in test [%s].",
-            FeatureName.class.getCanonicalName(), this.getClass().getCanonicalName()));
+    Arrays.stream(FeatureName.values()).forEach(featureName -> {
+      if (!featureName.name().equals(featureNameOrdinalMapping.get(featureName.ordinal()))) {
+        Assertions.fail(String.format("Not all constants from enum [%s] mapped in test [%s]. Feature Name = [%s]",
+            FeatureName.class.getCanonicalName(), this.getClass().getCanonicalName(), featureName.name()));
       }
     });
   }


### PR DESCRIPTION
## Describe your changes
Previous error message
```
Not all constants from enum [io.harness.beans.FeatureName] mapped in test [software.wings.features.FeatureNameTest]
```

New Error Message
```
Not all constants from enum [io.harness.beans.FeatureName] mapped in test [software.wings.features.FeatureNameTest]. Feature Name = [<FEATURE NAME>]

```
## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/40444)
<!-- Reviewable:end -->
