### PR TITLE
fix: [CDS-43600]: WinRM remote PS execution 15+ second delays after connection before script(s) begin execution.

### DIFF
--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/winrm/DefaultWinRmExecutor.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/winrm/DefaultWinRmExecutor.java
@@ -8,9 +8,13 @@
 package io.harness.delegate.task.winrm;
 
 import static io.harness.annotations.dev.HarnessTeam.CDP;
-import static io.harness.delegate.task.winrm.WinRmExecutorHelper.constructCommandsList;
+import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
 import static io.harness.delegate.task.winrm.WinRmExecutorHelper.constructPSScriptWithCommands;
+import static io.harness.delegate.task.winrm.WinRmExecutorHelper.executablePSFilePath;
+import static io.harness.delegate.task.winrm.WinRmExecutorHelper.getEncodedScriptFile;
 import static io.harness.delegate.task.winrm.WinRmExecutorHelper.getScriptExecutingCommand;
+import static io.harness.delegate.task.winrm.WinRmExecutorHelper.prepareCommandForCopyingToRemoteFile;
+import static io.harness.delegate.task.winrm.WinRmExecutorHelper.splitCommandForCopyingToRemoteFile;
 import static io.harness.logging.CommandExecutionStatus.FAILURE;
 import static io.harness.logging.CommandExecutionStatus.RUNNING;
 import static io.harness.logging.CommandExecutionStatus.SUCCESS;
@@ -41,7 +45,9 @@ import software.wings.core.winrm.executors.WinRmExecutor;
 import software.wings.utils.ExecutionLogWriter;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
 import java.io.StringWriter;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
