### PR TITLE
[feat]: [PIE-5675]: Adding retry-failure-strategy support with retry-failed-pipeline

### DIFF
--- a/pipeline-service/modules/orchestration-beans/contracts/src/main/java/io/harness/plan/Node.java
+++ b/pipeline-service/modules/orchestration-beans/contracts/src/main/java/io/harness/plan/Node.java
@@ -10,10 +10,14 @@ package io.harness.plan;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.persistence.UuidAccess;
+import io.harness.pms.contracts.advisers.AdviserObtainment;
 import io.harness.pms.contracts.steps.SkipType;
 import io.harness.pms.contracts.steps.StepCategory;
 import io.harness.pms.contracts.steps.StepType;
 import io.harness.pms.data.stepparameters.PmsStepParameters;
+
+import java.util.Collections;
+import java.util.List;
 
 @OwnedBy(HarnessTeam.PIPELINE)
 public interface Node extends UuidAccess {
@@ -58,4 +62,8 @@ public interface Node extends UuidAccess {
   }
 
   boolean isSkipUnresolvedExpressionsCheck();
+
+  default List<AdviserObtainment> getAdviserObtainments() {
+    return Collections.emptyList();
+  }
 }

--- a/pipeline-service/modules/orchestration-beans/src/main/java/io/harness/plan/IdentityPlanNode.java
+++ b/pipeline-service/modules/orchestration-beans/src/main/java/io/harness/plan/IdentityPlanNode.java
@@ -9,10 +9,12 @@ package io.harness.plan;
 
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.pms.contracts.advisers.AdviserObtainment;
 import io.harness.pms.contracts.steps.SkipType;
 import io.harness.pms.contracts.steps.StepType;
 import io.harness.pms.data.stepparameters.PmsStepParameters;
 
