### PR TITLE
[feat]:[pie-7121]: remove mandatory validations on name and identifier for import flow

### DIFF
--- a/pipeline-service/contracts/src/main/java/io/harness/pms/pipeline/PipelineResource.java
+++ b/pipeline-service/contracts/src/main/java/io/harness/pms/pipeline/PipelineResource.java
@@ -395,7 +395,7 @@ public interface PipelineResource {
           PipelineResourceConstants.GET_METADATA_ONLY_PARAM_KEY) Boolean getMetadataOnly);
 
   @POST
-  @Path("/import/{pipelineIdentifier}")
+  @Path("/import/{pipelineIdentifier: .*}")
   @Hidden
   @ApiOperation(value = "Get Pipeline YAML from Git Repository", nickname = "importPipeline")
   @Operation(operationId = "importPipeline", summary = "Get Pipeline YAML from Git Repository",

--- a/pipeline-service/service/src/main/java/io/harness/pms/pipeline/service/PMSPipelineServiceHelper.java
+++ b/pipeline-service/service/src/main/java/io/harness/pms/pipeline/service/PMSPipelineServiceHelper.java
@@ -223,12 +223,13 @@ public class PMSPipelineServiceHelper {
     Map<String, String> changedFields = new HashMap<>();
 
     String identifierFromGit = pipelineInnerField.getNode().getIdentifier();
-    if (!pipelineIdentifier.equals(identifierFromGit)) {
+    if (isNotEmpty(pipelineIdentifier) && !pipelineIdentifier.equals(identifierFromGit)) {
       changedFields.put(YAMLMetadataFieldNameConstants.IDENTIFIER, identifierFromGit);
     }
 
     String nameFromGit = pipelineInnerField.getNode().getName();
-    if (!pipelineImportRequest.getPipelineName().equals(nameFromGit)) {
+    if (isNotEmpty(pipelineImportRequest.getPipelineName())
+        && !pipelineImportRequest.getPipelineName().equals(nameFromGit)) {
       changedFields.put(YAMLMetadataFieldNameConstants.NAME, nameFromGit);
     }
 

--- a/pipeline-service/service/src/test/java/io/harness/pms/pipeline/service/PMSPipelineServiceHelperTest.java
+++ b/pipeline-service/service/src/test/java/io/harness/pms/pipeline/service/PMSPipelineServiceHelperTest.java
@@ -404,6 +404,52 @@ public class PMSPipelineServiceHelperTest extends PipelineServiceTestBase {
   @Test
   @Owner(developers = ADITHYA)
   @Category(UnitTests.class)
+  public void testImportPipelineWithoutNameAndIdentifierValidationChecks() {
+    String importedPipeline = "pipeline:\n"
+        + "  name: abcPipelineImport\n"
+        + "  identifier: abcPipelineImport\n"
+        + "  projectIdentifier: GitX_Remote\n"
+        + "  orgIdentifier: default\n"
+        + "  tags: {}\n"
+        + "  stages:\n"
+        + "    - stage:\n"
+        + "        name: zd\n"
+        + "        identifier: zd\n"
+        + "        description: \"\"\n"
+        + "        type: Approval\n"
+        + "        spec:\n"
+        + "          execution:\n"
+        + "            steps:\n"
+        + "              - step:\n"
+        + "                  name: dsf\n"
+        + "                  identifier: dsf\n"
+        + "                  type: HarnessApproval\n"
+        + "                  timeout: 1d\n"
+        + "                  spec:\n"
+        + "                    approvalMessage: |-\n"
+        + "                      Please review the following information\n"
+        + "                      and approve the pipeline progression\n"
+        + "                    includePipelineExecutionHistory: true\n"
+        + "                    approvers:\n"
+        + "                      minimumCount: 1\n"
+        + "                      disallowPipelineExecutor: false\n"
+        + "                      userGroups: <+input>\n"
+        + "                    approverInputs: []\n"
+        + "        tags: {}";
+    String orgIdentifier = "default";
+    String projectIdentifier = "GitX_Remote";
+    String pipelineIdentifier = "";
+    PipelineImportRequestDTO pipelineImportRequest =
+        PipelineImportRequestDTO.builder().pipelineDescription("junk pipeline description").build();
+    Assertions.assertDoesNotThrow(
+        ()
+            -> PMSPipelineServiceHelper.checkAndThrowMismatchInImportedPipelineMetadataInternal(
+                orgIdentifier, projectIdentifier, pipelineIdentifier, pipelineImportRequest, importedPipeline));
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
   public void testResolveTemplatesAndValidatePipeline() {
     String yaml = "yaml";
     PipelineEntity pipelineEntity = PipelineEntity.builder()


### PR DESCRIPTION
## Describe your changes
Removed mandatory validations on name and identifier for import flow, the validations are done if only the fields are passed.

Impact -> Easier to onboard remote pipelines to harness

Tested out the following cases from postman as the UI support isnt there:
1. without passing name and identifier -> successful 
2. passing only name and no identifier -> successful
3. passing only identifier and no name -> successful
4. passing both name and identifier -> successful
5. passing incorrect name and identifier -> unsuccessful [expected]

ReleaseNotes summary needed? No

Is it new task type? No
Did you make changes to the code in a backward-compatible manner? Yes
Did you add a new class which is added in kryo serialization? - No
Will the new version of the delegate receive old version task and process? Yes
If new version of the pipeline-service receives response for the old task will it be able to handle it successfully? Yes
Did you make a change in delegate task which will be created in pipeline-services via grpc call to manager? No change
If the older version of pipeline-service creates the task parameter and calls newer cg manager, will it be okay? Yes
if the newer version of pipeline-service creates the task parameter and calls older cg manager, will it be okay? Yes
Did you remove an enum → No
Did you add an enum(That too at end of list) → No
FeatureFlag Added/Removed -> No
Verify Changes with affects any -> No

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/41787)
<!-- Reviewable:end -->