@@ -124,10 +130,8 @@ public class DefaultWinRmExecutor implements WinRmExecutor {
       if (disableCommandEncoding) {
         psScriptFile = getPSScriptFile();
         if (winrmScriptCommandSplit) {
-          List<String> commandList =
-              constructCommandsList(command, psScriptFile, powershell, config.getCommandParameters());
-          exitCode = session.executeCommandsListV2(
-              commandList, outputWriter, errorWriter, false, getScriptExecutingCommand(psScriptFile, powershell), true);
+          String encodedScriptFilePath = getEncodedScriptFile(config.getWorkingDirectory(), config.getExecutionId());
+          exitCode = splitAndExecute(command, session, outputWriter, errorWriter, psScriptFile, encodedScriptFilePath);
         } else {
           List<List<String>> commandList =
               constructPSScriptWithCommands(command, psScriptFile, powershell, config.getCommandParameters());
@@ -224,12 +228,9 @@ public class DefaultWinRmExecutor implements WinRmExecutor {
       int exitCode;
       if (disableCommandEncoding) {
         psScriptFile = getPSScriptFile();
-
         if (winrmScriptCommandSplit) {
-          List<String> commandList =
-              constructCommandsList(command, psScriptFile, powershell, config.getCommandParameters());
-          exitCode = session.executeCommandsListV2(
-              commandList, outputWriter, errorWriter, false, getScriptExecutingCommand(psScriptFile, powershell), true);
+          String encodedScriptFilePath = getEncodedScriptFile(config.getWorkingDirectory(), config.getExecutionId());
+          exitCode = splitAndExecute(command, session, outputWriter, errorWriter, psScriptFile, encodedScriptFilePath);
         } else {
           List<List<String>> commandList =
               constructPSScriptWithCommands(command, psScriptFile, powershell, config.getCommandParameters());
@@ -294,10 +295,9 @@ public class DefaultWinRmExecutor implements WinRmExecutor {
       if (disableCommandEncoding) {
         psScriptFile = getPSScriptFile();
         if (winrmScriptCommandSplit) {
-          List<String> commandList =
-              constructCommandsList(commandWithoutEncoding, psScriptFile, powershell, config.getCommandParameters());
-          exitCode = session.executeCommandsListV2(commandList, outputAccumulator, errorAccumulator, true,
-              getScriptExecutingCommand(psScriptFile, powershell), true);
+          String encodedScriptFilePath = getEncodedScriptFile(config.getWorkingDirectory(), config.getExecutionId());
+          exitCode = splitAndExecute(
+              command, session, outputAccumulator, errorAccumulator, psScriptFile, encodedScriptFilePath);
         } else {
           List<List<String>> commandList = constructPSScriptWithCommands(
               commandWithoutEncoding, psScriptFile, powershell, config.getCommandParameters());
@@ -371,6 +371,33 @@ public class DefaultWinRmExecutor implements WinRmExecutor {
         .stringBuilder(new StringBuilder(1024))
         .logLevel(logLevel)
         .build();
+  }
+
+  private int splitAndExecute(String command, WinRmSession session, Writer outputWriter, Writer errorWriter,
+      String psScriptFile, String encodedScriptFilePath) throws IOException {
+    int exitCode;
+    List<String> commandList =
+        splitCommandForCopyingToRemoteFile(command, encodedScriptFilePath, powershell, config.getCommandParameters());
+    exitCode = session.copyScriptToRemote(commandList, outputWriter, errorWriter);
+    if (exitCode != 0) {
+      log.error("Transferring encoded script data to remote file FAILED.");
+      return exitCode;
+    }
+
+    String executable = executablePSFilePath(config.getWorkingDirectory(), config.getExecutionId());
+    String psExecutionCommand = prepareCommandForCopyingToRemoteFile(
+        encodedScriptFilePath, psScriptFile, powershell, config.getCommandParameters(), executable);
+    exitCode = session.executeCommandString(psExecutionCommand, outputWriter, errorWriter, false);
+    if (exitCode != 0) {
+      log.error("Transferring execution script to PowerShell script file FAILED.");
+      return exitCode;
+    }
+
+    String scriptFileExecutingCommand = getScriptExecutingCommand(psScriptFile, powershell);
+    if (isNotEmpty(scriptFileExecutingCommand)) {
+      exitCode = session.executeScript(scriptFileExecutingCommand, outputWriter, errorWriter);
+    }
+    return exitCode;
   }
 
   @Override

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/winrm/FileBasedAbstractWinRmExecutor.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/winrm/FileBasedAbstractWinRmExecutor.java
@@ -8,11 +8,14 @@
 package io.harness.delegate.task.winrm;
 
 import static io.harness.annotations.dev.HarnessTeam.CDP;
-import static io.harness.delegate.task.winrm.WinRmExecutorHelper.constructCommandsList;
 import static io.harness.delegate.task.winrm.WinRmExecutorHelper.constructPSScriptWithCommands;
 import static io.harness.delegate.task.winrm.WinRmExecutorHelper.constructPSScriptWithCommandsBulk;
+import static io.harness.delegate.task.winrm.WinRmExecutorHelper.executablePSFilePath;
+import static io.harness.delegate.task.winrm.WinRmExecutorHelper.getEncodedScriptFile;
 import static io.harness.delegate.task.winrm.WinRmExecutorHelper.getScriptExecutingCommand;
+import static io.harness.delegate.task.winrm.WinRmExecutorHelper.prepareCommandForCopyingToRemoteFile;
 import static io.harness.delegate.task.winrm.WinRmExecutorHelper.psWrappedCommandWithEncoding;
+import static io.harness.delegate.task.winrm.WinRmExecutorHelper.splitCommandForCopyingToRemoteFile;
 import static io.harness.exception.WingsException.USER;
 import static io.harness.logging.CommandExecutionStatus.FAILURE;
 import static io.harness.logging.CommandExecutionStatus.RUNNING;
@@ -58,6 +61,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public abstract class FileBasedAbstractWinRmExecutor {
   public static final String WINDOWS_TEMPFILE_LOCATION = "%TEMP%";
+
   public static final String NOT_IMPLEMENTED = "Not implemented";
   protected static final String ERROR_WHILE_EXECUTING_COMMAND = "Error while executing command";
   /**
@@ -247,9 +251,25 @@ public abstract class FileBasedAbstractWinRmExecutor {
       }
     } else {
       if (winrmScriptCommandSplit) {
-        exitCode = session.executeCommandsListV2(
-            constructCommandsList(command, psScriptFile, getPowershell(), config.getCommandParameters()), outputWriter,
-            errorWriter, false, getScriptExecutingCommand(psScriptFile, getPowershell()), true);
+        String encodedScriptFile = getEncodedScriptFile(config.getWorkingDirectory(), config.getExecutionId());
+        exitCode = session.copyScriptToRemote(splitCommandForCopyingToRemoteFile(command, encodedScriptFile,
+                                                  getPowershell(), config.getCommandParameters()),
+            outputWriter, errorWriter);
+        if (exitCode != 0) {
+          log.error("Transferring encoded script to remote file failed.");
+          return exitCode;
+        }
+
+        String executable = executablePSFilePath(config.getWorkingDirectory(), config.getExecutionId());
+        String psExecutionCommand = prepareCommandForCopyingToRemoteFile(
+            encodedScriptFile, psScriptFile, getPowershell(), config.getCommandParameters(), executable);
+        exitCode = session.executeCommandString(psExecutionCommand, outputWriter, errorWriter, false);
+        if (exitCode != 0) {
+          log.error("Transferring execution script to PowerShell script file FAILED.");
+          return exitCode;
+        }
+        String scriptFileExecutingCommand = getScriptExecutingCommand(psScriptFile, getPowershell());
+        exitCode = session.executeScript(scriptFileExecutingCommand, outputWriter, errorWriter);
       } else {
         exitCode = session.executeCommandsList(
             constructPSScriptWithCommands(command, psScriptFile, getPowershell(), config.getCommandParameters()),

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/winrm/WinRmExecutorHelper.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/winrm/WinRmExecutorHelper.java
@@ -8,12 +8,12 @@
 package io.harness.delegate.task.winrm;
 
 import static io.harness.annotations.dev.HarnessTeam.CDP;
+import static io.harness.data.encoding.EncodingUtils.encodeBase64;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
-import static io.harness.windows.CmdUtils.escapeLineBreakChars;
-import static io.harness.windows.CmdUtils.escapeWordBreakChars;
 
 import static java.lang.String.format;
 import static org.apache.commons.codec.binary.Base64.encodeBase64String;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 
 import io.harness.annotations.dev.HarnessModule;
 import io.harness.annotations.dev.OwnedBy;
@@ -38,7 +38,11 @@ import lombok.extern.slf4j.Slf4j;
 @TargetModule(HarnessModule._930_DELEGATE_TASKS)
 public class WinRmExecutorHelper {
   private static final int SPLITLISTOFCOMMANDSBY = 20;
-  public static final int PARTITION_SIZE_IN_BYTES = 4 * 1024; // 4 KB
+  public static final int PARTITION_SIZE_IN_BYTES = 6 * 1024; // 6 KB
+
+  private static final String HARNESS_ENCODED_SCRIPT_FILENAME_PREFIX = "\\harness-encoded-";
+  private static final String HARNESS_EXECUTABLE_SCRIPT_FILENAME_PREFIX = "\\harness-executable-";
+  private static final String WINDOWS_TEMPFILE_LOCATION = "%TEMP%";
 
   /**
    * To construct the powershell script for running on target windows host.
@@ -83,48 +87,43 @@ public class WinRmExecutorHelper {
     return Lists.partition(commandList, SPLITLISTOFCOMMANDSBY);
   }
 
-  public static List<String> constructCommandsList(
-      String command, String psScriptFile, String powershell, List<WinRmCommandParameter> commandParameters) {
-    command = "$ErrorActionPreference=\"Stop\"\n" + command;
-
+  public static List<String> splitCommandForCopyingToRemoteFile(
+      String command, String encodedScriptFile, String powershell, List<WinRmCommandParameter> commandParameters) {
+    command = "$ErrorActionPreference='Stop'\n" + command;
+    String base64Command = encodeBase64(command.getBytes(StandardCharsets.UTF_16LE));
     // write commands to a file and then execute the file
     String commandParametersString = buildCommandParameters(commandParameters);
 
-    List<List<Byte>> partitions = Lists.partition(Bytes.asList(command.getBytes()), PARTITION_SIZE_IN_BYTES);
+    List<List<Byte>> partitions =
+        Lists.partition(Bytes.asList(base64Command.getBytes(StandardCharsets.UTF_8)), PARTITION_SIZE_IN_BYTES);
     List<String> commandList = new ArrayList<>();
     for (List<Byte> partition : partitions) {
-      String partOfCommand = new String(Bytes.toArray(partition));
-      // Yes, replace() is intentional. We are replacing only character and not a regex pattern.
-      partOfCommand = partOfCommand.replace("$", "`$");
-      // This is to escape quotes
-      partOfCommand = partOfCommand.replaceAll("\"", "`\\\\\"");
-      // Replace pipe only if part of a string, else skip
-      partOfCommand = escapePipe(partOfCommand);
-      // Replace ampersand only if part of a string, else skip
-      partOfCommand = escapeAmpersand(partOfCommand);
-      partOfCommand = escapeWordBreakChars(escapeLineBreakChars(partOfCommand));
       String appendTextToFileCommand = powershell + " Invoke-Command " + commandParametersString
-          + " -command {[IO.File]::AppendAllText(\\\"" + psScriptFile + "\\\", \\\"" + partOfCommand + "\\\" ) }";
+          + " -command {[IO.File]::AppendAllText(\\\"" + encodedScriptFile + "\\\", \\\""
+          + new String(Bytes.toArray(partition)) + "\\\" ) }";
 
       commandList.add(appendTextToFileCommand);
     }
     return commandList;
   }
 
-  private static String escapePipe(String partOfCommand) {
-    Pattern patternForPipeWithinAString = Pattern.compile("[a-zA-Z]+\\|");
-    if (patternForPipeWithinAString.matcher(partOfCommand).find()) {
-      partOfCommand = partOfCommand.replaceAll("\\|", "`\\\"|`\\\"");
-    }
-    return partOfCommand;
-  }
+  public static String prepareCommandForCopyingToRemoteFile(String encodedScriptFile, String psExecutableFile,
+      String powershell, List<WinRmCommandParameter> commandParameters, String scriptExecutionFile) {
+    // write commands to a file and then execute the file
+    String commandParametersString = buildCommandParameters(commandParameters);
 
-  private static String escapeAmpersand(String partOfCommand) {
-    Pattern patternForAmpersandWithinString = Pattern.compile("[a-zA-Z0-9]+&");
-    if (patternForAmpersandWithinString.matcher(partOfCommand).find()) {
-      partOfCommand = partOfCommand.replaceAll("&", "^&");
-    }
-    return partOfCommand;
+    return powershell + " Invoke-Command " + commandParametersString + " -command {[IO.File]::AppendAllText(\\\""
+        + psExecutableFile + "\\\", \\\""
+        + "try{`n"
+        + "`t`$encoded = get-content " + encodedScriptFile + "`n"
+        + "`t`$decoded = [System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String(`$encoded));`n"
+        + "`tSet-Content -Path " + scriptExecutionFile + " -Value `$decoded -Encoding Unicode`n"
+        + "`tInvoke-Expression -Command " + scriptExecutionFile + "`n"
+        + "}`ncatch`n{`n`tWrite-Error `$_;`n`texit 1`n}`n"
+        + "finally`n{`n"
+        + "`tif (Test-Path " + scriptExecutionFile + ") {Remove-Item -Force -Path " + scriptExecutionFile + "}"
+        + "`tif (Test-Path " + encodedScriptFile + ") {Remove-Item -Force -Path " + encodedScriptFile + "}`n}"
+        + "\\\" ) }";
   }
 
   private static String buildCommandParameters(List<WinRmCommandParameter> commandParameters) {
@@ -230,5 +229,17 @@ public class WinRmExecutorHelper {
     } catch (Exception e) {
       log.error("Exception while trying to remove file {} {}", file, e);
     }
+  }
+
+  public static String getEncodedScriptFile(String workingDir, String suffix) {
+    return isEmpty(workingDir)
+        ? WINDOWS_TEMPFILE_LOCATION + HARNESS_ENCODED_SCRIPT_FILENAME_PREFIX + randomAlphanumeric(10)
+        : workingDir + HARNESS_ENCODED_SCRIPT_FILENAME_PREFIX + suffix;
+  }
+
+  public static String executablePSFilePath(String workingDir, String suffix) {
+    return isEmpty(workingDir)
+        ? WINDOWS_TEMPFILE_LOCATION + HARNESS_EXECUTABLE_SCRIPT_FILENAME_PREFIX + randomAlphanumeric(10) + ".ps1"
+        : workingDir + HARNESS_EXECUTABLE_SCRIPT_FILENAME_PREFIX + suffix + ".ps1";
   }
 }

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/winrm/WinRmSession.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/winrm/WinRmSession.java
@@ -8,13 +8,14 @@
 package io.harness.delegate.task.winrm;
 
 import static io.harness.annotations.dev.HarnessTeam.CDP;
+import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
 import static io.harness.delegate.task.winrm.WinRmExecutorHelper.PARTITION_SIZE_IN_BYTES;
 import static io.harness.delegate.utils.TaskExceptionUtils.calcPercentage;
-import static io.harness.logging.CommandExecutionStatus.FAILURE;
 import static io.harness.logging.CommandExecutionStatus.RUNNING;
 import static io.harness.logging.LogLevel.INFO;
 import static io.harness.windows.CmdUtils.escapeEnvValueSpecialChars;
+import static io.harness.winrm.WinRmHelperUtils.buildErrorDetailsFromWinRmClientException;
 
 import static java.lang.String.format;
 
@@ -25,6 +26,7 @@ import io.harness.data.structure.EmptyPredicate;
 import io.harness.delegate.clienttools.ClientTool;
 import io.harness.delegate.clienttools.HarnessPywinrmVersion;
 import io.harness.delegate.clienttools.InstallUtils;
+import io.harness.eraro.ResponseMessage;
 import io.harness.exception.InvalidRequestException;
 import io.harness.exception.WingsException;
 import io.harness.logging.LogCallback;
@@ -50,6 +52,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 
@@ -61,6 +65,10 @@ public class WinRmSession implements AutoCloseable {
   @VisibleForTesting static final String FILE_CACHE_TYPE = "FILE";
   @VisibleForTesting static final String KERBEROS_CACHE_NAME_ENV = "KRB5CCNAME";
   @VisibleForTesting static final String COMMAND_PLACEHOLDER = "%s %s";
+  private static final String START_OF_ERROR_TAG = "<S S=\"Error\">";
+  private static final String END_OF_ERROR_TAG = "</S>";
+  private static final Pattern ERROR_PATTERN = Pattern.compile(START_OF_ERROR_TAG + ".*?" + END_OF_ERROR_TAG);
+  private static final String START_OF_XML_RESPONSE = "#< CLIXML";
 
   private final ShellCommand shell;
   private final WinRmTool winRmTool;
@@ -70,6 +78,7 @@ public class WinRmSession implements AutoCloseable {
   private WinRmClientContext context;
   private PyWinrmArgs args;
   private Path cacheFilePath;
+  private final AuthenticationScheme authenticationScheme;
 
   public WinRmSession(WinRmSessionConfig config, LogCallback logCallback) throws JSchException {
     Map<String, String> processedEnvironmentMap = new HashMap<>();
@@ -79,8 +88,9 @@ public class WinRmSession implements AutoCloseable {
       }
     }
     this.logCallback = logCallback;
+    this.authenticationScheme = config.getAuthenticationScheme();
     Map<String, String> generateTGTEnv = new HashMap<>();
-    if (config.getAuthenticationScheme() == AuthenticationScheme.KERBEROS) {
+    if (authenticationScheme == AuthenticationScheme.KERBEROS) {
       if (config.isUseKerberosUniqueCacheFile()) {
         this.cacheFilePath = config.getSessionCacheFilePath();
         String cache = String.format("%s:%s", FILE_CACHE_TYPE, cacheFilePath);
@@ -115,7 +125,7 @@ public class WinRmSession implements AutoCloseable {
     WinRmClientBuilder clientBuilder =
         WinRmClient.builder(getEndpoint(config.getHostname(), config.getPort(), config.isUseSSL()))
             .disableCertificateChecks(config.isSkipCertChecks())
-            .authenticationScheme(getAuthSchemeString(config.getAuthenticationScheme()))
+            .authenticationScheme(getAuthSchemeString(authenticationScheme))
             .credentials(config.getDomain(), config.getUsername(), config.getPassword())
             .workingDirectory(config.getWorkingDirectory())
             .environment(processedEnvironmentMap)
@@ -129,7 +139,7 @@ public class WinRmSession implements AutoCloseable {
 
     winRmTool = WinRmTool.Builder.builder(config.getHostname(), config.getUsername(), config.getPassword())
                     .disableCertificateChecks(config.isSkipCertChecks())
-                    .authenticationScheme(getAuthSchemeString(config.getAuthenticationScheme()))
+                    .authenticationScheme(getAuthSchemeString(authenticationScheme))
                     .workingDirectory(config.getWorkingDirectory())
                     .environment(processedEnvironmentMap)
                     .port(config.getPort())
@@ -140,29 +150,33 @@ public class WinRmSession implements AutoCloseable {
 
   public int executeCommandString(String command, Writer output, Writer error, boolean isOutputWriter) {
     if (args != null) {
-      String commandFilePath = null;
-      try {
-        File commandFile = File.createTempFile("winrm-kerberos-command", null);
-        commandFilePath = commandFile.getPath();
-        byte[] buff = command.getBytes(StandardCharsets.UTF_8);
-        Files.write(Paths.get(commandFilePath), buff);
-
-        return SshHelperUtils.executeLocalCommand(
-                   format(COMMAND_PLACEHOLDER,
-                       InstallUtils.getPath(ClientTool.HARNESS_PYWINRM, HarnessPywinrmVersion.V0_4),
-                       args.getArgs(commandFile.getAbsolutePath())),
-                   logCallback, output, isOutputWriter, args.getEnvironmentMap())
-            ? 0
-            : 1;
-      } catch (IOException e) {
-        log.error(format("Error while creating temporary file: %s", e));
-        logCallback.saveExecutionLog("Error while creating temporary file");
-        return 1;
-      } finally {
-        deleteSilently(commandFilePath);
-      }
+      return executeCommandWithKerberos(command, output, isOutputWriter);
     }
     return shell.execute(command, output, error);
+  }
+
+  public int executeCommandWithKerberos(String command, Writer output, boolean isOutputWriter) {
+    String commandFilePath = null;
+    try {
+      File commandFile = File.createTempFile("winrm-kerberos-command", null);
+      commandFilePath = commandFile.getPath();
+      byte[] buff = command.getBytes(StandardCharsets.UTF_8);
+      Files.write(Paths.get(commandFilePath), buff);
+
+      return SshHelperUtils.executeLocalCommand(
+                 format(COMMAND_PLACEHOLDER,
+                     InstallUtils.getPath(ClientTool.HARNESS_PYWINRM, HarnessPywinrmVersion.V0_4),
+                     args.getArgs(commandFile.getAbsolutePath())),
+                 logCallback, output, isOutputWriter, args.getEnvironmentMap())
+          ? 0
+          : 1;
+    } catch (IOException e) {
+      log.error(format("Error while creating temporary file: %s", e));
+      logCallback.saveExecutionLog("Error while creating temporary file");
+      return 1;
+    } finally {
+      deleteSilently(commandFilePath);
+    }
   }
 
   private void deleteSilently(String path) {
@@ -196,13 +210,7 @@ public class WinRmSession implements AutoCloseable {
     } else {
       for (List<String> list : commandList) {
         winRmToolResponse = winRmTool.executeCommand(list);
-        if (!winRmToolResponse.getStdOut().isEmpty()) {
-          output.write(winRmToolResponse.getStdOut());
-        }
-
-        if (!winRmToolResponse.getStdErr().isEmpty()) {
-          error.write(winRmToolResponse.getStdErr());
-        }
+        writeLogs(winRmToolResponse, output, error);
         statusCode = winRmToolResponse.getStatusCode();
         if (statusCode != 0) {
           return statusCode;
@@ -216,59 +224,129 @@ public class WinRmSession implements AutoCloseable {
     return statusCode;
   }
 
-  public int executeCommandsListV2(List<String> commandList, Writer output, Writer error, boolean isOutputWriter,
-      String scriptExecCommand, boolean isScriptFileExecution) {
+  public int copyScriptToRemote(List<String> commandList, Writer output, Writer error) throws IOException {
     if (commandList.isEmpty()) {
       return -1;
     }
-    int statusCode;
-    if (args != null) {
-      if (isNotEmpty(scriptExecCommand)) {
-        commandList.add(scriptExecCommand);
-      }
-      statusCode = executeAllCommands(commandList, output, error, isOutputWriter, isScriptFileExecution);
-      if (statusCode != 0) {
-        log.warn("Transferring script data to PowerShell script file failed.");
-      }
-      return statusCode;
+    if (authenticationScheme == AuthenticationScheme.KERBEROS) {
+      return executeCopyCommandsWithKerberos(commandList, output);
     } else {
-      statusCode = executeAllCommands(commandList, output, error, isOutputWriter, isScriptFileExecution);
-      if (statusCode != 0) {
-        log.warn("Transferring script data to PowerShell script file failed.");
-        return statusCode;
-      }
-      if (isNotEmpty(scriptExecCommand)) {
-        statusCode = shell.execute(scriptExecCommand, output, error);
-      }
+      return executeCopyCommands(commandList, output, error);
     }
-
-    return statusCode;
   }
 
-  private int executeAllCommands(
-      List<String> commandList, Writer output, Writer error, boolean isOutputWriter, boolean isScriptFileExecution) {
-    int statusCode = 0;
-    int chunkNumber = 1;
-    if (isScriptFileExecution) {
-      logCallback.saveExecutionLog(
-          format("Transferring script to a remote file. Chunk size: %s Bytes\n", PARTITION_SIZE_IN_BYTES), INFO,
-          RUNNING);
-    }
-    for (String command : commandList) {
-      int fileLength = commandList.stream().mapToInt(c -> c.getBytes().length).sum();
-      statusCode = executeCommandString(command, output, error, isOutputWriter);
-      if (statusCode != 0) {
-        logCallback.saveExecutionLog("Transferring script data to PowerShell script file failed.", INFO, FAILURE);
-        return statusCode;
+  public int executeScript(String scriptExecCommand, Writer output, Writer error) {
+    try {
+      if (authenticationScheme == AuthenticationScheme.KERBEROS) {
+        return executeCommandWithKerberos(scriptExecCommand, output, false);
+      } else {
+        // adding output format at the end because there is a bug in powershell 5.1 and bellow which is fixed in 6.1.
+        // https://github.com/PowerShell/PowerShell/issues/5912
+        WinRmToolResponse winRmToolResponse = winRmTool.executeCommand(scriptExecCommand + " -OutputFormat Text");
+        writeLogs(winRmToolResponse, output, error);
+        return hasError(winRmToolResponse) ? 1 : winRmToolResponse.getStatusCode();
       }
-      if (isScriptFileExecution) {
-        logCallback.saveExecutionLog(format("Transferred %s data to PowerShell script file...\n",
+    } catch (Exception e) {
+      ResponseMessage details = buildErrorDetailsFromWinRmClientException(e);
+      log.error("Script execution failed.", e);
+      logCallback.saveExecutionLog(details.getMessage(), INFO, RUNNING);
+      return 1;
+    }
+  }
+
+  private int executeCopyCommands(List<String> commandList, Writer output, Writer error) {
+    try {
+      int statusCode = 0;
+      int chunkNumber = 1;
+      int fileLength = commandList.stream().mapToInt(c -> c.getBytes().length).sum();
+      logCallback.saveExecutionLog(
+          format("Transferring encoded script to a remote file. File size: %s Bytes, Chunk size: %s Bytes\n",
+              fileLength, PARTITION_SIZE_IN_BYTES),
+          INFO, RUNNING);
+      for (String command : commandList) {
+        WinRmToolResponse winRmToolResponse = winRmTool.executeCommand(command);
+        writeLogs(winRmToolResponse, output, error);
+        statusCode = winRmToolResponse.getStatusCode();
+        if (statusCode != 0) {
+          logCallback.saveExecutionLog("Transferring encoded script data to remote file FAILED.", INFO, RUNNING);
+          return statusCode;
+        }
+        logCallback.saveExecutionLog(format("Transferred %s data to remote file...\n",
                                          calcPercentage(chunkNumber * PARTITION_SIZE_IN_BYTES, fileLength)),
             INFO, RUNNING);
+        chunkNumber++;
       }
+      return statusCode;
+    } catch (IOException e) {
+      log.error("Transferring encoded script data to remote file FAILED.", e);
+      logCallback.saveExecutionLog("Transferring encoded script data to remote file FAILED.", INFO, RUNNING);
+      return 1;
+    } catch (Exception e) {
+      ResponseMessage details = buildErrorDetailsFromWinRmClientException(e);
+      log.error("Transferring encoded script data to remote file FAILED.", e);
+      logCallback.saveExecutionLog(
+          "Transferring encoded script data to remote file FAILED.\n\n" + details.getMessage(), INFO, RUNNING);
+      return 1;
+    }
+  }
+
+  private int executeCopyCommandsWithKerberos(List<String> commandList, Writer output) {
+    int statusCode = 0;
+    int chunkNumber = 1;
+    int fileLength = commandList.stream().mapToInt(c -> c.getBytes().length).sum();
+    logCallback.saveExecutionLog(
+        format("Transferring encoded script to a remote file. File size: %s Bytes, Chunk size: %s Bytes\n", fileLength,
+            PARTITION_SIZE_IN_BYTES),
+        INFO, RUNNING);
+    for (String command : commandList) {
+      statusCode = executeCommandWithKerberos(command, output, false);
+      if (statusCode != 0) {
+        logCallback.saveExecutionLog("Transferring encoded script data to remote file FAILED.", INFO, RUNNING);
+        return statusCode;
+      }
+      logCallback.saveExecutionLog(format("Transferred %s data to remote file...\n",
+                                       calcPercentage(chunkNumber * PARTITION_SIZE_IN_BYTES, fileLength)),
+          INFO, RUNNING);
       chunkNumber++;
     }
     return statusCode;
+  }
+
+  private void writeLogs(WinRmToolResponse winRmToolResponse, Writer output, Writer error) throws IOException {
+    if (!winRmToolResponse.getStdOut().isEmpty()) {
+      output.write(winRmToolResponse.getStdOut());
+    }
+
+    if (!winRmToolResponse.getStdErr().isEmpty()) {
+      if (isXmlResponse(winRmToolResponse)) {
+        writeLogsFromXmlResponse(error, winRmToolResponse);
+      } else {
+        error.write(winRmToolResponse.getStdErr());
+      }
+    }
+  }
+
+  private boolean isXmlResponse(WinRmToolResponse winRmToolResponse) {
+    return winRmToolResponse.getStdErr() != null && winRmToolResponse.getStdErr().startsWith(START_OF_XML_RESPONSE);
+  }
+
+  private boolean hasError(WinRmToolResponse winRmToolResponse) {
+    return (isXmlResponse(winRmToolResponse) && ERROR_PATTERN.matcher(winRmToolResponse.getStdErr()).find())
+        || (!isXmlResponse(winRmToolResponse)) && !isEmpty(winRmToolResponse.getStdErr());
+  }
+
+  private void writeLogsFromXmlResponse(Writer error, WinRmToolResponse winRmToolResponse) throws IOException {
+    // There is a bug in powershell versions 5.1 and bellow to display output and error in XML format because we are
+    // calling powershell from powershell. The solution is to avoid writing this XML message in execution logs. We
+    // are searching for the error tags in this XML and writing them into execution logs.
+    Matcher matcher = ERROR_PATTERN.matcher(winRmToolResponse.getStdErr());
+    while (matcher.find()) {
+      final String errorString = winRmToolResponse.getStdErr()
+                                     .substring(matcher.start(), matcher.end())
+                                     .replaceFirst(START_OF_ERROR_TAG, "")
+                                     .replaceFirst(END_OF_ERROR_TAG, "");
+      error.write(errorString + "\n");
+    }
   }
 
   private static String getEndpoint(String hostname, int port, boolean useHttps) {

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=77318
-build.patch=003
+build.number=77319
+build.patch=000
 delegate.version=22.10.12
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes

With the new implementation we have 4 steps:

1. Copying encoded script into separate file on remote
2. Decode on remote and create new file with the script content
3. Creating Executable file which reads and decodes upper one
4. Execute file from step 3

Test plan executed: 
https://docs.google.com/spreadsheets/d/1d6mp1_APzZ8pmNLSZaMFmeXHPahXU6AHuXlmMNKOMGc/edit#gid=1321123544

Screenshot of initial Schwab issue:
![image](https://user-images.githubusercontent.com/84450157/204929187-6a8e6a8c-0507-4eee-85ca-f6896f190e39.png)


Executable file content:

```
try{
	$encoded = get-content C:\Users\cdp_admin/bojan/\harness-encoded-BhFe992DRxi8k9fD1DPNoA
	$decoded = [System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String($encoded));
	Set-Content -Path C:\Users\cdp_admin/bojan/\harness-executable-BhFe992DRxi8k9fD1DPNoA.ps1 -Value $decoded -Encoding Unicode
	Invoke-Expression -Command C:\Users\cdp_admin/bojan/\harness-executable-BhFe992DRxi8k9fD1DPNoA.ps1
}
catch
{
	Write-Error $_;
	exit 1
}
finally
{
	if (Test-Path C:\Users\cdp_admin/bojan/\harness-executable-BhFe992DRxi8k9fD1DPNoA.ps1) {Remove-Item -Force -Path C:\Users\cdp_admin/bojan/\harness-executable-BhFe992DRxi8k9fD1DPNoA.ps1}
	if (Test-Path C:\Users\cdp_admin/bojan/\harness-encoded-BhFe992DRxi8k9fD1DPNoA) {Remove-Item -Force -Path C:\Users\cdp_admin/bojan/\harness-encoded-BhFe992DRxi8k9fD1DPNoA
}
```
We need this exception handling because child process Invoke-Expression -Command "file-path" doesn’t propagate exit code.

**NOTE:** _The whole feature is behind two FFs_ (**WINRM_SCRIPT_COMMAND_SPLIT** and **DISABLE_WINRM_COMMAND_ENCODING**)

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/40899)
<!-- Reviewable:end -->
