### PR TITLE
feat: [BT-2453]: Exclude extensions from copyright check

### DIFF
--- a/scripts/jenkins/copyright-check.sh
+++ b/scripts/jenkins/copyright-check.sh
@@ -4,36 +4,31 @@
 # that can be found in the licenses directory at the root of this repository, also available at
 # https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
 
-merge_summary=()
-merge_summary+=( $(git diff HEAD@{0} HEAD@{1} --name-only) )
+FILES_WITHOUT_STMTS=()
 
-echo "Merge Summary: "${merge_summary[@]}
-error_data=()
+HARNESS_INC="Copyright [0-9]{4} Harness Inc. All rights reserved."
+EXCLUSION_LIST='\.log\|\.toml\|\.yml\|\.yaml\|\.properties\|\.md\|\.json\|\.config\|\.env\|\.txt\|\.info\|\.jks\|\.mod\|\.env\|\.xml\|^\.'
 
-copyright_text="Copyright "$current_year" Harness Inc. All rights reserved."
-echo "'"$copyright_text"'"
+#MERGE_SUMMARY=$(git diff HEAD@{0} HEAD@{1} --name-only | grep -v ${EXCLUSION_LIST})
 
-for file in ${merge_summary[@]}
+MERGE_SUMMARY=$(cat test-file | grep -v ${EXCLUSION_LIST})
+
+echo "$MERGE_SUMMARY"
+
+for file in ${MERGE_SUMMARY[@]}
 do
-    if [ -z "$(grep  "$copyright_text" $file)" ];
-    then
-      error_data+=( "$file" )
-    else
-      echo "checked... " $file
-    fi
+    [ -z "$(grep -E "${HARNESS_INC}" $file)" ] && FILES_WITHOUT_STMTS+=( "$file" )
 done
 
-echo ${error_data[@]}
-len=${#error_data[@]}
+len=${#FILES_WITHOUT_STMTS[@]}
 
-if [ $len -eq 0 ];
-then
-  echo "All file have up to date copyrights... "
+if [ $len -eq 0 ]; then
+  echo "INFO: All files have copyright statement..."
 else
-  echo "please update the copyright issue in following files and re-trigger the execution... "
-  for i in ${error_data[@]}
+  echo "ERROR: Following ${len} files do not have the Copyright statements. please update and re-trigger the execution..."
+  for file in ${FILES_WITHOUT_STMTS[@]}
   do
-    echo $i
+    echo "-> $file"
   done
   exit 1
 fi


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
