### PR TITLE
fix: [CDS-2970]: PRE-QA Fix for Double migration run and casting of s3URIList to deprecated BasicDBList

### DIFF
--- a/260-delegate/build.properties
+++ b/260-delegate/build.properties
@@ -1,3 +1,3 @@
 build.majorVersion=22
 build.minorVersion=09
-build.number=76800
+build.number=78100

--- a/260-delegate/build.properties
+++ b/260-delegate/build.properties
@@ -1,3 +1,3 @@
 build.majorVersion=22
 build.minorVersion=09
-build.number=78100
+build.number=76800

--- a/390-db-migration/src/main/java/io/harness/migrations/all/InitTerraformProvisionersSourceType.java
+++ b/390-db-migration/src/main/java/io/harness/migrations/all/InitTerraformProvisionersSourceType.java
@@ -31,7 +31,8 @@ public class InitTerraformProvisionersSourceType implements Migration {
   public void migrate() {
     log.info("InitTerraformProvisionersSourceType migration started");
     UpdateResults updateResults = persistence.update(persistence.createQuery(TerraformInfrastructureProvisioner.class)
-                                                         .filter(INFRASTRUCTURE_PROVISIONER_TYPE_KEY, "TERRAFORM"),
+                                                         .filter(INFRASTRUCTURE_PROVISIONER_TYPE_KEY, "TERRAFORM")
+                                                         .filter("sourceType", null),
         persistence.createUpdateOperations(TerraformInfrastructureProvisioner.class)
             .set("sourceType", TerraformSourceType.GIT));
     log.info("InitTerraformProvisionersSourceType migration finishes");

--- a/400-rest/src/main/java/software/wings/sm/states/provision/TerraformProvisionState.java
+++ b/400-rest/src/main/java/software/wings/sm/states/provision/TerraformProvisionState.java
@@ -1271,7 +1271,7 @@ public abstract class TerraformProvisionState extends State {
                   S3FileConfig.builder()
                       .awsConfigId(backendAwsConfigId)
                       .s3URI((String) fileMetadata.getMetadata().get(REMOTE_BE_CONFIG_S3_URI_KEY))
-                      .s3URIList((List<String>) fileMetadata.getMetadata().get(REMOTE_BE_CONFIG_S3_URI_LIST_KEY))
+                      .s3URIList(getS3URIList(fileMetadata, REMOTE_BE_CONFIG_S3_URI_LIST_KEY))
                       .build();
 
               AwsConfig awsConfig = (AwsConfig) getAwsConfigSettingAttribute(backendAwsConfigId).getValue();
@@ -1303,12 +1303,11 @@ public abstract class TerraformProvisionState extends State {
 
           String tfVarS3FileConfigId = (String) fileMetadata.getMetadata().get(TF_VAR_FILES_S3_CONFIG_ID_KEY);
           if (isNotEmpty(tfVarS3FileConfigId)) {
-            S3FileConfig s3FileConfig =
-                S3FileConfig.builder()
-                    .awsConfigId(tfVarS3FileConfigId)
-                    .s3URI((String) fileMetadata.getMetadata().get(TF_VAR_FILES_S3_URI_KEY))
-                    .s3URIList((List<String>) fileMetadata.getMetadata().get(TF_VAR_FILES_S3_URI_LIST_KEY))
-                    .build();
+            S3FileConfig s3FileConfig = S3FileConfig.builder()
+                                            .awsConfigId(tfVarS3FileConfigId)
+                                            .s3URI((String) fileMetadata.getMetadata().get(TF_VAR_FILES_S3_URI_KEY))
+                                            .s3URIList(getS3URIList(fileMetadata, TF_VAR_FILES_S3_URI_LIST_KEY))
+                                            .build();
 
             setTfVarS3FileConfig(s3FileConfig);
           }
@@ -1601,6 +1600,14 @@ public abstract class TerraformProvisionState extends State {
       return tfVarFiles;
     }
     return tfVarFiles.stream().map(context::renderExpression).collect(toList());
+  }
+
+  private ArrayList<String> getS3URIList(FileMetadata fileMetadata, String key) {
+    Object uriListObject = fileMetadata.getMetadata().get(key);
+    if (uriListObject != null) {
+      return new ArrayList<>((List<String>) fileMetadata.getMetadata().get(REMOTE_BE_CONFIG_S3_URI_LIST_KEY));
+    }
+    return null;
   }
 
   protected List<String> resolveTargets(List<String> targets, ExecutionContext context) {


### PR DESCRIPTION
## Describe your changes
With Terraform S3 Support for CG we introduced a class containing S3FileConfig, which had a field s3URIList, which was getting passed to the delegateTaskPackage as BasicDBList, which was deprecated from DelegateKryo due to security issue,

This is now fixed as we're resolving it to Java ArrayList and passed to delegate
## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/42189)
<!-- Reviewable:end -->
