### PR TITLE
feat: [PL-30263] Implement new mongo iterator mode based on sharding

### DIFF
--- a/360-cg-manager/config.yml
+++ b/360-cg-manager/config.yml
@@ -59,6 +59,8 @@ serviceScheduler:
 
 enableIterators: ${ENABLE_ITERATORS:-true}
 iteratorConfigPath: ${ITERATOR_CONFIG_PATH:-""}
+replicaCount: ${REPLICA_COUNT:-1}
+containerName: ${CONTAINER_NAME:-""}
 trialRegistrationAllowed: true
 eventsFrameworkAvailableInOnPrem: false
 trialRegistrationAllowedForBugathon: false

--- a/360-cg-manager/iterator_config.json
+++ b/360-cg-manager/iterator_config.json
@@ -6,7 +6,8 @@
     "threadPoolIntervalInSeconds": 60,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 600,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "ArtifactCollection",
@@ -15,7 +16,8 @@
     "threadPoolIntervalInSeconds": 10,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 60,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "SHARD"
   },
   {
     "name": "ArtifactCleanup",
@@ -24,7 +26,8 @@
     "threadPoolIntervalInSeconds": 300,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 7200,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "EventDelivery",
@@ -33,7 +36,8 @@
     "threadPoolIntervalInSeconds": 60,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 5,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "InstanceSync",
@@ -42,7 +46,8 @@
     "threadPoolIntervalInSeconds": 30,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 600,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "LicenseExpiryCheck",
@@ -51,7 +56,8 @@
     "threadPoolIntervalInSeconds": 30,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 3600,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "ApprovalPolling",
@@ -60,7 +66,8 @@
     "threadPoolIntervalInSeconds": 10,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 60,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "GCPBilling",
@@ -69,7 +76,8 @@
     "threadPoolIntervalInSeconds": 1800,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 3600,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "SegmentGroupEventJob",
@@ -78,7 +86,8 @@
     "threadPoolIntervalInSeconds": 1800,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 86400,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "BarrierInstanceMonitor",
@@ -87,7 +96,8 @@
     "threadPoolIntervalInSeconds": 60,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 60,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "EntityAuditRecordProcessor",
@@ -96,7 +106,8 @@
     "threadPoolIntervalInSeconds": 30,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 1800,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "UsageMetricsHandler",
@@ -105,7 +116,8 @@
     "threadPoolIntervalInSeconds": 30,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 86400,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "ResourceConstraint-Backup",
@@ -114,7 +126,8 @@
     "threadPoolIntervalInSeconds": 60,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 30,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "WorkflowExecutionMonitor",
@@ -123,7 +136,8 @@
     "threadPoolIntervalInSeconds": 10,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 60,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "SettingAttributeValidateConnectivity",
@@ -132,7 +146,8 @@
     "threadPoolIntervalInSeconds": 600,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 10800,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "VaultSecretManagerRenewalHandler",
@@ -141,7 +156,8 @@
     "threadPoolIntervalInSeconds": 5,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 31,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "SettingAttributesSecretsMigrationHandler",
@@ -150,7 +166,8 @@
     "threadPoolIntervalInSeconds": 30,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 1800,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "GitSyncEntityExpiryCheck",
@@ -159,7 +176,8 @@
     "threadPoolIntervalInSeconds": 600,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 43200,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "ExportExecutionsRequestHandler",
@@ -168,7 +186,8 @@
     "threadPoolIntervalInSeconds": 60,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 1800,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "ExportExecutionsRequestCleanupHandler",
@@ -177,7 +196,8 @@
     "threadPoolIntervalInSeconds": 3600,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 2700,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "DeploymentFreezeActivities",
@@ -186,7 +206,8 @@
     "threadPoolIntervalInSeconds": 0,
     "nextIterationMode": "THROTTLE",
     "targetIntervalInSeconds": 0,
-    "throttleIntervalInSeconds": 45
+    "throttleIntervalInSeconds": 45,
+    "iteratorMode": "LOOP"
   },
   {
     "name": "DeploymentFreezeDeactivation",
@@ -195,7 +216,8 @@
     "threadPoolIntervalInSeconds": 0,
     "nextIterationMode": "THROTTLE",
     "targetIntervalInSeconds": 0,
-    "throttleIntervalInSeconds": 45
+    "throttleIntervalInSeconds": 45,
+    "iteratorMode": "LOOP"
   },
   {
     "name": "CeLicenceExpiryProcessor",
@@ -204,7 +226,8 @@
     "threadPoolIntervalInSeconds": 86400,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 86400,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "DeleteAccountIterator",
@@ -213,7 +236,8 @@
     "threadPoolIntervalInSeconds": 60,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 18000,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "DeletedEntityIterator",
@@ -222,7 +246,8 @@
     "threadPoolIntervalInSeconds": 60,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 43200,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "ResourceLookupTagLinkSync",
@@ -231,7 +256,8 @@
     "threadPoolIntervalInSeconds": 43200,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 43200,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "AccessRequestHandler",
@@ -240,7 +266,8 @@
     "threadPoolIntervalInSeconds": 5,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 15,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "ScheduledTrigger",
@@ -249,7 +276,8 @@
     "threadPoolIntervalInSeconds": 0,
     "nextIterationMode": "THROTTLE",
     "targetIntervalInSeconds": 0,
-    "throttleIntervalInSeconds": 45
+    "throttleIntervalInSeconds": 45,
+    "iteratorMode": "LOOP"
   },
   {
     "name": "LdapGroupScheduled",
@@ -258,7 +286,8 @@
     "threadPoolIntervalInSeconds": 0,
     "nextIterationMode": "THROTTLE",
     "targetIntervalInSeconds": 0,
-    "throttleIntervalInSeconds": 45
+    "throttleIntervalInSeconds": 45,
+    "iteratorMode": "LOOP"
   },
   {
     "name": "EncryptedDataLocalToGcpKmsMigrationHandler",
@@ -267,7 +296,8 @@
     "threadPoolIntervalInSeconds": 30,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 72000,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "TimeoutEngine",
@@ -276,7 +306,8 @@
     "threadPoolIntervalInSeconds": 10,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 10,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "GitSyncPollingIterator",
@@ -285,7 +316,8 @@
     "threadPoolIntervalInSeconds": 60,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 300,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "PerpetualTaskAssignment",
@@ -294,7 +326,8 @@
     "threadPoolIntervalInSeconds": 60,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 60,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "DelegateDisconnectDetector",
@@ -303,7 +336,8 @@
     "threadPoolIntervalInSeconds": 60,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 60,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "DelegateTaskFail",
@@ -312,7 +346,8 @@
     "threadPoolIntervalInSeconds": 30,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 30,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   },
   {
     "name": "DelegateTelemetryPublisherIteration",
@@ -321,6 +356,7 @@
     "threadPoolIntervalInSeconds": 600,
     "nextIterationMode": "TARGET",
     "targetIntervalInSeconds": 86400,
-    "throttleIntervalInSeconds": 0
+    "throttleIntervalInSeconds": 0,
+    "iteratorMode": "PUMP"
   }
 ]

