### PR TITLE
[fix]: [PIE-7775]: Fixing pipeline not getting aborted when aborted from queued status

### DIFF
--- a/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/interrupts/handlers/InterruptPropagatorHandler.java
+++ b/pipeline-service/modules/orchestration/src/main/java/io/harness/engine/interrupts/handlers/InterruptPropagatorHandler.java
@@ -83,11 +83,16 @@ public abstract class InterruptPropagatorHandler {
     return handleDiscontinuingNodes(updatedInterrupt, updatedCount);
   }
 
+  void finalisePlanExecutionIfQueued(Interrupt interrupt) {}
+
   protected Interrupt handleDiscontinuingNodes(Interrupt updatedInterrupt, long updatedCount) {
     if (updatedCount < 0) {
       // IF count is less than 0 then the update didn't go through
       return interruptService.markProcessed(updatedInterrupt.getUuid(), PROCESSED_UNSUCCESSFULLY);
     } else if (updatedCount == 0) {
+      // If the planExecution is queued then no nodeExecution is created. So in that case updatedCount will always be 0.
+      // And we can directly conclude the execution.
+      finalisePlanExecutionIfQueued(updatedInterrupt);
       // If count is 0 that means no running leaf node and hence nothing to do
       return updatedInterrupt;
     } else {

--- a/pipeline-service/modules/orchestration/src/test/java/io/harness/engine/interrupts/handlers/AbortAllInterruptHandlerTest.java
+++ b/pipeline-service/modules/orchestration/src/test/java/io/harness/engine/interrupts/handlers/AbortAllInterruptHandlerTest.java
@@ -8,11 +8,17 @@
 package io.harness.engine.interrupts.handlers;
 
 import static io.harness.data.structure.UUIDGenerator.generateUuid;
+import static io.harness.pms.contracts.execution.Status.ABORTED;
 import static io.harness.pms.contracts.execution.Status.DISCONTINUING;
+import static io.harness.pms.contracts.execution.Status.QUEUED;
+import static io.harness.rule.OwnerRule.BRIJESH;
 import static io.harness.rule.OwnerRule.PRASHANT;
 import static io.harness.rule.OwnerRule.PRASHANTSHARMA;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.harness.OrchestrationTestBase;
@@ -23,6 +29,7 @@ import io.harness.engine.OrchestrationTestHelper;
 import io.harness.engine.executions.node.NodeExecutionService;
 import io.harness.engine.executions.plan.PlanExecutionService;
 import io.harness.execution.NodeExecution;
+import io.harness.execution.PlanExecution;
 import io.harness.interrupts.Interrupt;
 import io.harness.interrupts.Interrupt.State;
 import io.harness.pms.contracts.execution.Status;
@@ -148,6 +155,37 @@ public class AbortAllInterruptHandlerTest extends OrchestrationTestBase {
   }
 
   @Test
+  @Owner(developers = BRIJESH)
+  @Category(UnitTests.class)
+  public void testFinalisePlanExecutionIfQueued() {
+    String planExecutionId = generateUuid();
+    String interruptUuid = generateUuid();
+    Interrupt interrupt = Interrupt.builder()
+                              .uuid(interruptUuid)
+                              .type(InterruptType.ABORT_ALL)
+                              .interruptConfig(InterruptConfig.newBuilder().build())
+                              .planExecutionId(planExecutionId)
+                              .state(State.PROCESSING)
+                              .build();
+
+    mongoTemplate.save(interrupt);
+
+    abortAllInterruptHandler.finalisePlanExecutionIfQueued(interrupt);
+    verify(planExecutionService, times(1))
+        .updateStatusForceful(interrupt.getPlanExecutionId(), ABORTED, null, false, EnumSet.of(QUEUED));
+    // returned PlanExecution will be null. So no action on interrupt.
+    assertThat(mongoTemplate.findById(interruptUuid, Interrupt.class).getState()).isEqualTo(State.PROCESSING);
+
+    doReturn(PlanExecution.builder().status(ABORTED).build())
+        .when(planExecutionService)
+        .updateStatusForceful(interrupt.getPlanExecutionId(), ABORTED, null, false, EnumSet.of(QUEUED));
+    abortAllInterruptHandler.finalisePlanExecutionIfQueued(interrupt);
+    // Returned planExecution has the status ABORTED. So interrupt will be marked as PROCESSED_SUCCESSFULLY.
+    assertThat(mongoTemplate.findById(interruptUuid, Interrupt.class).getState())
+        .isEqualTo(State.PROCESSED_SUCCESSFULLY);
+  }
+
+  @Test
   @Owner(developers = PRASHANTSHARMA)
   @Category(UnitTests.class)
   public void testHandleAllNodes() {
@@ -171,6 +209,8 @@ public class AbortAllInterruptHandlerTest extends OrchestrationTestBase {
     assertThat(handledInterrupt).isNotNull();
     assertThat(handledInterrupt.getUuid()).isEqualTo(interruptUuid);
     assertThat(handledInterrupt.getState()).isEqualTo(State.PROCESSING);
+    verify(planExecutionService, times(1))
+        .updateStatusForceful(interrupt.getPlanExecutionId(), ABORTED, null, false, EnumSet.of(QUEUED));
 
     // case2: updatedCount < 0
     when(nodeExecutionService.markAllLeavesAndQueuedNodesDiscontinuing(


### PR DESCRIPTION
## Describe your changes

Fixing pipeline not getting aborted when aborted from queued status.
What is the change: In abortAllInterruptHandler, when there are no nodeExecutions. Then the updatedCount will always be zero. And in case of zero, we were not doing anything and out interrupt monitor will used to handle the interrupt.
But now if planExecution status is queued, then we will mark the planExecution as ABORTED and mark the interrupt as PROCESSED_SUCCESSFULLY.

Impact: Abort interrupt processing. But the change is very contained and will come into effect only if planExecution status is QUEUED. 

Testing: Tested that if planExecution is queued then abort is happening. And if planExecution is not in queued state and updatedCount is zero then its not marking the plan as aborted directly.


## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/42836)
<!-- Reviewable:end -->
