### PR TITLE
[fix]: [PL-30065]: Enabling Job to create Default User Groups or add any user which has not already been added to User Group.

### DIFF
--- a/120-ng-manager/src/main/java/io/harness/ng/NextGenApplication.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/NextGenApplication.java
@@ -103,6 +103,7 @@ import io.harness.migration.NGMigrationSdkModule;
 import io.harness.migration.beans.NGMigrationConfiguration;
 import io.harness.migrations.InstanceMigrationProvider;
 import io.harness.ng.core.CorrelationFilter;
+import io.harness.ng.core.DefaultUserGroupsCreationJob;
 import io.harness.ng.core.EtagFilter;
 import io.harness.ng.core.TraceFilter;
 import io.harness.ng.core.event.NGEventConsumerService;
@@ -784,6 +785,7 @@ public class NextGenApplication extends Application<NextGenConfiguration> {
     environment.lifecycle().manage(injector.getInstance(QueueListenerController.class));
     environment.lifecycle().manage(injector.getInstance(NotifierScheduledExecutorService.class));
     environment.lifecycle().manage(injector.getInstance(OutboxEventPollService.class));
+    environment.lifecycle().manage(injector.getInstance(DefaultUserGroupsCreationJob.class));
     createConsumerThreadsToListenToEvents(environment, injector);
   }
 

--- a/123-ng-core-user/src/main/java/io/harness/ng/core/DefaultUserGroupsCreationJob.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/core/DefaultUserGroupsCreationJob.java
@@ -39,7 +39,7 @@ public class DefaultUserGroupsCreationJob implements Managed {
   public void start() throws Exception {
     log.info(DEBUG_MESSAGE + "started...");
     defaultUserGroupJobFuture =
-        executorService.scheduleWithFixedDelay(defaultUserGroupCreationService, 15, 720, TimeUnit.MINUTES);
+        executorService.scheduleWithFixedDelay(defaultUserGroupCreationService, 15, 1440, TimeUnit.MINUTES);
   }
 
   @Override

--- a/123-ng-core-user/src/main/java/io/harness/ng/core/api/impl/DefaultUserGroupServiceImpl.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/core/api/impl/DefaultUserGroupServiceImpl.java
@@ -45,7 +45,6 @@ import io.harness.remote.client.NGRestUtils;
 import io.harness.repositories.user.spring.UserMembershipRepository;
 import io.harness.utils.NGFeatureFlagHelperService;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;

--- a/123-ng-core-user/src/main/java/io/harness/ng/core/api/impl/DefaultUserGroupServiceImpl.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/core/api/impl/DefaultUserGroupServiceImpl.java
@@ -345,7 +345,7 @@ public class DefaultUserGroupServiceImpl implements DefaultUserGroupService {
   private RoleAssignmentFilterDTO getRoleAssignmentFilterDTOForAccountScope() {
     return RoleAssignmentFilterDTO.builder()
         .resourceGroupFilter(Collections.singleton(DEFAULT_ACCOUNT_LEVEL_RESOURCE_GROUP_IDENTIFIER))
-        .roleFilter(Collections.singleton((ACCOUNT_BASIC_ROLE)))
+        .roleFilter(Collections.singleton(ACCOUNT_BASIC_ROLE))
         .principalFilter(Collections.singleton(PrincipalDTO.builder()
                                                    .identifier(DEFAULT_ACCOUNT_LEVEL_USER_GROUP_IDENTIFIER)
                                                    .scopeLevel("account")

--- a/123-ng-core-user/src/main/java/io/harness/ng/core/api/impl/DefaultUserGroupServiceImpl.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/core/api/impl/DefaultUserGroupServiceImpl.java
@@ -194,12 +194,12 @@ public class DefaultUserGroupServiceImpl implements DefaultUserGroupService {
   }
 
   private void createRoleAssignmentsForAccount(
-      String principalIdentifier, Scope scope, boolean createAccountViewerRole) {
+      String principalIdentifier, Scope scope, boolean createAccountViewerRoleBinding) {
     createRoleAssignment(
         principalIdentifier, scope, true, ACCOUNT_BASIC_ROLE, DEFAULT_ACCOUNT_LEVEL_RESOURCE_GROUP_IDENTIFIER);
     boolean isAccountBasicFeatureFlagEnabled =
         ngFeatureFlagHelperService.isEnabled(scope.getAccountIdentifier(), FeatureName.ACCOUNT_BASIC_ROLE_ONLY);
-    if (!isAccountBasicFeatureFlagEnabled && createAccountViewerRole) {
+    if (!isAccountBasicFeatureFlagEnabled && createAccountViewerRoleBinding) {
       createRoleAssignment(
           principalIdentifier, scope, false, ACCOUNT_VIEWER_ROLE, DEFAULT_ACCOUNT_LEVEL_RESOURCE_GROUP_IDENTIFIER);
     }
@@ -308,16 +308,12 @@ public class DefaultUserGroupServiceImpl implements DefaultUserGroupService {
 
   private void createRoleAssignmentAtScope(Scope scope) {
     Optional<List<RoleAssignmentResponseDTO>> optionalRoleAssignmentResponseDTO = getRoleAssignmentsAtScope(scope);
-    if (optionalRoleAssignmentResponseDTO.isPresent()) {
+    if (optionalRoleAssignmentResponseDTO.isPresent() && isEmpty(optionalRoleAssignmentResponseDTO.get())) {
       String userGroupIdentifier = getUserGroupIdentifier(scope);
       if (isNotEmpty(scope.getProjectIdentifier())) {
-        if (isEmpty(optionalRoleAssignmentResponseDTO.get())) {
-          createRoleAssignmentForProject(userGroupIdentifier, scope);
-        }
+        createRoleAssignmentForProject(userGroupIdentifier, scope);
       } else if (isNotEmpty(scope.getOrgIdentifier())) {
-        if (isEmpty(optionalRoleAssignmentResponseDTO.get())) {
-          createRoleAssignmentsForOrganization(userGroupIdentifier, scope);
-        }
+        createRoleAssignmentsForOrganization(userGroupIdentifier, scope);
       } else {
         createRoleAssignmentsForAccount(userGroupIdentifier, scope, false);
       }

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=77618
+build.number=77619
 build.patch=000
 delegate.version=22.11.11
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes
This HF is for OnPrem. No impact if goes to SAAS.
Enabling Job to create Default User Groups.
https://docs.harness.io/article/n3cel7d8re-harness-default-user-groups

- This Job creates Default User Group(UG) in scope where it doesn't exist and adds all the users into UG or if Default UG already exists then it adds any user which has not already been added to User Group.
- This helps with following failure scenarios:
   1. When Scope entity ie. Organization, Project gets created but corresponding User Group is not created.
  2. When user is added to the scope and if is not added to Default UG due to failure in User Membership addition event consumption.

- Not assigning Account Viewer - All Account resources Role binding anymore since we had already rolled out this feature earlier and made Account Viewer - All Account resources Role binding deletable there is possibility that customer might have removed the same Role binding. This will ensure no change in system behavior.
- Also reducing the frequency of Job run from 12 hours to 24 hours.


## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/41161)
<!-- Reviewable:end -->