--- a/400-rest/src/main/java/io/harness/workers/background/critical/iterator/ArtifactCollectionHandler.java
+++ b/400-rest/src/main/java/io/harness/workers/background/critical/iterator/ArtifactCollectionHandler.java
@@ -56,6 +56,7 @@ import lombok.extern.slf4j.Slf4j;
 @TargetModule(HarnessModule._815_CG_TRIGGERS)
 public class ArtifactCollectionHandler extends IteratorPumpModeHandler implements Handler<ArtifactStream> {
   public static final String GROUP = "ARTIFACT_STREAM_CRON_GROUP";
+  private static final int ACCEPTABLE_NO_ALERT_DELAY = 30;
 
   @Inject private AccountService accountService;
   @Inject private PersistenceIteratorFactory persistenceIteratorFactory;
@@ -74,10 +75,28 @@ public class ArtifactCollectionHandler extends IteratorPumpModeHandler implement
                            .clazz(ArtifactStream.class)
                            .fieldName(ArtifactStreamKeys.nextIteration)
                            .targetInterval(targetInterval)
-                           .acceptableNoAlertDelay(ofSeconds(30))
+                           .acceptableNoAlertDelay(ofSeconds(ACCEPTABLE_NO_ALERT_DELAY))
                            .handler(this)
                            .entityProcessController(new AccountStatusBasedEntityProcessController<>(accountService))
                            .schedulingType(REGULAR)
+                           .persistenceProvider(persistenceProvider)
+                           .filterExpander(
+                               query -> query.field(ArtifactStreamKeys.collectionEnabled).in(Arrays.asList(true, null)))
+                           .redistribute(true));
+  }
+
+  @Override
+  public void createAndStartShardIterator(
+      PersistenceIteratorFactory.ShardExecutorOptions executorOptions, Duration targetInterval) {
+    iterator = (MongoPersistenceIterator<ArtifactStream, MorphiaFilterExpander<ArtifactStream>>)
+                   persistenceIteratorFactory.createShardIteratorWithDedicatedThreadPool(executorOptions,
+                       ArtifactCollectionHandler.class,
+                       MongoPersistenceIterator.<ArtifactStream, MorphiaFilterExpander<ArtifactStream>>builder()
+                           .clazz(ArtifactStream.class)
+                           .targetInterval(targetInterval)
+                           .acceptableNoAlertDelay(ofSeconds(ACCEPTABLE_NO_ALERT_DELAY))
+                           .handler(this)
+                           .entityProcessController(new AccountStatusBasedEntityProcessController<>(accountService))
                            .persistenceProvider(persistenceProvider)
                            .filterExpander(
                                query -> query.field(ArtifactStreamKeys.collectionEnabled).in(Arrays.asList(true, null)))

--- a/400-rest/src/main/java/software/wings/app/MainConfiguration.java
+++ b/400-rest/src/main/java/software/wings/app/MainConfiguration.java
@@ -132,6 +132,8 @@ public class MainConfiguration extends Configuration implements AssetsBundleConf
   @JsonProperty("disableResourceValidation") private boolean disableResourceValidation;
   @JsonProperty("enableIterators") private boolean enableIterators;
   @JsonProperty("iteratorConfigPath") private String iteratorConfigPath;
+  @JsonProperty("replicaCount") private int replicaCount;
+  @JsonProperty("containerName") private String containerName;
   @JsonProperty(defaultValue = "true") private boolean enableAuth = true;
   @JsonProperty(defaultValue = "50") private int jenkinsBuildQuerySize = 50;
   @JsonProperty("iteratorsConfig") private IteratorsConfig iteratorsConfig;

--- a/959-ng-persistence/src/main/java/io/harness/mongo/iterator/provider/SpringPersistenceProvider.java
+++ b/959-ng-persistence/src/main/java/io/harness/mongo/iterator/provider/SpringPersistenceProvider.java
@@ -21,6 +21,7 @@ import com.mongodb.BasicDBObject;
 import java.time.Duration;
 import java.util.List;
 import org.mongodb.morphia.query.FilterOperator;
+import org.mongodb.morphia.query.MorphiaIterator;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
@@ -105,5 +106,21 @@ public class SpringPersistenceProvider<T extends PersistentIterable>
     Update updateEmpty = new Update();
     updateEmpty.unset(fieldName);
     persistence.updateFirst(new Query(Criteria.where(fieldName).size(0)), updateEmpty, clazz);
+  }
+
+  @Override
+  public long getDocumentsCount(Class<T> clazz) {
+    return 0;
+  }
+
+  @Override
+  public T getOneDocumentBySkip(Class<T> clazz, SpringFilterExpander filterExpander, int limit) {
+    return null;
+  }
+
+  @Override
+  public MorphiaIterator<T, T> getDocumentsGreaterThanID(
+      Class<T> clazz, SpringFilterExpander filterExpander, String id, int limit) {
+    return null;
   }
 }

