### PR TITLE
fix: [PL-30389]: Mask multiline json secret saved as inline secret

### DIFF
--- a/950-log-client/src/main/java/io/harness/logstreaming/LogStreamingSanitizer.java
+++ b/950-log-client/src/main/java/io/harness/logstreaming/LogStreamingSanitizer.java
@@ -57,9 +57,20 @@ public class LogStreamingSanitizer {
     return secrets.stream()
         .flatMap(secret -> {
           String[] split = secret.split("\\r?\\n");
-          return Arrays.stream(split).filter(EmptyPredicate::isNotEmpty);
+          return Arrays.stream(split).map(LogStreamingSanitizer::cleanup).filter(EmptyPredicate::isNotEmpty);
         })
         .collect(Collectors.toSet());
+  }
+
+  public static String cleanup(String secretLine) {
+    if (secretLine == null) {
+      return null;
+    }
+    String line = secretLine.trim();
+    if (line.length() < 3) {
+      return null;
+    }
+    return line;
   }
 
   private void addSecretMasksWithQuotesRemoved(


### PR DESCRIPTION
## Describe your changes
If a multiline json string is save as inline secret and is printed in shell step using echo then the secret was getting printed with being masked. This PR inherits the logic CG and used in NG log sanitiser to handle this scenario as well.
## Checklist
- [x] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/41675)
<!-- Reviewable:end -->
