### PR TITLE
[fix]: [PIE-7181]: Fix expressions with hyphen in key not working for execution-input

### DIFF
--- a/953-yaml-commons/src/main/java/io/harness/pms/merger/fqn/FQN.java
+++ b/953-yaml-commons/src/main/java/io/harness/pms/merger/fqn/FQN.java
@@ -93,7 +93,6 @@ public class FQN {
   // This method return the ExpressionFQN without ignoring the ignorableStringForQualifiedName. We need full path in a
   // step/stage/pipeline yaml as expression because we convert the user input yaml to map and use it for expression
   // evaluation.
-
   public String getExpressionFqnWithoutIgnoring() {
     return getExpressionFqnWithoutIgnoring(false);
   }

--- a/953-yaml-commons/src/main/java/io/harness/pms/merger/fqn/FQN.java
+++ b/953-yaml-commons/src/main/java/io/harness/pms/merger/fqn/FQN.java
@@ -93,16 +93,24 @@ public class FQN {
   // This method return the ExpressionFQN without ignoring the ignorableStringForQualifiedName. We need full path in a
   // step/stage/pipeline yaml as expression because we convert the user input yaml to map and use it for expression
   // evaluation.
+
   public String getExpressionFqnWithoutIgnoring() {
+    return getExpressionFqnWithoutIgnoring(false);
+  }
+
+  public String getExpressionFqnWithoutIgnoring(boolean surroundKeyInQuotesIfHyphenPresent) {
     StringBuilder res = new StringBuilder();
     for (int i = 0; i < fqnList.size(); i++) {
       FQNNode currNode = fqnList.get(i);
       if (currNode.getNodeType() == FQNNode.NodeType.KEY) {
-        res.append(currNode.getKey()).append('.');
+        res.append(surroundKeyInQuotesIfHyphenPresent(currNode.getKey(), surroundKeyInQuotesIfHyphenPresent))
+            .append('.');
       } else if (currNode.getNodeType() == FQNNode.NodeType.KEY_WITH_UUID) {
-        res.append(currNode.getUuidValue()).append('.');
+        res.append(surroundKeyInQuotesIfHyphenPresent(currNode.getUuidValue(), surroundKeyInQuotesIfHyphenPresent))
+            .append('.');
       } else if (currNode.getNodeType() == FQNNode.NodeType.UUID) {
-        res.append(currNode.getUuidValue()).append('.');
+        res.append(surroundKeyInQuotesIfHyphenPresent(currNode.getUuidValue(), surroundKeyInQuotesIfHyphenPresent))
+            .append('.');
         if (i < fqnList.size() - 1 && shouldSkipNextNode(currNode, fqnList.get(i + 1))) {
           i++;
         }
@@ -110,6 +118,15 @@ public class FQN {
     }
     String temp = res.toString();
     return temp.substring(0, temp.length() - 1);
+  }
+
+  // When hyphen is present in the key, the expression evaluation will not work normally. But if we surround the key
+  // with single-quotes, then expression evaluation starts working.
+  private String surroundKeyInQuotesIfHyphenPresent(String key, boolean flag) {
+    if (flag && key.contains("-")) {
+      return "'" + key + "'";
+    }
+    return key;
   }
 
   /**

--- a/953-yaml-commons/src/main/java/io/harness/pms/merger/helpers/RuntimeInputFormHelper.java
+++ b/953-yaml-commons/src/main/java/io/harness/pms/merger/helpers/RuntimeInputFormHelper.java
@@ -145,8 +145,10 @@ public class RuntimeInputFormHelper {
       String value = fullMap.get(key).toString().replace("\\\"", "").replace("\"", "");
       if (NGExpressionUtils.matchesExecutionInputPattern(value)) {
         templateMap.put(key, fullMap.get(key));
+        // Passing the flag true so that they key having Hyphen will be surrounded by '.
+        // Example: artifact.hello-world -> artifact.'hello-world'
         fullMap.put(key,
-            EXPR_START + NGExpressionUtils.EXPRESSION_INPUT_CONSTANT + "." + key.getExpressionFqnWithoutIgnoring()
+            EXPR_START + NGExpressionUtils.EXPRESSION_INPUT_CONSTANT + "." + key.getExpressionFqnWithoutIgnoring(true)
                 + EXPR_END_ESC);
       } else if (NGExpressionUtils.matchesUpdatedExecutionInputPattern(value)) {
         templateMap.put(key, fullMap.get(key));
@@ -169,7 +171,7 @@ public class RuntimeInputFormHelper {
         if (NGExpressionUtils.matchesExecutionInputPattern(value)) {
           templateMap.put(key, fullMap.get(key));
           fullMap.put(key,
-              EXPR_START + NGExpressionUtils.EXPRESSION_INPUT_CONSTANT + "." + key.getExpressionFqnWithoutIgnoring()
+              EXPR_START + NGExpressionUtils.EXPRESSION_INPUT_CONSTANT + "." + key.getExpressionFqnWithoutIgnoring(true)
                   + EXPR_END_ESC);
         } else if (NGExpressionUtils.matchesUpdatedExecutionInputPattern(value)) {
           templateMap.put(key, fullMap.get(key));

--- a/953-yaml-commons/src/test/java/io/harness/pms/merger/helpers/fqn/FQNTest.java
+++ b/953-yaml-commons/src/test/java/io/harness/pms/merger/helpers/fqn/FQNTest.java
@@ -56,5 +56,17 @@ public class FQNTest extends CategoryTest {
     fqn.setFqnList(Arrays.asList(FQNNode.builder().uuidValue("step").build(),
         FQNNode.builder().uuidValue("spec").nodeType(FQNNode.NodeType.UUID).build()));
     assertEquals(fqn.getExpressionFqnWithoutIgnoring(), "spec");
+
+    // Key having - in it. But flag is passed as false, so key hello-world will not be surrounded by '.
+    fqn.setFqnList(Arrays.asList(FQNNode.builder().uuidValue("step").nodeType(FQNNode.NodeType.KEY_WITH_UUID).build(),
+        FQNNode.builder().key("spec").nodeType(FQNNode.NodeType.KEY).build(),
+        FQNNode.builder().key("hello-world").nodeType(FQNNode.NodeType.KEY).build()));
+    assertEquals(fqn.getExpressionFqnWithoutIgnoring(false), "step.spec.hello-world");
+
+    // Key having - in it. And flag is passed as true, so key hello-world will be surrounded by '.
+    fqn.setFqnList(Arrays.asList(FQNNode.builder().uuidValue("step").nodeType(FQNNode.NodeType.KEY_WITH_UUID).build(),
+        FQNNode.builder().key("spec").nodeType(FQNNode.NodeType.KEY).build(),
+        FQNNode.builder().key("hello-world").nodeType(FQNNode.NodeType.KEY).build()));
+    assertEquals(fqn.getExpressionFqnWithoutIgnoring(true), "step.spec.'hello-world'");
   }
 }


### PR DESCRIPTION
## Describe your changes

Fixing expressions with hyphen in key not working in execution-time-input.

Example: artifact source with id hello-world made execution-time-input. Since the key has - in it, expression evaluation will not work.

What is the fix: Surround such keys with ' in the expression. <+...artifact.hello-world.tag> -> <+...artifact.'hello-world'.tag>

Impact: Execution-input expressions evaluation that has - inside any key.

Testing: Tested the execution-input with and without hyphen in the key.

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/42236)
<!-- Reviewable:end -->
