### PR TITLE
feat: [BT-2321]: Set size to medium

### DIFF
--- a/tools/bazel/GenTestRules.bzl
+++ b/tools/bazel/GenTestRules.bzl
@@ -1,3 +1,7 @@
+# Copyright 2022 Harness Inc. All rights reserved.
+# Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+# that can be found in the licenses directory at the root of this repository, also available at
+# https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
 load("//:test-util.bzl", "DISTRIBUTE_TESTING_WORKER", "DISTRIBUTE_TESTING_WORKERS", "OPTIMIZED_PACKAGE_TESTS")
 
 MAX_COMPILE_TESTS = 512

--- a/tools/bazel/GenTestRules.bzl
+++ b/tools/bazel/GenTestRules.bzl
@@ -1,7 +1,7 @@
 load("//:test-util.bzl", "DISTRIBUTE_TESTING_WORKER", "DISTRIBUTE_TESTING_WORKERS", "OPTIMIZED_PACKAGE_TESTS")
 
 MAX_COMPILE_TESTS = 512
-MAX_EXECUTION_TESTS = 20
+MAX_EXECUTION_TESTS = 100
 SUITE_CODE_FILEPATH = "code_filepath"
 SUITE_PACKAGE_NAME = "package_name"
 SUITE_INDEX = "index"
@@ -25,7 +25,7 @@ def run_tests(**kwargs):
         native.java_test(
             name = test,
             runtime_deps = ["tests"],
-            size = "enormous",
+            size = "medium",
             jvm_flags = [
                 "$(HARNESS_ARGS)",
                 "-Xmx4G",
@@ -137,7 +137,7 @@ EOF""" % code,
             name = package + ".tests" + index,
             test_class = package + "." + test_class,
             deps = [":shared_package_tests"] + deps,
-            size = "enormous",
+            size = "medium",
 
             # inputs
             srcs = code_filepath + [x[0] for x in tests],
@@ -213,7 +213,7 @@ def optimized_package_test(combined_tests_target_index, package, index, test_cla
         name = target_name,
         test_class = package + "." + test_class,
         runtime_deps = [COMBINED_TESTS_TARGET + str(combined_tests_target_index)],
-        size = "enormous",
+        size = "medium",
 
         #Additional
         visibility = ["//visibility:public"],


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/40676)
<!-- Reviewable:end -->
