### PR TITLE
feat: [CDS-47520]: Sanitize secrets with new line for NG

### DIFF
--- a/950-log-client/src/main/java/io/harness/logstreaming/LogStreamingSanitizer.java
+++ b/950-log-client/src/main/java/io/harness/logstreaming/LogStreamingSanitizer.java
@@ -9,6 +9,7 @@ package io.harness.logstreaming;
 
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.expression.SecretString.SECRET_MASK;
+
 import static org.apache.commons.lang3.StringUtils.replaceEach;
 
 import io.harness.data.structure.EmptyPredicate;

--- a/950-log-client/src/main/java/io/harness/logstreaming/LogStreamingSanitizer.java
+++ b/950-log-client/src/main/java/io/harness/logstreaming/LogStreamingSanitizer.java
@@ -9,18 +9,26 @@ package io.harness.logstreaming;
 
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.expression.SecretString.SECRET_MASK;
-
 import static org.apache.commons.lang3.StringUtils.replaceEach;
 
+import io.harness.data.structure.EmptyPredicate;
 import io.harness.logging.LogSanitizerHelper;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Builder;
 
 @Builder
 public class LogStreamingSanitizer {
   private final Set<String> secrets;
+
+  public LogStreamingSanitizer(Set<String> secrets) {
+    this.secrets = calculateSecretLines(secrets);
+  }
+
   public void sanitizeLogMessage(LogLine logLine) {
     String sanitizedLogMessage = logLine.getMessage();
     if (!isEmpty(secrets)) {
@@ -54,5 +62,17 @@ public class LogStreamingSanitizer {
       secretMasks.add(SECRET_MASK);
       secretValues.add(secretWithSingleQuoteRemoved);
     }
+  }
+
+  private static Set<String> calculateSecretLines(Set<String> secrets) {
+    if (isEmpty(secrets)) {
+      return new HashSet<>();
+    }
+    return secrets.stream()
+        .flatMap(secret -> {
+          String[] split = secret.split("\\r?\\n");
+          return Arrays.stream(split).filter(EmptyPredicate::isNotEmpty);
+        })
+        .collect(Collectors.toSet());
   }
 }

--- a/950-log-client/src/test/java/io/harness/logstreaming/LogStreamingSanitizerTest.java
+++ b/950-log-client/src/test/java/io/harness/logstreaming/LogStreamingSanitizerTest.java
@@ -10,14 +10,17 @@ package io.harness.logstreaming;
 import static io.harness.expression.SecretString.SECRET_MASK;
 import static io.harness.rule.OwnerRule.MARKO;
 import static io.harness.rule.OwnerRule.TEJAS;
+import static io.harness.rule.OwnerRule.YOGESH;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.harness.CategoryTest;
 import io.harness.category.element.UnitTests;
 import io.harness.rule.Owner;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.HashSet;
 import java.util.Set;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -32,7 +35,7 @@ public class LogStreamingSanitizerTest extends CategoryTest {
     LogStreamingSanitizer logStreamingSanitizer = LogStreamingSanitizer.builder().secrets(null).build();
 
     logStreamingSanitizer.sanitizeLogMessage(logLine);
-    Assertions.assertThat(logLine.getMessage()).isEqualTo(message);
+    assertThat(logLine.getMessage()).isEqualTo(message);
   }
 
   @Test
@@ -52,7 +55,7 @@ public class LogStreamingSanitizerTest extends CategoryTest {
         LogStreamingSanitizer.builder().secrets(secrets).build();
 
     logStreamingSanitizer.sanitizeLogMessage(logLine);
-    Assertions.assertThat(logLine.getMessage()).isEqualTo(sanitizedMessage);
+    assertThat(logLine.getMessage()).isEqualTo(sanitizedMessage);
   }
 
   @Test
@@ -72,6 +75,26 @@ public class LogStreamingSanitizerTest extends CategoryTest {
     LogStreamingSanitizer logStreamingSanitizer = LogStreamingSanitizer.builder().secrets(null).build();
 
     logStreamingSanitizer.sanitizeLogMessage(logLine);
-    Assertions.assertThat(logLine.getMessage()).isEqualTo(sanitizedMessage);
+    assertThat(logLine.getMessage()).isEqualTo(sanitizedMessage);
+  }
+
+  @Test
+  @Owner(developers = YOGESH)
+  @Category(UnitTests.class)
+  public void testGenericSanitize_ShouldReplaceMultiLineSecret() {
+    Set<String> secrets = ImmutableSet.<String>builder().add("line1\nline2\nline3").build();
+    LogStreamingSanitizer logSanitizer = LogStreamingSanitizer.builder().secrets(secrets).build();
+
+    LogLine logLine = LogLine.builder()
+                          .message("sanitize this log: line1\n"
+                              + "      line2\n"
+                              + "       line3")
+                          .build();
+    logSanitizer.sanitizeLogMessage(logLine);
+
+    assertThat(logLine.getMessage())
+        .isEqualTo("sanitize this log: **************\n"
+            + "      **************\n"
+            + "       **************");
   }
 }


### PR DESCRIPTION
- feat: [CDS-47520]: Sanitize secrets with new line for NG
- feat: [CDS-47520]: Code Format

## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)


[CDS-47520]: https://harness.atlassian.net/browse/CDS-47520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDS-47520]: https://harness.atlassian.net/browse/CDS-47520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/40887)
<!-- Reviewable:end -->
