### PR TITLE
feat: [CDS-49931]: populate cluster details to service_infra_info table after pipeline execution

### DIFF
--- a/110-change-data-capture/src/main/java/io/harness/changehandlers/PlanExecutionSummaryCDConstants.java
+++ b/110-change-data-capture/src/main/java/io/harness/changehandlers/PlanExecutionSummaryCDConstants.java
@@ -26,4 +26,10 @@ class PlanExecutionSummaryCDConstants {
   static final String GITOPS_ENABLED_KEY = "gitOpsEnabled";
   static final String ENV_GROUP_ID = "envGroupId";
   static final String ENV_GROUP_NAME = "envGroupName";
+  static final String ENV_ID = "envId";
+  static final String CLUSTER_ID = "clusterId";
+  static final String CLUSTER_NAME = "clusterName";
+  static final String ENVIRONMENTS = "environments";
+  static final String CLUSTERS = "clusters";
+  static final String GITOPS_EXECUTION_SUMMARY = "gitopsExecutionSummary";
 }


### PR DESCRIPTION
## Describe your changes
When the instances gets published to NG, last pipeline execution details are currently retrieved using account, org, project, service and env ids.

This IS enhanced to include cluster id as well.

Currently cluster id column is not present in table service_infra_info. We should get the data to that table and then modify the instance sync API to achieve the functionality.

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)
