### PR TITLE
feat: [CDS-48893]: Added support for config file built in variable

### DIFF
--- a/120-ng-manager/src/main/java/io/harness/ng/NextGenApplication.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/NextGenApplication.java
@@ -7,6 +7,7 @@
 
 package io.harness.ng;
 
+import static io.harness.NGCommonEntityConstants.CONFIG_FILE_FUNCTOR;
 import static io.harness.accesscontrol.filter.NGScopeAccessCheckFilter.bypassInterMsvcRequests;
 import static io.harness.accesscontrol.filter.NGScopeAccessCheckFilter.bypassInternalApi;
 import static io.harness.accesscontrol.filter.NGScopeAccessCheckFilter.bypassPaths;
@@ -145,6 +146,7 @@ import io.harness.pms.contracts.plan.JsonExpansionInfo;
 import io.harness.pms.contracts.steps.StepCategory;
 import io.harness.pms.contracts.steps.StepType;
 import io.harness.pms.events.base.PipelineEventConsumerController;
+import io.harness.pms.expressions.functors.ConfigFileFunctor;
 import io.harness.pms.expressions.functors.ImagePullSecretFunctor;
 import io.harness.pms.expressions.functors.InstanceFunctor;
 import io.harness.pms.governance.EnvironmentExpansionHandler;
@@ -709,6 +711,7 @@ public class NextGenApplication extends Application<NextGenConfiguration> {
     sdkFunctorMap.put(
         TerraformHumanReadablePlanFunctor.TERRAFORM_HUMAN_READABLE_PLAN, TerraformHumanReadablePlanFunctor.class);
     sdkFunctorMap.put(InstanceFunctor.INSTANCE, InstanceFunctor.class);
+    sdkFunctorMap.put(CONFIG_FILE_FUNCTOR, ConfigFileFunctor.class);
     return sdkFunctorMap;
   }
 

--- a/120-ng-manager/src/main/java/io/harness/pms/expressions/functors/ConfigFileFunctor.java
+++ b/120-ng-manager/src/main/java/io/harness/pms/expressions/functors/ConfigFileFunctor.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.pms.expressions.functors;
+
+import static io.harness.NGCommonEntityConstants.CONFIG_FILE_FUNCTOR_BASE64_METHOD_NAME;
+import static io.harness.NGCommonEntityConstants.CONFIG_FILE_FUNCTOR_STRING_METHOD_NAME;
+import static io.harness.common.EntityTypeConstants.FILES;
+import static io.harness.common.EntityTypeConstants.SECRETS;
+
+import static java.lang.String.format;
+
+import io.harness.beans.FileReference;
+import io.harness.data.encoding.EncodingUtils;
+import io.harness.exception.InvalidArgumentsException;
+import io.harness.exception.InvalidRequestException;
+import io.harness.expression.ExpressionEvaluatorUtils;
+import io.harness.filestore.dto.node.FileNodeDTO;
+import io.harness.filestore.dto.node.FileStoreNodeDTO;
+import io.harness.filestore.service.FileStoreService;
+import io.harness.pms.contracts.ambiance.Ambiance;
+import io.harness.pms.execution.utils.AmbianceUtils;
+import io.harness.pms.sdk.core.execution.expression.SdkFunctor;
+
+import com.google.inject.Inject;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Optional;
+
+public class ConfigFileFunctor implements SdkFunctor {
+  private static final int MAX_CONFIG_FILE_SIZE = 4 * ExpressionEvaluatorUtils.EXPANSION_LIMIT;
+  @Inject private FileStoreService fileStoreService;
+
+  @Override
+  public Object get(Ambiance ambiance, String... args) {
+    if (args.length != 3) {
+      throw new InvalidArgumentsException(
+          format("Invalid number of config file functor arguments: %s", Arrays.asList(args)));
+    }
+    String refType = args[0];
+    String methodName = args[1];
+    String ref = args[2];
+
+    if (FILES.equals(refType)) {
+      return getFileContent(ambiance, methodName, ref);
+    } else if (SECRETS.equals(refType)) {
+      return getSecretFileContent(ambiance, methodName, ref);
+    } else {
+      throw new InvalidArgumentsException(format("Unsupported config file entity type: %s, ref: %s", refType, ref));
+    }
+  }
+
+  private String getFileContent(Ambiance ambiance, final String methodName, final String ref) {
+    if (CONFIG_FILE_FUNCTOR_STRING_METHOD_NAME.equals(methodName)) {
+      return getFileContentAsString(ambiance, ref);
+    } else if (CONFIG_FILE_FUNCTOR_BASE64_METHOD_NAME.equals(methodName)) {
+      return getFileContentAsBase64(ambiance, ref);
+    } else {
+      throw new InvalidArgumentsException(
+          format("Unsupported config file functor method: %s, ref: %s", methodName, ref));
+    }
+  }
+
+  private String getFileContentAsString(Ambiance ambiance, final String ref) {
+    return fetchFileContent(ambiance, ref);
+  }
+
+  private String getFileContentAsBase64(Ambiance ambiance, String ref) {
+    return EncodingUtils.encodeBase64(fetchFileContent(ambiance, ref));
+  }
+
+  private String fetchFileContent(Ambiance ambiance, final String ref) {
+    FileReference fileReference = FileReference.of(ref, AmbianceUtils.getAccountId(ambiance),
+        AmbianceUtils.getOrgIdentifier(ambiance), AmbianceUtils.getProjectIdentifier(ambiance));
+
+    Optional<FileStoreNodeDTO> file = fileStoreService.getWithChildrenByPath(fileReference.getAccountIdentifier(),
+        fileReference.getOrgIdentifier(), fileReference.getProjectIdentifier(), fileReference.getPath(), true);
+
+    if (file.isEmpty()) {
+      throw new InvalidRequestException(format("File not found in local file store, path [%s], scope: [%s]",
+          fileReference.getPath(), fileReference.getScope()));
+    }
+
+    FileStoreNodeDTO fileStoreNodeDTO = file.get();
+    if (!(fileStoreNodeDTO instanceof FileNodeDTO)) {
+      throw new InvalidRequestException(format(
+          "Config file cannot be folder, path [%s], scope: [%s]", fileReference.getPath(), fileReference.getScope()));
+    }
+
+    String content = ((FileNodeDTO) fileStoreNodeDTO).getContent();
+    if (content.getBytes(StandardCharsets.UTF_8).length > MAX_CONFIG_FILE_SIZE) {
+      throw new InvalidRequestException(format("Too large config file, ref: %s", ref));
+    }
+
+    return content;
+  }
+
+  private String getSecretFileContent(Ambiance ambiance, final String methodName, final String ref) {
+    if (CONFIG_FILE_FUNCTOR_STRING_METHOD_NAME.equals(methodName)) {
+      return getSecretFileContentAsString(ambiance, ref);
+    } else if (CONFIG_FILE_FUNCTOR_BASE64_METHOD_NAME.equals(methodName)) {
+      return getSecretFileContentAsBase64(ambiance, ref);
+    } else {
+      throw new InvalidArgumentsException(
+          format("Unsupported config secret file functor method: %s, ref: %s", methodName, ref));
+    }
+  }
+
+  private String getSecretFileContentAsString(Ambiance ambiance, final String ref) {
+    return "${ngSecretManager.obtainSecretFileAsString(\"" + ref + "\", " + ambiance.getExpressionFunctorToken() + ")}";
+  }
+
+  private String getSecretFileContentAsBase64(Ambiance ambiance, final String ref) {
+    return "${ngSecretManager.obtainSecretFileAsBase64(\"" + ref + "\", " + ambiance.getExpressionFunctorToken() + ")}";
+  }
+}

