### PR TITLE
fix: [DEL-5374]: immutable delegate for on prem 

### DIFF
--- a/400-rest/src/test/java/io/harness/delegate/service/DelegateVersionServiceTest.java
+++ b/400-rest/src/test/java/io/harness/delegate/service/DelegateVersionServiceTest.java
@@ -185,13 +185,6 @@ public class DelegateVersionServiceTest {
 
   @Test
   @Category(UnitTests.class)
-  public void whenUpgraderImageTagConfigOverrideThenUseIt() {
-    mockUpgraderOverrides(null, false, true, false);
-    assertOverrides(DEFAULT_DELEGATE_IMAGE, HARNESS_UPGRADER_PORTAL_IMAGE, emptyList(), null, false);
-  }
-
-  @Test
-  @Category(UnitTests.class)
   public void whenNoUpgraderOverrideUseDefault() {
     mockUpgraderOverrides(null, false, false, false);
     assertOverrides(DEFAULT_DELEGATE_IMAGE, DEFAULT_UPGRADER_IMAGE, emptyList(), null, false);
@@ -278,7 +271,6 @@ public class DelegateVersionServiceTest {
 
     when(managerConfig.getPortal().getDelegateDockerImage())
         .thenReturn(isPortalDelegateOverride ? HARNESS_DELEGATE_PORTAL_IMAGE : null);
-    when(managerConfig.getPortal().getUpgraderDockerImage()).thenReturn(null);
     doReturn(null).when(underTest).getWatcherJarVersions(ACCOUNT_ID);
   }
 
@@ -291,8 +283,6 @@ public class DelegateVersionServiceTest {
     }
 
     when(managerConfig.getPortal().getDelegateDockerImage()).thenReturn(null);
-    when(managerConfig.getPortal().getUpgraderDockerImage())
-        .thenReturn(isPortalUpgraderOverride ? HARNESS_UPGRADER_PORTAL_IMAGE : null);
     doReturn(null).when(underTest).getWatcherJarVersions(ACCOUNT_ID);
   }
 
@@ -303,7 +293,6 @@ public class DelegateVersionServiceTest {
       when(delegateRingService.getDelegateVersions(ACCOUNT_ID)).thenReturn(DELEGATE_JAR_RING);
     }
     when(managerConfig.getPortal().getDelegateDockerImage()).thenReturn(null);
-    when(managerConfig.getPortal().getUpgraderDockerImage()).thenReturn(null);
     doReturn(null).when(underTest).getWatcherJarVersions(ACCOUNT_ID);
   }
 
@@ -314,7 +303,6 @@ public class DelegateVersionServiceTest {
       when(delegateRingService.getWatcherVersions(ACCOUNT_ID)).thenReturn(WATCHER_JAR_RING);
     }
     when(managerConfig.getPortal().getDelegateDockerImage()).thenReturn(null);
-    when(managerConfig.getPortal().getUpgraderDockerImage()).thenReturn(null);
   }
 
   private void mockVersionOverride(final VersionOverride delegateImageOverride, final VersionOverride upgraderOverride,

--- a/890-sm-core/src/main/java/software/wings/app/PortalConfig.java
+++ b/890-sm-core/src/main/java/software/wings/app/PortalConfig.java
@@ -45,7 +45,6 @@ public class PortalConfig {
   @ConfigSecret private String jwtDataHandlerSecret;
   @ConfigSecret private String jwtNextGenManagerSecret;
   private String delegateDockerImage;
-  private String upgraderDockerImage;
   private int externalGraphQLRateLimitPerMinute = 500;
   private int customDashGraphQLRateLimitPerMinute = 1000;
   private Long authTokenExpiryInMillis = 24 * 60 * 60 * 1000L;

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
 build.number=77611
-build.patch=000
+build.patch=001
 delegate.version=22.11.11
 delegate.patch=000

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=77611
-build.patch=001
+build.number=77612
+build.patch=000
 delegate.version=22.11.11
 delegate.patch=000


### PR DESCRIPTION
Variable:
1- IMMUTABLE_DELEGATE_DOCKER_IMAGE
2- UPGRADER_DOCKER_IMAGE
will be added to configMap for manager running on on-prem.

corresponding helm-chart pr: https://github.com/harness/helm-harness-manager/pull/30
This change and helm-chart changes needs to go in same release if BE goes first then on-prem will break for accounts with immutable enabled.

Testing:
1- Immutable image was used for delegates in new account. Helm delegate used immutable image as specified in configMap, upgrader pointed to latest tag. 
Installed delegate and checked on smp.

<img width="1488" alt="Screenshot 2022-11-21 at 3 51 32 PM" src="https://user-images.githubusercontent.com/102655013/203087110-293cc3b4-d0c3-4b49-9211-3249443c26fc.png">


<img width="1728" alt="Screenshot 2022-11-21 at 3 41 58 PM" src="https://user-images.githubusercontent.com/102655013/203087288-bef6eb55-a5ff-4d06-bf37-c05e294aef53.png">

<img width="1728" alt="Screenshot 2022-11-21 at 3 42 15 PM" src="https://user-images.githubusercontent.com/102655013/203087309-cc3637f7-be7f-4e87-8337-efb1fc222863.png">


## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/40314)
<!-- Reviewable:end -->
