### PR TITLE
fix: [CDS-50725]: reduce time of cache of lock file git

### DIFF
--- a/930-delegate-tasks/src/main/java/software/wings/service/impl/yaml/GitClientHelper.java
+++ b/930-delegate-tasks/src/main/java/software/wings/service/impl/yaml/GitClientHelper.java
@@ -87,7 +87,7 @@ public class GitClientHelper {
 
   private LoadingCache<String, File> cache = CacheBuilder.newBuilder()
                                                  .maximumSize(2000)
-                                                 .expireAfterAccess(1, TimeUnit.HOURS)
+                                                 .expireAfterAccess(10, TimeUnit.MINUTES)
                                                  .build(new CacheLoader<String, File>() {
                                                    @Override
                                                    public File load(String key) throws Exception {

--- a/960-api-services/src/main/java/io/harness/git/GitClientV2Impl.java
+++ b/960-api-services/src/main/java/io/harness/git/GitClientV2Impl.java
@@ -265,6 +265,13 @@ public class GitClientV2Impl implements GitClientV2 {
                        // if set to <code>true</code> no branch will be checked out, after the clone.
                        // This enhances performance of the clone command when there is no need for a checked out branch.
                        .setNoCheckout(noCheckout)
+                       .setTransportConfigCallback(transport -> {
+                         if (transport instanceof TransportHttp) {
+                           TransportHttp http = (TransportHttp) transport;
+                           http.setTimeout(60);
+                           http.setHttpConnectionFactory(connectionFactory);
+                         }
+                       })
                        .call()) {
     } catch (GitAPIException ex) {
       log.error(GIT_YAML_LOG_PREFIX + "Error in cloning repo: " + ExceptionSanitizer.sanitizeForLogging(ex));


### PR DESCRIPTION
## Describe your changes
today the delegate timeout is 10 minutes and 30 seconds, in this case if you have several steps that use the same manifest in git with the connector id with the same name it will not follow until you reset the lock file cache.

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/42893)
<!-- Reviewable:end -->