--- a/120-ng-manager/src/main/java/io/harness/pms/expressions/functors/ConfigFileFunctor.java
+++ b/120-ng-manager/src/main/java/io/harness/pms/expressions/functors/ConfigFileFunctor.java
@@ -33,17 +33,22 @@ import java.util.Optional;
 
 public class ConfigFileFunctor implements SdkFunctor {
   private static final int MAX_CONFIG_FILE_SIZE = 4 * ExpressionEvaluatorUtils.EXPANSION_LIMIT;
+  private static final int NUMBER_OF_EXPECTED_ARGUMENTS = 3;
+  private static final int REFERENCE_TYPE_ARGUMENT = 0;
+  private static final int METHOD_NAME_ARGUMENT = 1;
+  private static final int FILE_OR_SECRET_REF_ARGUMENT = 2;
+
   @Inject private FileStoreService fileStoreService;
 
   @Override
   public Object get(Ambiance ambiance, String... args) {
-    if (args.length != 3) {
+    if (args.length != NUMBER_OF_EXPECTED_ARGUMENTS) {
       throw new InvalidArgumentsException(
           format("Invalid number of config file functor arguments: %s", Arrays.asList(args)));
     }
-    String refType = args[0];
-    String methodName = args[1];
-    String ref = args[2];
+    String refType = args[REFERENCE_TYPE_ARGUMENT];
+    String methodName = args[METHOD_NAME_ARGUMENT];
+    String ref = args[FILE_OR_SECRET_REF_ARGUMENT];
 
     if (FILES.equals(refType)) {
       return getFileContent(ambiance, methodName, ref);

--- a/120-ng-manager/src/test/java/io/harness/pms/expressions/functors/ConfigFileFunctorTest.java
+++ b/120-ng-manager/src/test/java/io/harness/pms/expressions/functors/ConfigFileFunctorTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.pms.expressions.functors;
+
+import static io.harness.NGCommonEntityConstants.CONFIG_FILE_FUNCTOR_BASE64_METHOD_NAME;
+import static io.harness.NGCommonEntityConstants.CONFIG_FILE_FUNCTOR_STRING_METHOD_NAME;
+import static io.harness.rule.OwnerRule.IVAN;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.harness.CategoryTest;
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.common.EntityTypeConstants;
+import io.harness.exception.InvalidArgumentsException;
+import io.harness.filestore.dto.node.FileNodeDTO;
+import io.harness.filestore.service.FileStoreService;
+import io.harness.pms.contracts.ambiance.Ambiance;
+import io.harness.pms.plan.execution.SetupAbstractionKeys;
+import io.harness.rule.Owner;
+
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@OwnedBy(HarnessTeam.CDP)
+public class ConfigFileFunctorTest extends CategoryTest {
+  private static final String SECRET_REF = "secretRef";
+  private static final Long EXPRESSION_FUNCTOR_TOKEN = 1L;
+  private static final String FILE_REF_PATH = "/folder1/filename";
+  private static final String ACCOUNT_IDENTIFIER = "accountIdentifier";
+  private static final String ORG_IDENTIFIER = "orgIdentifier";
+  private static final String PROJECT_IDENTIFIER = "projectIdentifier";
+  private static final String FILENAME = "filename";
+  private static final String FILE_CONTENT = "file content";
+
+  @Mock private FileStoreService fileStoreService;
+
+  @InjectMocks private ConfigFileFunctor configFileFunctor;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  @Owner(developers = IVAN)
+  @Category(UnitTests.class)
+  public void testGetNotValidArgs() {
+    assertThatThrownBy(()
+                           -> configFileFunctor.get(Ambiance.newBuilder().build(), EntityTypeConstants.FILES,
+                               CONFIG_FILE_FUNCTOR_STRING_METHOD_NAME))
+        .isInstanceOf(InvalidArgumentsException.class)
+        .hasMessage("Invalid number of config file functor arguments: [Files, getAsString]");
+  }
+
+  @Test
+  @Owner(developers = IVAN)
+  @Category(UnitTests.class)
+  public void testGetNotValidEntityType() {
+    assertThatThrownBy(()
+                           -> configFileFunctor.get(Ambiance.newBuilder().build(), EntityTypeConstants.CV_CONFIG,
+                               CONFIG_FILE_FUNCTOR_STRING_METHOD_NAME, FILE_REF_PATH))
+        .isInstanceOf(InvalidArgumentsException.class)
+        .hasMessage("Unsupported config file entity type: CvConfig, ref: /folder1/filename");
+  }
+
+  @Test
+  @Owner(developers = IVAN)
+  @Category(UnitTests.class)
+  public void testGetNotValidSecretTypeFunctorMethod() {
+    assertThatThrownBy(()
+                           -> configFileFunctor.get(
+                               Ambiance.newBuilder().build(), EntityTypeConstants.SECRETS, "obtainSecret", SECRET_REF))
+        .isInstanceOf(InvalidArgumentsException.class)
+        .hasMessage("Unsupported config secret file functor method: obtainSecret, ref: secretRef");
+  }
+
+  @Test
+  @Owner(developers = IVAN)
+  @Category(UnitTests.class)
+  public void testGetNotValidFileTypeFunctorMethod() {
+    assertThatThrownBy(()
+                           -> configFileFunctor.get(
+                               Ambiance.newBuilder().build(), EntityTypeConstants.FILES, "obtainSecret", FILE_REF_PATH))
+        .isInstanceOf(InvalidArgumentsException.class)
+        .hasMessage("Unsupported config file functor method: obtainSecret, ref: /folder1/filename");
+  }
+
+  @Test
+  @Owner(developers = IVAN)
+  @Category(UnitTests.class)
+  public void testFileGetAsString() {
+    Ambiance ambiance = getAmbiance();
+    when(fileStoreService.getWithChildrenByPath(
+             ACCOUNT_IDENTIFIER, ORG_IDENTIFIER, PROJECT_IDENTIFIER, FILE_REF_PATH, true))
+        .thenReturn(Optional.of(getFileNodeDTO()));
+
+    String fileContent = (String) configFileFunctor.get(
+        ambiance, EntityTypeConstants.FILES, CONFIG_FILE_FUNCTOR_STRING_METHOD_NAME, FILE_REF_PATH);
+
+    assertThat(fileContent).isEqualTo(FILE_CONTENT);
+  }
+
+  @Test
+  @Owner(developers = IVAN)
+  @Category(UnitTests.class)
+  public void testFileGetAsBase64() {
+    when(fileStoreService.getWithChildrenByPath(
+             ACCOUNT_IDENTIFIER, ORG_IDENTIFIER, PROJECT_IDENTIFIER, FILE_REF_PATH, true))
+        .thenReturn(Optional.of(getFileNodeDTO()));
+
+    String base64FileContent = (String) configFileFunctor.get(
+        getAmbiance(), EntityTypeConstants.FILES, CONFIG_FILE_FUNCTOR_BASE64_METHOD_NAME, FILE_REF_PATH);
+
+    assertThat(base64FileContent).isEqualTo("ZmlsZSBjb250ZW50");
+  }
+
+  @Test
+  @Owner(developers = IVAN)
+  @Category(UnitTests.class)
+  public void testSecretFileGetAsString() {
+    Ambiance ambiance = mock(Ambiance.class);
+    when(ambiance.getExpressionFunctorToken()).thenReturn(EXPRESSION_FUNCTOR_TOKEN);
+
+    String secretExpression = (String) configFileFunctor.get(
+        ambiance, EntityTypeConstants.SECRETS, CONFIG_FILE_FUNCTOR_STRING_METHOD_NAME, SECRET_REF);
+
+    assertThat(secretExpression).isEqualTo("${ngSecretManager.obtainSecretFileAsString(\"secretRef\", 1)}");
+  }
+
+  @Test
+  @Owner(developers = IVAN)
+  @Category(UnitTests.class)
+  public void testSecretFileGetAsBase64() {
+    Ambiance ambiance = mock(Ambiance.class);
+    when(ambiance.getExpressionFunctorToken()).thenReturn(EXPRESSION_FUNCTOR_TOKEN);
+
+    String secretExpression = (String) configFileFunctor.get(
+        ambiance, EntityTypeConstants.SECRETS, CONFIG_FILE_FUNCTOR_BASE64_METHOD_NAME, SECRET_REF);
+
+    assertThat(secretExpression).isEqualTo("${ngSecretManager.obtainSecretFileAsBase64(\"secretRef\", 1)}");
+  }
+
+  private Ambiance getAmbiance() {
+    return Ambiance.newBuilder()
+        .putSetupAbstractions(SetupAbstractionKeys.accountId, ACCOUNT_IDENTIFIER)
+        .putSetupAbstractions(SetupAbstractionKeys.orgIdentifier, ORG_IDENTIFIER)
+        .putSetupAbstractions(SetupAbstractionKeys.projectIdentifier, PROJECT_IDENTIFIER)
+        .build();
+  }
+
+  private FileNodeDTO getFileNodeDTO() {
+    return FileNodeDTO.builder().name(FILENAME).path(FILE_REF_PATH).content(FILE_CONTENT).build();
+  }
+}

--- a/400-rest/src/main/java/software/wings/expression/NgSecretManagerFunctor.java
+++ b/400-rest/src/main/java/software/wings/expression/NgSecretManagerFunctor.java
@@ -64,6 +64,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @TargetModule(HarnessModule._950_NG_CORE)
 public class NgSecretManagerFunctor implements ExpressionFunctor, NgSecretManagerFunctorInterface {
+  private static final String MISSMATCHING_INTERNAL_FUNCTOR_ERROR_MSG = "Inappropriate usage of internal functor";
+
   int expressionFunctorToken;
   String accountId;
   String orgId;
@@ -85,7 +87,7 @@ public class NgSecretManagerFunctor implements ExpressionFunctor, NgSecretManage
   @Override
   public Object obtain(String secretIdentifier, int token) {
     if (token != expressionFunctorToken) {
-      throw new FunctorException("Inappropriate usage of internal functor");
+      throw new FunctorException(MISSMATCHING_INTERNAL_FUNCTOR_ERROR_MSG);
     }
     try {
       if (!evaluateSync) {
@@ -105,7 +107,7 @@ public class NgSecretManagerFunctor implements ExpressionFunctor, NgSecretManage
   @Override
   public Object obtainSecretFileAsString(String secretIdentifier, int token) {
     if (token != expressionFunctorToken) {
-      throw new FunctorException("Inappropriate usage of internal functor");
+      throw new FunctorException(MISSMATCHING_INTERNAL_FUNCTOR_ERROR_MSG);
     }
 
     if (evaluatedSecrets.containsKey(secretIdentifier)) {
@@ -123,7 +125,7 @@ public class NgSecretManagerFunctor implements ExpressionFunctor, NgSecretManage
   @Override
   public Object obtainSecretFileAsBase64(String secretIdentifier, int token) {
     if (token != expressionFunctorToken) {
-      throw new FunctorException("Inappropriate usage of internal functor");
+      throw new FunctorException(MISSMATCHING_INTERNAL_FUNCTOR_ERROR_MSG);
     }
 
     if (evaluatedSecrets.containsKey(secretIdentifier)) {
@@ -153,8 +155,9 @@ public class NgSecretManagerFunctor implements ExpressionFunctor, NgSecretManage
       return format("${ngSecretManager.%s(\"%s\", %s)}", method, secretIdentifier, expressionFunctorToken);
     } else if (mode == SecretManagerMode.CHECK_FOR_SECRETS) {
       return format("<<<%s>>>", secretIdentifier);
+    } else {
+      return value;
     }
-    return value;
   }
 
   private Object obtainInternal(String secretIdentifier, SecretVariableDTO.Type secretType) {

--- a/400-rest/src/test/java/software/wings/expression/NgSecretManagerFunctorTest.java
+++ b/400-rest/src/test/java/software/wings/expression/NgSecretManagerFunctorTest.java
@@ -9,6 +9,7 @@ package software.wings.expression;
 
 import static io.harness.annotations.dev.HarnessTeam.CDP;
 import static io.harness.rule.OwnerRule.ANSHUL;
+import static io.harness.rule.OwnerRule.IVAN;
 
 import static software.wings.utils.WingsTestConstants.ACCOUNT_ID;
 
@@ -201,12 +202,58 @@ public class NgSecretManagerFunctorTest extends WingsBaseTest {
     }
   }
 
+  @Test
+  @Owner(developers = IVAN)
+  @Category(UnitTests.class)
+  public void testObtainSecretFileAsString() {
+    final String secretIdentifier = "fileIdentifier";
+    int token = HashGenerator.generateIntegerHash();
+    NgSecretManagerFunctor ngSecretManagerFunctor = buildFunctor(token);
+    assertFunctor(ngSecretManagerFunctor);
+
+    List<EncryptedDataDetail> encryptedDataDetails = generateEncryptedDataDetails();
+    when(ngSecretService.getEncryptionDetails(any(BaseNGAccess.class), any(SecretVariableDTO.class)))
+        .thenReturn(encryptedDataDetails);
+
+    String decryptedValue = (String) ngSecretManagerFunctor.obtainSecretFileAsString(secretIdentifier, token);
+    assertThat(decryptedValue).isNotNull().startsWith("${secretDelegate.obtain(");
+    assertDelegateDecryptedSecretFile(secretIdentifier, ngSecretManagerFunctor, decryptedValue);
+    verify(ngSecretService, times(1)).getEncryptionDetails(any(BaseNGAccess.class), any(SecretVariableDTO.class));
+  }
+
+  @Test
+  @Owner(developers = IVAN)
+  @Category(UnitTests.class)
+  public void testObtainSecretFileAsBase64() {
+    final String secretIdentifier = "secretIdentifier";
+    int token = HashGenerator.generateIntegerHash();
+    NgSecretManagerFunctor ngSecretManagerFunctor = buildFunctor(token);
+    assertFunctor(ngSecretManagerFunctor);
+
+    List<EncryptedDataDetail> encryptedDataDetails = generateEncryptedDataDetails();
+    when(ngSecretService.getEncryptionDetails(any(BaseNGAccess.class), any(SecretVariableDTO.class)))
+        .thenReturn(encryptedDataDetails);
+
+    String decryptedValue = (String) ngSecretManagerFunctor.obtainSecretFileAsBase64(secretIdentifier, token);
+    assertThat(decryptedValue).isNotNull().startsWith("${secretDelegate.obtainBase64(");
+    assertDelegateDecryptedSecretFile(secretIdentifier, ngSecretManagerFunctor, decryptedValue);
+    verify(ngSecretService, times(1)).getEncryptionDetails(any(BaseNGAccess.class), any(SecretVariableDTO.class));
+  }
+
   private void assertDelegateDecryptedValue(
       String secretName, NgSecretManagerFunctor ngSecretManagerFunctor, String decryptedValue) {
     assertThat(decryptedValue).isNotNull().startsWith("${secretDelegate.obtain(");
     assertThat(decryptedValue).isNotNull().contains(String.valueOf(ngSecretManagerFunctor.getExpressionFunctorToken()));
     assertThat(ngSecretManagerFunctor.getEvaluatedDelegateSecrets()).isNotEmpty().containsKey(secretName);
     assertThat(ngSecretManagerFunctor.getEvaluatedDelegateSecrets().get(secretName)).isNotEmpty();
+    assertThat(ngSecretManagerFunctor.getEncryptionConfigs()).isNotEmpty();
+  }
+
+  private void assertDelegateDecryptedSecretFile(
+      String secretIdentifier, NgSecretManagerFunctor ngSecretManagerFunctor, String decryptedValue) {
+    assertThat(decryptedValue).isNotNull().contains(String.valueOf(ngSecretManagerFunctor.getExpressionFunctorToken()));
+    assertThat(ngSecretManagerFunctor.getEvaluatedDelegateSecrets()).isNotEmpty().containsKey(secretIdentifier);
+    assertThat(ngSecretManagerFunctor.getEvaluatedDelegateSecrets().get(secretIdentifier)).isNotEmpty();
     assertThat(ngSecretManagerFunctor.getEncryptionConfigs()).isNotEmpty();
   }
 }

--- a/877-filestore/src/main/java/io/harness/filestore/utils/FileStoreUtils.java
+++ b/877-filestore/src/main/java/io/harness/filestore/utils/FileStoreUtils.java
@@ -23,6 +23,8 @@ import lombok.experimental.UtilityClass;
 @OwnedBy(CDP)
 @UtilityClass
 public class FileStoreUtils {
+  public static final Pattern FILE_PATH_PATTERN = Pattern.compile("^(/)([^/\0]+(/)?)+$");
+
   public static boolean nameChanged(NGFile oldNGFile, FileDTO fileDto) {
     return !oldNGFile.getName().equals(fileDto.getName());
   }

--- a/877-filestore/src/main/java/io/harness/filestore/utils/FileStoreUtils.java
+++ b/877-filestore/src/main/java/io/harness/filestore/utils/FileStoreUtils.java
@@ -23,7 +23,7 @@ import lombok.experimental.UtilityClass;
 @OwnedBy(CDP)
 @UtilityClass
 public class FileStoreUtils {
-  public static final Pattern FILE_PATH_PATTERN = Pattern.compile("^(/)([^/\0]+(/)?)+$");
+  public static final Pattern FILE_PATH_PATTERN = Pattern.compile("^(/)([^/\0]+(/)?)++$");
 
   public static boolean nameChanged(NGFile oldNGFile, FileDTO fileDto) {
     return !oldNGFile.getName().equals(fileDto.getName());

--- a/877-filestore/src/main/java/io/harness/filestore/utils/FileStoreUtils.java
+++ b/877-filestore/src/main/java/io/harness/filestore/utils/FileStoreUtils.java
@@ -23,8 +23,6 @@ import lombok.experimental.UtilityClass;
 @OwnedBy(CDP)
 @UtilityClass
 public class FileStoreUtils {
-  public static final Pattern FILE_PATH_PATTERN = Pattern.compile("^(/)([^/\0]+(/)?)++$");
-
   public static boolean nameChanged(NGFile oldNGFile, FileDTO fileDto) {
     return !oldNGFile.getName().equals(fileDto.getName());
   }

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/expression/SecretDelegateFunctor.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/expression/SecretDelegateFunctor.java
@@ -7,6 +7,7 @@
 
 package io.harness.delegate.expression;
 
+import io.harness.data.encoding.EncodingUtils;
 import io.harness.exception.FunctorException;
 import io.harness.expression.functors.ExpressionFunctor;
 
@@ -31,5 +32,9 @@ public class SecretDelegateFunctor implements ExpressionFunctor {
     }
     log.error("Unable to find secret details for {} ", secretDetailsUuid);
     throw new FunctorException("Secret details not found");
+  }
+
+  public Object obtainBase64(String secretDetailsUuid, int token) {
+    return EncodingUtils.encodeBase64((String) obtain(secretDetailsUuid, token));
   }
 }

--- a/970-ng-commons/src/main/java/io/harness/NGCommonEntityConstants.java
+++ b/970-ng-commons/src/main/java/io/harness/NGCommonEntityConstants.java
@@ -170,4 +170,7 @@ public class NGCommonEntityConstants {
   public static final String HARNESS_IMAGE = "harnessImage";
   public static final String METHOD_NAME = "methodName";
   public static final String AGENT_KEY = "agentIdentifier";
+  public static final String CONFIG_FILE_FUNCTOR = "configFile";
+  public static final String CONFIG_FILE_FUNCTOR_STRING_METHOD_NAME = "getAsString";
+  public static final String CONFIG_FILE_FUNCTOR_BASE64_METHOD_NAME = "getAsBase64";
 }

--- a/980-commons/src/main/java/software/wings/expression/NgSecretManagerFunctorInterface.java
+++ b/980-commons/src/main/java/software/wings/expression/NgSecretManagerFunctorInterface.java
@@ -11,4 +11,6 @@ package software.wings.expression;
 public interface NgSecretManagerFunctorInterface {
   String FUNCTOR_NAME = "ngSecretManager";
   Object obtain(String secretIdentifier, int token);
+  Object obtainSecretFileAsString(String secretIdentifier, int token);
+  Object obtainSecretFileAsBase64(String secretIdentifier, int token);
 }

--- a/pipeline-service/service/src/main/java/io/harness/pms/expressions/PMSExpressionEvaluator.java
+++ b/pipeline-service/service/src/main/java/io/harness/pms/expressions/PMSExpressionEvaluator.java
@@ -7,6 +7,8 @@
 
 package io.harness.pms.expressions;
 
+import static io.harness.NGCommonEntityConstants.CONFIG_FILE_FUNCTOR;
+
 import io.harness.ModuleType;
 import io.harness.account.AccountClient;
 import io.harness.annotations.dev.HarnessTeam;
@@ -24,6 +26,7 @@ import io.harness.organization.remote.OrganizationClient;
 import io.harness.pms.contracts.ambiance.Ambiance;
 import io.harness.pms.contracts.expression.RemoteFunctorServiceGrpc.RemoteFunctorServiceBlockingStub;
 import io.harness.pms.expressions.functors.AccountFunctor;
+import io.harness.pms.expressions.functors.ConfigFileRemoteExpressionFunctor;
 import io.harness.pms.expressions.functors.ExecutionInputExpressionFunctor;
 import io.harness.pms.expressions.functors.OrgFunctor;
 import io.harness.pms.expressions.functors.PipelineExecutionFunctor;
@@ -85,12 +88,20 @@ public class PMSExpressionEvaluator extends AmbianceExpressionEvaluator {
 
     cacheValueMap.forEach((key, value) -> {
       for (String functorKey : CollectionUtils.emptyIfNull(value.getSdkFunctors())) {
-        addToContext(functorKey,
-            RemoteExpressionFunctor.builder()
-                .ambiance(ambiance)
-                .remoteFunctorServiceBlockingStub(remoteFunctorServiceBlockingStubMap.get(ModuleType.fromString(key)))
-                .functorKey(functorKey)
-                .build());
+        if (CONFIG_FILE_FUNCTOR.equals(functorKey)) {
+          addToContext(CONFIG_FILE_FUNCTOR,
+              ConfigFileRemoteExpressionFunctor.builder()
+                  .ambiance(ambiance)
+                  .remoteFunctorServiceBlockingStub(remoteFunctorServiceBlockingStubMap.get(ModuleType.fromString(key)))
+                  .build());
+        } else {
+          addToContext(functorKey,
+              RemoteExpressionFunctor.builder()
+                  .ambiance(ambiance)
+                  .remoteFunctorServiceBlockingStub(remoteFunctorServiceBlockingStubMap.get(ModuleType.fromString(key)))
+                  .functorKey(functorKey)
+                  .build());
+        }
       }
     });
 

--- a/pipeline-service/service/src/main/java/io/harness/pms/expressions/functors/ConfigFileRemoteExpressionFunctor.java
+++ b/pipeline-service/service/src/main/java/io/harness/pms/expressions/functors/ConfigFileRemoteExpressionFunctor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.pms.expressions.functors;
+
+import static io.harness.NGCommonEntityConstants.CONFIG_FILE_FUNCTOR;
+import static io.harness.NGCommonEntityConstants.CONFIG_FILE_FUNCTOR_BASE64_METHOD_NAME;
+import static io.harness.NGCommonEntityConstants.CONFIG_FILE_FUNCTOR_STRING_METHOD_NAME;
+import static io.harness.common.EntityTypeConstants.FILES;
+import static io.harness.common.EntityTypeConstants.SECRETS;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.data.structure.EmptyPredicate;
+import io.harness.exception.InvalidArgumentsException;
+import io.harness.exception.InvalidRequestException;
+import io.harness.expression.LateBindingMap;
+import io.harness.expression.functors.ExpressionFunctor;
+import io.harness.pms.contracts.ambiance.Ambiance;
+import io.harness.pms.contracts.expression.ExpressionRequest;
+import io.harness.pms.contracts.expression.ExpressionResponse;
+import io.harness.pms.contracts.expression.RemoteFunctorServiceGrpc.RemoteFunctorServiceBlockingStub;
+import io.harness.pms.sdk.core.execution.expression.ExpressionResultUtils;
+import io.harness.pms.serializer.recaster.RecastOrchestrationUtils;
+import io.harness.pms.utils.PmsGrpcClientUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+
+@Builder
+@OwnedBy(HarnessTeam.CDP)
+@Slf4j
+public class ConfigFileRemoteExpressionFunctor extends LateBindingMap implements ExpressionFunctor {
+  private RemoteFunctorServiceBlockingStub remoteFunctorServiceBlockingStub;
+  private Ambiance ambiance;
+
+  public Object getAsString(String ref) {
+    List<String> args = Arrays.asList(getReferenceType(ref), CONFIG_FILE_FUNCTOR_STRING_METHOD_NAME, ref);
+    return get(args);
+  }
+
+  public Object getAsBase64(String ref) {
+    List<String> args = Arrays.asList(getReferenceType(ref), CONFIG_FILE_FUNCTOR_BASE64_METHOD_NAME, ref);
+    return get(args);
+  }
+
+  private String getReferenceType(String ref) {
+    if (EmptyPredicate.isEmpty(ref)) {
+      throw new InvalidArgumentsException("File or secret reference cannot be null or empty");
+    }
+
+    return ref.contains("/") ? FILES : SECRETS;
+  }
+
+  private Object get(List<String> args) {
+    try {
+      ExpressionResponse expressionResponse =
+          PmsGrpcClientUtils.retryAndProcessException(remoteFunctorServiceBlockingStub::evaluate,
+              ExpressionRequest.newBuilder()
+                  .setAmbiance(ambiance)
+                  .setFunctorKey(CONFIG_FILE_FUNCTOR)
+                  .addAllArgs(args)
+                  .build());
+      if (expressionResponse.getIsPrimitive()) {
+        return ExpressionResultUtils.getPrimitiveResponse(
+            expressionResponse.getValue(), expressionResponse.getPrimitiveType());
+      }
+      return RecastOrchestrationUtils.fromJson(expressionResponse.getValue());
+    } catch (ClassNotFoundException e) {
+      log.error(e.getMessage());
+      throw new InvalidRequestException(e.getMessage(), e);
+    } catch (Exception ex) {
+      log.error("Could not get object from remote functor for key: " + CONFIG_FILE_FUNCTOR);
+      throw ex;
+    }
+  }
+}

--- a/pipeline-service/service/src/test/java/io/harness/pms/expressions/functors/ConfigFileRemoteExpressionFunctorTest.java
+++ b/pipeline-service/service/src/test/java/io/harness/pms/expressions/functors/ConfigFileRemoteExpressionFunctorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.pms.expressions.functors;
+
+import static io.harness.rule.OwnerRule.IVAN;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.joor.Reflect.on;
+
+import io.harness.CategoryTest;
+import io.harness.category.element.UnitTests;
+import io.harness.pms.contracts.ambiance.Ambiance;
+import io.harness.pms.contracts.expression.ExpressionRequest;
+import io.harness.pms.contracts.expression.ExpressionResponse;
+import io.harness.pms.contracts.expression.RemoteFunctorServiceGrpc;
+import io.harness.rule.Owner;
+
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.GrpcCleanupRule;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+
+public class ConfigFileRemoteExpressionFunctorTest extends CategoryTest {
+  private RemoteFunctorServiceGrpc.RemoteFunctorServiceBlockingStub blockingStub;
+  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  private ExpressionRequest request;
+  private RemoteFunctorServiceGrpc.RemoteFunctorServiceImplBase remoteFunctorServiceImplBase =
+      new RemoteFunctorServiceGrpc.RemoteFunctorServiceImplBase() {
+        @Override
+        public void evaluate(ExpressionRequest grpcRequest, StreamObserver<ExpressionResponse> responseObserver) {
+          request = grpcRequest;
+          responseObserver.onNext(ExpressionResponse.newBuilder().setValue(expressionResponseJson).build());
+          responseObserver.onCompleted();
+        }
+      };
+  private String expressionResponseJson =
+      "{\"__recast\":\"io.harness.pms.sdk.core.execution.expression.StringResult\",\"value\":\"DummyValue\"}";
+
+  @InjectMocks ConfigFileRemoteExpressionFunctor configFileRemoteExpressionFunctor;
+
+  @Before
+  public void setUp() throws IOException {
+    grpcCleanup.register(InProcessServerBuilder.forName("configFileRemoteExpressionFunctorTest")
+                             .directExecutor()
+                             .addService(remoteFunctorServiceImplBase)
+                             .build()
+                             .start());
+    ManagedChannel chan = grpcCleanup.register(
+        InProcessChannelBuilder.forName("configFileRemoteExpressionFunctorTest").directExecutor().build());
+    blockingStub = RemoteFunctorServiceGrpc.newBlockingStub(chan);
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  @Owner(developers = IVAN)
+  @Category(UnitTests.class)
+  public void testGetAsString() {
+    Ambiance ambiance = Ambiance.newBuilder().build();
+    on(configFileRemoteExpressionFunctor).set("ambiance", ambiance);
+    on(configFileRemoteExpressionFunctor).set("remoteFunctorServiceBlockingStub", blockingStub);
+
+    Map<String, Object> map = (Map<String, Object>) configFileRemoteExpressionFunctor.getAsString("/folder/filename");
+
+    assertEquals(request.getAmbiance(), ambiance);
+    assertEquals(request.getArgsList().size(), 3);
+    List<String> args = Arrays.asList(request.getArgsList().toArray(new String[0]));
+    assertThat(args).contains("Files", "getAsString", "/folder/filename");
+    assertNotNull(map);
+    assertEquals(map.get("value"), "DummyValue");
+  }
+
+  @Test
+  @Owner(developers = IVAN)
+  @Category(UnitTests.class)
+  public void testGetAsBase64() {
+    Ambiance ambiance = Ambiance.newBuilder().build();
+    on(configFileRemoteExpressionFunctor).set("ambiance", ambiance);
+    on(configFileRemoteExpressionFunctor).set("remoteFunctorServiceBlockingStub", blockingStub);
+
+    Map<String, Object> map = (Map<String, Object>) configFileRemoteExpressionFunctor.getAsBase64("secretRef");
+
+    assertEquals(request.getAmbiance(), ambiance);
+    assertEquals(request.getArgsList().size(), 3);
+    List<String> args = Arrays.asList(request.getArgsList().toArray(new String[0]));
+    assertThat(args).contains("Secrets", "getAsBase64", "secretRef");
+    assertNotNull(map);
+    assertEquals(map.get("value"), "DummyValue");
+  }
+}


### PR DESCRIPTION
## Describe your changes

Added support for `configFile.getAsString` and `configFile.getAsBase64` buit-in methods

Examples
 File from File Store
`<+configFile.getAsString("account:/folder1/yamlFile.yaml")> `     >> configFile account level
`<+configFile.getAsString("org:/folder1/yamlFile.yaml")>  `            >> configFile org level
`<+configFile.getAsString("/folder1/yamlFile.yaml")> `                    >> configFile project level
 
Secret File from Secret Manager
`<+configFile.getAsString("account.MySecretFile")> `                    >> secret account level
`<+configFile.getAsString("org.MySecretFile")>  `                           >> secret org level
`<+configFile.getAsString("MySecretFile")> `                                   >> secret project level

The same and for getAsBase64 method.

Code changes include:
- `ConfigFileRemoteExpressionFunctor` is added because the existing `RemoteExpressionFunctor` only sends the first `getAsString` or `getAsBase64` argument to SDK functors.
- `ConfigFileFunctor` is added as a new SDK functor it will return the content for files but for secrets, it will only prepare the expression that will be evaluated by `NgSecretManagerFunctor`.
- `NgSecretManagerFunctor` will evaluate the Harness local secrets, and other types like KMS, GCP_KMS ... will be evaluated on the delegate. 




## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/42757)
<!-- Reviewable:end -->