+import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Value;
@@ -38,6 +40,7 @@ public class IdentityPlanNode implements Node {
   String originalNodeExecutionId;
   String serviceName;
   String executionInputTemplate;
+  List<AdviserObtainment> adviserObtainments;
 
   @Override
   public String getStageFqn() {
@@ -90,6 +93,7 @@ public class IdentityPlanNode implements Node {
         .group(node.getGroup())
         .skipGraphType(node.getSkipGraphType())
         .stepType(stepType)
+        .adviserObtainments(node.getAdviserObtainments())
         .isSkipExpressionChain(node.isSkipExpressionChain())
         .serviceName(node.getServiceName())
         .stageFqn(node.getStageFqn())
@@ -109,6 +113,7 @@ public class IdentityPlanNode implements Node {
         .isSkipExpressionChain(node.isSkipExpressionChain())
         .serviceName(node.getServiceName())
         .stageFqn(node.getStageFqn())
+        .adviserObtainments(node.getAdviserObtainments())
         .whenCondition(node.getWhenCondition())
         .originalNodeExecutionId(originalNodeExecutionUuid)
         .build();

--- a/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/executions/node/NodeExecutionServiceImpl.java
+++ b/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/executions/node/NodeExecutionServiceImpl.java
@@ -925,10 +925,23 @@ public class NodeExecutionServiceImpl implements NodeExecutionService {
 
     List<NodeExecution> nodeExecutions = mongoTemplate.find(query, NodeExecution.class);
 
+    Map<String, NodeExecution> nodeExecutionMap = new HashMap<>();
+    for (NodeExecution nodeExecution : nodeExecutions) {
+      if (nodeExecution.getStepType().getStepCategory() == StepCategory.STRATEGY) {
+        continue;
+      }
+      if (!nodeExecutionMap.containsKey(nodeExecution.getNode().getUuid())) {
+        nodeExecutionMap.put(nodeExecution.getNode().getUuid(), nodeExecution);
+      } else if (nodeExecutionMap.get(nodeExecution.getNode().getUuid()).getCreatedAt()
+          > nodeExecution.getCreatedAt()) {
+        nodeExecutionMap.put(nodeExecution.getNode().getUuid(), nodeExecution);
+      }
+    }
+
     // fetching stageFqn of stage Nodes
     Map<String, Node> nodeExecutionIdToPlanNode = new HashMap<>();
-    nodeExecutions.forEach(
-        nodeExecution -> nodeExecutionIdToPlanNode.put(nodeExecution.getUuid(), nodeExecution.getNode()));
+    nodeExecutionMap.forEach(
+        (uuid, nodeExecution) -> nodeExecutionIdToPlanNode.put(nodeExecution.getUuid(), nodeExecution.getNode()));
     return nodeExecutionIdToPlanNode;
   }
 

--- a/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/pms/advise/NodeAdviseHelper.java
+++ b/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/pms/advise/NodeAdviseHelper.java
@@ -23,6 +23,11 @@ public class NodeAdviseHelper {
   }
 
   public void queueAdvisingEvent(
+      NodeExecution nodeExecution, FailureInfo failureInfo, Status toStatus, Status fromStatus) {
+    nodeAdviseEventPublisher.publishEvent(nodeExecution, failureInfo, toStatus, fromStatus);
+  }
+
+  public void queueAdvisingEvent(
       NodeExecution nodeExecution, FailureInfo failureInfo, PlanNode planNode, Status fromStatus) {
     nodeAdviseEventPublisher.publishEvent(nodeExecution, failureInfo, planNode, fromStatus);
   }

--- a/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/pms/advise/handlers/RetryAdviserResponseHandler.java
+++ b/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/pms/advise/handlers/RetryAdviserResponseHandler.java
@@ -17,6 +17,7 @@ import io.harness.engine.interrupts.InterruptPackage;
 import io.harness.engine.pms.advise.AdviserResponseHandler;
 import io.harness.engine.pms.resume.EngineWaitRetryCallback;
 import io.harness.execution.NodeExecution;
+import io.harness.plan.NodeType;
 import io.harness.pms.contracts.advisers.AdviseType;
 import io.harness.pms.contracts.advisers.AdviserResponse;
 import io.harness.pms.contracts.advisers.RetryAdvise;
@@ -44,7 +45,8 @@ public class RetryAdviserResponseHandler implements AdviserResponseHandler {
   @Override
   public void handleAdvise(NodeExecution nodeExecution, AdviserResponse adviserResponse) {
     RetryAdvise advise = adviserResponse.getRetryAdvise();
-    if (advise.getWaitInterval() > 0) {
+    // Do not register waitInterval if its called from IdentityNodeExecutionStrategy.
+    if (advise.getWaitInterval() > 0 && nodeExecution.getNode().getNodeType() != NodeType.IDENTITY_PLAN_NODE) {
       log.info("Retry Wait Interval : {}", advise.getWaitInterval());
       String resumeId = delayEventHelper.delay(advise.getWaitInterval(), Collections.emptyMap());
       waitNotifyEngine.waitForAllOn(publisherName,

--- a/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/pms/advise/publisher/NodeAdviseEventPublisher.java
+++ b/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/pms/advise/publisher/NodeAdviseEventPublisher.java
@@ -18,5 +18,6 @@ import io.harness.pms.contracts.execution.failure.FailureInfo;
 public interface NodeAdviseEventPublisher {
   String publishEvent(NodeExecution nodeExecutionId, PlanNode node, Status fromStatus);
 
+  String publishEvent(NodeExecution nodeExecution, FailureInfo failureInfo, Status toStatus, Status fromStatus);
   String publishEvent(NodeExecution nodeExecution, FailureInfo failureInfo, PlanNode planNode, Status fromStatus);
 }

--- a/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/pms/advise/publisher/RedisNodeAdviseEventPublisher.java
+++ b/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/pms/advise/publisher/RedisNodeAdviseEventPublisher.java
@@ -33,6 +33,23 @@ public class RedisNodeAdviseEventPublisher implements NodeAdviseEventPublisher {
   }
 
   @Override
+  public String publishEvent(NodeExecution nodeExecution, FailureInfo failureInfo, Status toStatus, Status fromStatus) {
+    AdviseEvent adviseEvent =
+        AdviseEvent.newBuilder()
+            .setAmbiance(nodeExecution.getAmbiance())
+            .setFailureInfo(failureInfo)
+            .addAllAdviserObtainments(nodeExecution.getNode().getAdviserObtainments())
+            .setIsPreviousAdviserExpired(isPreviousAdviserExpired(nodeExecution.getInterruptHistories()))
+            .addAllRetryIds(nodeExecution.getRetryIds())
+            .setNotifyId(generateUuid())
+            .setToStatus(toStatus)
+            .setFromStatus(fromStatus)
+            .build();
+
+    return eventSender.sendEvent(nodeExecution.getAmbiance(), adviseEvent.toByteString(), PmsEventCategory.NODE_ADVISE,
+        nodeExecution.getModule(), true);
+  }
+  @Override
   public String publishEvent(
       NodeExecution nodeExecution, FailureInfo failureInfo, PlanNode planNode, Status fromStatus) {
     AdviseEvent adviseEvent =


### PR DESCRIPTION
## Describe your changes
Adding retry-failure-strategy support with retry-failed pipeline.
Also instead of ending the nodeExecution in IdentityNodeExecution, sending the nodeAdvise event so that all failure-strategies will be handled by their AdviserResponse handlers with the same flow that run for PlanNode.

Testing: Tested the retry-failed-pipeline flows in local. Will run the retry-failed-pipeline automation before merging this PR.

ReleaseNotes summary needed? No

Is it new task type? No
Did you make changes to the code in a backward-compatible manner? Yes
Did you add a new class which is added in kryo serialization? - No
Will the new version of the delegate receive old version task and process? Yes
If new version of the pipeline-service receives response for the old task will it be able to handle it successfully? Yes
Did you make a change in delegate task which will be created in pipeline-services via grpc call to manager? No change
If the older version of pipeline-service creates the task parameter and calls newer cg manager, will it be okay? Yes
if the newer version of pipeline-service creates the task parameter and calls older cg manager, will it be okay? Yes
Did you remove an enum → No
Did you add an enum(That too at end of list) → No
FeatureFlag Added/Removed -> No
Verify Changes with affects any -> No


## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/40532)
<!-- Reviewable:end -->