--- a/959-ng-persistence/src/main/java/io/harness/mongo/iterator/provider/SpringPersistenceRequiredProvider.java
+++ b/959-ng-persistence/src/main/java/io/harness/mongo/iterator/provider/SpringPersistenceRequiredProvider.java
@@ -21,6 +21,7 @@ import com.mongodb.BasicDBObject;
 import java.time.Duration;
 import java.util.List;
 import org.mongodb.morphia.query.FilterOperator;
+import org.mongodb.morphia.query.MorphiaIterator;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
@@ -103,5 +104,21 @@ public class SpringPersistenceRequiredProvider<T extends PersistentIterable>
     Update updateEmpty = new Update();
     updateEmpty.unset(fieldName);
     persistence.updateFirst(new Query(Criteria.where(fieldName).size(0)), updateEmpty, clazz);
+  }
+
+  @Override
+  public long getDocumentsCount(Class<T> clazz) {
+    return 0;
+  }
+
+  @Override
+  public T getOneDocumentBySkip(Class<T> clazz, SpringFilterExpander filterExpander, int skip) {
+    return null;
+  }
+
+  @Override
+  public MorphiaIterator<T, T> getDocumentsGreaterThanID(
+      Class<T> clazz, SpringFilterExpander filterExpander, String id, int limit) {
+    return null;
   }
 }

