### PR TITLE
[fix]: [PIE-7623]: Fixing Pipeline status remains in waiting when execution-time-input is submitted for Verify step

### DIFF
--- a/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/interrupts/statusupdate/AsyncWaitingStatusUpdate.java
+++ b/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/interrupts/statusupdate/AsyncWaitingStatusUpdate.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.engine.interrupts.statusupdate;
+
+import static io.harness.annotations.dev.HarnessTeam.PIPELINE;
+import static io.harness.pms.contracts.execution.Status.RUNNING;
+
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.engine.executions.plan.PlanExecutionService;
+import io.harness.engine.observers.NodeStatusUpdateHandler;
+import io.harness.engine.observers.NodeUpdateInfo;
+
+import com.google.inject.Inject;
+
+@OwnedBy(PIPELINE)
+public class AsyncWaitingStatusUpdate implements NodeStatusUpdateHandler {
+  @Inject private PlanExecutionService planExecutionService;
+
+  @Override
+  public void handleNodeStatusUpdate(NodeUpdateInfo nodeStatusUpdateInfo) {
+    planExecutionService.updateStatus(nodeStatusUpdateInfo.getPlanExecutionId(), RUNNING);
+  }
+}

--- a/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/interrupts/statusupdate/NodeStatusUpdateHandlerFactory.java
+++ b/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/interrupts/statusupdate/NodeStatusUpdateHandlerFactory.java
@@ -28,6 +28,7 @@ public class NodeStatusUpdateHandlerFactory {
   @Inject TerminalStepStatusUpdate terminalStepStatusUpdate;
   @Inject AbortAndRunningStepStatusUpdate abortAndRunningStepStatusUpdate;
   @Inject WaitStepStatusUpdate waitStepStatusUpdate;
+  @Inject AsyncWaitingStatusUpdate asyncWaitingStatusUpdate;
 
   public NodeStatusUpdateHandler obtainStepStatusUpdate(NodeUpdateInfo nodeStatusUpdateInfo) {
     switch (nodeStatusUpdateInfo.getStatus()) {
@@ -45,6 +46,8 @@ public class NodeStatusUpdateHandlerFactory {
         return abortAndRunningStepStatusUpdate;
       case WAIT_STEP_RUNNING:
         return waitStepStatusUpdate;
+      case ASYNC_WAITING:
+        return asyncWaitingStatusUpdate;
       default:
         // Do not do this for other statuses as there multiple queries
         // Till Now only handling these will figure out a better way to do this

--- a/pipeline-service/modules/orchestration/src/test/java/io/harness/engine/interrupts/statusupdate/NodeStatusUpdateHandlerFactoryTest.java
+++ b/pipeline-service/modules/orchestration/src/test/java/io/harness/engine/interrupts/statusupdate/NodeStatusUpdateHandlerFactoryTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.engine.interrupts.statusupdate;
+
+import static io.harness.rule.OwnerRule.BRIJESH;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.harness.CategoryTest;
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.engine.observers.NodeUpdateInfo;
+import io.harness.execution.NodeExecution;
+import io.harness.pms.contracts.execution.Status;
+import io.harness.rule.Owner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@OwnedBy(HarnessTeam.PIPELINE)
+public class NodeStatusUpdateHandlerFactoryTest extends CategoryTest {
+  @Mock ApprovalStepStatusUpdate approvalStepStatusUpdate;
+  @Mock InterventionWaitStepStatusUpdate interventionWaitStepStatusUpdate;
+  @Mock PausedStepStatusUpdate pausedStepStatusUpdate;
+  @Mock InputWaitingStepStatusUpdate inputWaitingStepStatusUpdate;
+  @Mock ResumeStepStatusUpdate resumeStepStatusUpdate;
+  @Mock TerminalStepStatusUpdate terminalStepStatusUpdate;
+  @Mock AbortAndRunningStepStatusUpdate abortAndRunningStepStatusUpdate;
+  @Mock WaitStepStatusUpdate waitStepStatusUpdate;
+  @Mock AsyncWaitingStatusUpdate asyncWaitingStatusUpdate;
+  @InjectMocks NodeStatusUpdateHandlerFactory nodeStatusUpdateHandlerFactory;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  @Owner(developers = BRIJESH)
+  @Category(UnitTests.class)
+  public void testObtainStepStatusUpdate() {
+    assertThat(nodeStatusUpdateHandlerFactory.obtainStepStatusUpdate(
+                   NodeUpdateInfo.builder()
+                       .nodeExecution(NodeExecution.builder().status(Status.APPROVAL_WAITING).build())
+                       .build()))
+        .isEqualTo(approvalStepStatusUpdate);
+    assertThat(nodeStatusUpdateHandlerFactory.obtainStepStatusUpdate(
+                   NodeUpdateInfo.builder()
+                       .nodeExecution(NodeExecution.builder().status(Status.INTERVENTION_WAITING).build())
+                       .build()))
+        .isEqualTo(interventionWaitStepStatusUpdate);
+    assertThat(
+        nodeStatusUpdateHandlerFactory.obtainStepStatusUpdate(
+            NodeUpdateInfo.builder().nodeExecution(NodeExecution.builder().status(Status.PAUSED).build()).build()))
+        .isEqualTo(pausedStepStatusUpdate);
+    assertThat(nodeStatusUpdateHandlerFactory.obtainStepStatusUpdate(
+                   NodeUpdateInfo.builder()
+                       .nodeExecution(NodeExecution.builder().status(Status.INPUT_WAITING).build())
+                       .build()))
+        .isEqualTo(inputWaitingStepStatusUpdate);
+    assertThat(
+        nodeStatusUpdateHandlerFactory.obtainStepStatusUpdate(
+            NodeUpdateInfo.builder().nodeExecution(NodeExecution.builder().status(Status.QUEUED).build()).build()))
+        .isEqualTo(resumeStepStatusUpdate);
+    assertThat(
+        nodeStatusUpdateHandlerFactory.obtainStepStatusUpdate(
+            NodeUpdateInfo.builder().nodeExecution(NodeExecution.builder().status(Status.ABORTED).build()).build()))
+        .isEqualTo(abortAndRunningStepStatusUpdate);
+    assertThat(nodeStatusUpdateHandlerFactory.obtainStepStatusUpdate(
+                   NodeUpdateInfo.builder()
+                       .nodeExecution(NodeExecution.builder().status(Status.WAIT_STEP_RUNNING).build())
+                       .build()))
+        .isEqualTo(waitStepStatusUpdate);
+    assertThat(nodeStatusUpdateHandlerFactory.obtainStepStatusUpdate(
+                   NodeUpdateInfo.builder()
+                       .nodeExecution(NodeExecution.builder().status(Status.ASYNC_WAITING).build())
+                       .build()))
+        .isEqualTo(asyncWaitingStatusUpdate);
+
+    assertThat(
+        nodeStatusUpdateHandlerFactory.obtainStepStatusUpdate(
+            NodeUpdateInfo.builder().nodeExecution(NodeExecution.builder().status(Status.FAILED).build()).build()))
+        .isEqualTo(terminalStepStatusUpdate);
+    assertThat(
+        nodeStatusUpdateHandlerFactory.obtainStepStatusUpdate(
+            NodeUpdateInfo.builder().nodeExecution(NodeExecution.builder().status(Status.RUNNING).build()).build()))
+        .isNull();
+  }
+}


### PR DESCRIPTION
## Describe your changes

Fixing Pipeline status remains in waiting when execution-time-input is submitted for Verify step.
Cause: for verify step, the nodeExecution status is updated to asyncWaiting. And in NodeStatusUpdateObserver, there was no StatusUpdateHandler registered for asyncWaiting so PlanExecution status was not being updated.
Fix: Registered AsyncWaitingStatusUpdate for AsyncWaiting status to update the planExecution status.

Impact: NodeExecution status updates. 

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/42573)
<!-- Reviewable:end -->
