### PR TITLE
fix: [CDS-48904]: Removed the NPE when manifest files are empty.

### DIFF
--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/k8s/K8sTaskHelperBase.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/k8s/K8sTaskHelperBase.java
@@ -3113,8 +3113,12 @@ public class K8sTaskHelperBase {
         }
 
         createDirectoryIfDoesNotExist(parent.toString());
-        FileIo.writeUtf8StringToFile(filePath.toString(), manifestFile.getFileContent());
-        executionLogCallback.saveExecutionLog(color(format("- %s", manifestFile.getFilePath()), LogColor.White));
+        if (isNotEmpty(manifestFile.getFileContent())) {
+          FileIo.writeUtf8StringToFile(filePath.toString(), manifestFile.getFileContent());
+          executionLogCallback.saveExecutionLog(color(format("- %s", manifestFile.getFilePath()), LogColor.White));
+        } else {
+          executionLogCallback.saveExecutionLog(color(format("- %s is empty", manifestFile.getFilePath()), Yellow));
+        }
       }
       executionLogCallback.saveExecutionLog("Done.", INFO, SUCCESS);
       return true;

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/k8s/K8sTaskHelperBaseTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/k8s/K8sTaskHelperBaseTest.java
@@ -2811,18 +2811,19 @@ public class K8sTaskHelperBaseTest extends CategoryTest {
   public void testFetchManifestFilesAndWriteToDirectoryLocalStoreWithEmptyManifestFiles() throws Exception {
     K8sTaskHelperBase spyHelperBase = spy(k8sTaskHelperBase);
     LocalFileStoreDelegateConfig localFileStoreDelegateConfig =
-            LocalFileStoreDelegateConfig.builder()
-                    .filePaths(asList("path/to/k8s/template/deploy.yaml"))
-                    .manifestIdentifier("identifier")
-                    .manifestType("K8sManifest")
-                    .manifestFiles(getEmptyManifestFiles())
-                    .build();
+        LocalFileStoreDelegateConfig.builder()
+            .filePaths(asList("path/to/k8s/template/deploy.yaml"))
+            .manifestIdentifier("identifier")
+            .manifestType("K8sManifest")
+            .manifestFiles(getEmptyManifestFiles())
+            .build();
 
     K8sManifestDelegateConfig manifestDelegateConfig =
-            K8sManifestDelegateConfig.builder().storeDelegateConfig(localFileStoreDelegateConfig).build();
+        K8sManifestDelegateConfig.builder().storeDelegateConfig(localFileStoreDelegateConfig).build();
 
     assertThat(spyHelperBase.fetchManifestFilesAndWriteToDirectory(
-            manifestDelegateConfig, "manifest", executionLogCallback, 9000L, "accountId")).isEqualTo(true);
+                   manifestDelegateConfig, "manifest", executionLogCallback, 9000L, "accountId"))
+        .isEqualTo(true);
   }
 
   @Test
@@ -3594,9 +3595,9 @@ public class K8sTaskHelperBaseTest extends CategoryTest {
 
   private List<ManifestFiles> getEmptyManifestFiles() {
     return asList(ManifestFiles.builder()
-            .fileName("chart.yaml")
-            .filePath("path/to/helm/chart/chart.yaml")
-            .fileContent(null)
-            .build());
+                      .fileName("chart.yaml")
+                      .filePath("path/to/helm/chart/chart.yaml")
+                      .fileContent(null)
+                      .build());
   }
 }

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/k8s/K8sTaskHelperBaseTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/k8s/K8sTaskHelperBaseTest.java
@@ -2806,6 +2806,26 @@ public class K8sTaskHelperBaseTest extends CategoryTest {
   }
 
   @Test
+  @Owner(developers = PRATYUSH)
+  @Category(UnitTests.class)
+  public void testFetchManifestFilesAndWriteToDirectoryLocalStoreWithEmptyManifestFiles() throws Exception {
+    K8sTaskHelperBase spyHelperBase = spy(k8sTaskHelperBase);
+    LocalFileStoreDelegateConfig localFileStoreDelegateConfig =
+            LocalFileStoreDelegateConfig.builder()
+                    .filePaths(asList("path/to/k8s/template/deploy.yaml"))
+                    .manifestIdentifier("identifier")
+                    .manifestType("K8sManifest")
+                    .manifestFiles(getEmptyManifestFiles())
+                    .build();
+
+    K8sManifestDelegateConfig manifestDelegateConfig =
+            K8sManifestDelegateConfig.builder().storeDelegateConfig(localFileStoreDelegateConfig).build();
+
+    assertThat(spyHelperBase.fetchManifestFilesAndWriteToDirectory(
+            manifestDelegateConfig, "manifest", executionLogCallback, 9000L, "accountId")).isEqualTo(true);
+  }
+
+  @Test
   @Owner(developers = TMACARI)
   @Category(UnitTests.class)
   public void testFetchManifestFilesAndWriteToDirectoryOptimizedFileFetch() throws Exception {
@@ -3570,5 +3590,13 @@ public class K8sTaskHelperBaseTest extends CategoryTest {
                       .filePath("path/to/helm/chart/chart.yaml")
                       .fileContent("Test content")
                       .build());
+  }
+
+  private List<ManifestFiles> getEmptyManifestFiles() {
+    return asList(ManifestFiles.builder()
+            .fileName("chart.yaml")
+            .filePath("path/to/helm/chart/chart.yaml")
+            .fileContent(null)
+            .build());
   }
 }


### PR DESCRIPTION
## Describe your changes
Removed the NPE when manifest files are empty. Instead logging it and showing to the user.

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/42033)
<!-- Reviewable:end -->
