### PR TITLE
[fix]: [CDS-49108]: fixing condition where value string was empty

### DIFF
--- a/400-rest/src/main/java/software/wings/sm/states/collaboration/JiraCreateUpdate.java
+++ b/400-rest/src/main/java/software/wings/sm/states/collaboration/JiraCreateUpdate.java
@@ -629,8 +629,9 @@ public class JiraCreateUpdate extends State implements SweepingOutputStateMixin 
             -> Arrays.stream(jiraField.getAllowedValues().toArray())
                    .map(json -> (JSONObject) json)
                    .collect(toMap(ob
-                       -> ob.get(VALUE) != null ? ((String) ob.get(VALUE)).toLowerCase()
-                                                : ((String) ob.get("name")).toLowerCase(),
+                       -> (ob.get(VALUE) != null && !((String) ob.get(VALUE)).isEmpty())
+                           ? ((String) ob.get(VALUE)).toLowerCase()
+                           : ((String) ob.get("name")).toLowerCase(),
                        ob -> ob.get("id"), (id, duplicateId) -> {
                          throw new HarnessJiraException(
                              String.format(

--- a/400-rest/src/test/resources/mock_create_meta
+++ b/400-rest/src/test/resources/mock_create_meta
@@ -27,8 +27,8 @@
             "system" : "components"
           },
           "allowedValues" : [
-            {"id" : "multiselect_id_1", "name" : "MultiselectName1"},
-            {"id" : "multiselect_id_2", "name" : "MultiselectName2"}
+            {"id" : "multiselect_id_1", "name" : "MultiselectName1", "value": ""},
+            {"id" : "multiselect_id_2", "name" : "MultiselectName2", "value": ""}
           ],
           "custom" : "false"
         },

--- a/400-rest/src/test/resources/mock_create_meta
+++ b/400-rest/src/test/resources/mock_create_meta
@@ -27,7 +27,7 @@
             "system" : "components"
           },
           "allowedValues" : [
-            {"id" : "multiselect_id_1", "name" : "MultiselectName1", "value": ""},
+            {"id" : "multiselect_id_1", "name" : "MultiselectName1"},
             {"id" : "multiselect_id_2", "name" : "MultiselectName2"}
           ],
           "custom" : "false"

--- a/400-rest/src/test/resources/mock_create_meta
+++ b/400-rest/src/test/resources/mock_create_meta
@@ -28,7 +28,7 @@
           },
           "allowedValues" : [
             {"id" : "multiselect_id_1", "name" : "MultiselectName1", "value": ""},
-            {"id" : "multiselect_id_2", "name" : "MultiselectName2", "value": ""}
+            {"id" : "multiselect_id_2", "name" : "MultiselectName2"}
           ],
           "custom" : "false"
         },


### PR DESCRIPTION
## Describe your changes

For Jira connectors using new meta endpoint, and execution containing multi-select fields, allowedValues.value was containing an empty string, breaking the original implementation logic.
Now we check both for null equality and also empty string.


You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/42176)
<!-- Reviewable:end -->