--- a/960-persistence/src/main/java/io/harness/iterator/IteratorBaseHandler.java
+++ b/960-persistence/src/main/java/io/harness/iterator/IteratorBaseHandler.java
@@ -45,4 +45,15 @@ public abstract class IteratorBaseHandler<T extends PersistentIterable, F extend
    */
   protected abstract void createAndStartIterator(
       PersistenceIteratorFactory.PumpExecutorOptions executorOptions, Duration targetInterval);
+
+  /**
+   * This method is to create and start Shard mode iterator.
+   * @param executorOptions provides the executor thread-pool options
+   *                        needed for shard mode.
+   * @param targetInterval the targetInterval for iteration
+   */
+  protected void createAndStartShardIterator(
+      PersistenceIteratorFactory.ShardExecutorOptions executorOptions, Duration targetInterval) {
+    log.warn("createAndStartShardIterator should be overridden by the child class");
+  }
 }

--- a/960-persistence/src/main/java/io/harness/iterator/IteratorExecutionHandler.java
+++ b/960-persistence/src/main/java/io/harness/iterator/IteratorExecutionHandler.java
@@ -26,6 +26,7 @@ public interface IteratorExecutionHandler {
     String nextIterationMode;
     int targetIntervalInSeconds;
     int throttleIntervalInSeconds;
+    String iteratorMode;
   }
 
   /**

--- a/960-persistence/src/main/java/io/harness/iterator/PersistenceIterator.java
+++ b/960-persistence/src/main/java/io/harness/iterator/PersistenceIterator.java
@@ -13,7 +13,7 @@ import io.harness.annotations.dev.OwnedBy;
 
 @OwnedBy(PL)
 public interface PersistenceIterator<T extends PersistentIterable> {
-  enum ProcessMode { LOOP, PUMP }
+  enum ProcessMode { LOOP, PUMP, SHARD }
 
   void wakeup();
   void process();

--- a/960-persistence/src/main/java/io/harness/mongo/iterator/provider/MorphiaPersistenceProvider.java
+++ b/960-persistence/src/main/java/io/harness/mongo/iterator/provider/MorphiaPersistenceProvider.java
@@ -24,6 +24,8 @@ import java.time.Duration;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.mongodb.morphia.query.FilterOperator;
+import org.mongodb.morphia.query.FindOptions;
+import org.mongodb.morphia.query.MorphiaIterator;
 import org.mongodb.morphia.query.Query;
 import org.mongodb.morphia.query.Sort;
 import org.mongodb.morphia.query.UpdateOperations;
@@ -99,5 +101,32 @@ public class MorphiaPersistenceProvider<T extends PersistentIterable>
         persistence.createUpdateOperations(clazz).unset(fieldName));
     persistence.update(persistence.createQuery(clazz).field(fieldName).sizeEq(0),
         persistence.createUpdateOperations(clazz).unset(fieldName));
+  }
+
+  @Override
+  public long getDocumentsCount(Class<T> clazz) {
+    Query<T> query = persistence.createQuery(clazz);
+    return query.count();
+  }
+
+  private Query<T> createIdSortQuery(Class<T> clazz) {
+    Query<T> query = persistence.createQuery(clazz);
+    query.order(Sort.ascending("_id"));
+
+    return query;
+  }
+
+  @Override
+  public T getOneDocumentBySkip(Class<T> clazz, MorphiaFilterExpander<T> filterExpander, int skip) {
+    Query<T> query = createIdSortQuery(clazz);
+    return query.get(new FindOptions().skip(skip).limit(1));
+  }
+
+  @Override
+  public MorphiaIterator<T, T> getDocumentsGreaterThanID(
+      Class<T> clazz, MorphiaFilterExpander<T> filterExpander, String id, int limit) {
+    Query<T> query = createIdSortQuery(clazz);
+    query.criteria("_id").greaterThan(id);
+    return query.fetch(new FindOptions().limit(limit));
   }
 }

--- a/960-persistence/src/main/java/io/harness/mongo/iterator/provider/PersistenceProvider.java
+++ b/960-persistence/src/main/java/io/harness/mongo/iterator/provider/PersistenceProvider.java
@@ -14,6 +14,7 @@ import io.harness.mongo.iterator.filter.FilterExpander;
 
 import java.time.Duration;
 import java.util.List;
+import org.mongodb.morphia.query.MorphiaIterator;
 
 public interface PersistenceProvider<T extends PersistentIterable, F extends FilterExpander> {
   void updateEntityField(T entity, List<Long> nextIterations, Class<T> clazz, String fieldName);
@@ -21,4 +22,7 @@ public interface PersistenceProvider<T extends PersistentIterable, F extends Fil
       Duration targetInterval, F filterExpander, boolean unsorted);
   T findInstance(Class<T> clazz, String fieldName, F filterExpander);
   void recoverAfterPause(Class<T> clazz, String fieldName);
+  long getDocumentsCount(Class<T> clazz);
+  T getOneDocumentBySkip(Class<T> clazz, F filterExpander, int limit);
+  MorphiaIterator<T, T> getDocumentsGreaterThanID(Class<T> clazz, F filterExpander, String id, int limit);
 }

--- a/960-persistence/src/test/java/io/harness/iterator/IteratorExecutionHandlerImplTest.java
+++ b/960-persistence/src/test/java/io/harness/iterator/IteratorExecutionHandlerImplTest.java
@@ -42,6 +42,7 @@ public class IteratorExecutionHandlerImplTest extends CategoryTest {
                                         .threadPoolIntervalInSeconds(10)
                                         .nextIterationMode("TARGET")
                                         .targetIntervalInSeconds(10)
+                                        .iteratorMode("PUMP")
                                         .build(),
           IteratorExecutionHandler.DynamicIteratorConfig.builder()
               .name("ArtifactCollection")
@@ -50,12 +51,13 @@ public class IteratorExecutionHandlerImplTest extends CategoryTest {
               .threadPoolIntervalInSeconds(60)
               .nextIterationMode("THROTTLE")
               .throttleIntervalInSeconds(10)
+              .iteratorMode("LOOP")
               .build()));
   private IteratorExecutionHandlerImpl iteratorExecutionHandler;
 
   @Before
   public void setup() throws IOException {
-    iteratorExecutionHandler = new IteratorExecutionHandlerImpl(iteratorConfigPath, iteratorConfigFile);
+    iteratorExecutionHandler = new IteratorExecutionHandlerImpl(iteratorConfigPath, iteratorConfigFile, -1, -1);
   }
 
   @Test


### PR DESCRIPTION
## Describe your changes

This PR implements a new mode of the mongo iterator framework to enable sharing. With this feature we can shard the mongo documents across multiple `manager-iterator` pods.  The brief description of this functionality is described below -

1. `manager-iterators` will be deployed as a `statefulSet` instead of `deployment` K8s kind. In a `statefulSet` K8s will append an integer ordinal index value at the end of the pod name which can be used as the pod's shardId. And the replica count is read through an environment variable. Note - this will not support auto-scaling option. The current assumption is the pods will be restarted if there is a change in replicas.
2. The new iterator mode called `Shard` mode will not use the `nextIteration` field and thus won't be doing a `findAndModify` query. Instead it will shard the total number of documents in a collection based on the given replica count and iterator from the start to end document within that shard using only the `find` query. It will fetch multiple documents in each `find` query based on the number of available worker threads that can process the documents. It will function based on the given `threadPoolInterval` similar to the other iterator modes.

This PR has been tested in the Pre-QA Env covering the below test scenarios -

1. Shard Mode iterator starting.
2. Fetching of batch docs from Mongo.
3. All the docs / records in ArtifactStream collection have been processed or not by checking the value of the nextIteration field.

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/41341)
<!-- Reviewable:end -->
