### PR TITLE
fix: [BT-2907]: Upgrade rules_proto_grpc version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -368,9 +368,9 @@ gazelle_dependencies()
 
 http_archive(
     name = "rules_proto_grpc",
-    sha256 = "5f0f2fc0199810c65a2de148a52ba0aff14d631d4e8202f41aff6a9d590a471b",
-    strip_prefix = "rules_proto_grpc-1.0.2",
-    urls = ["http://jfrogdev.dev.harness.io:80/artifactory/rules-proto-grpc-github/archive/1.0.2.tar.gz"],
+    sha256 = "d771584bbff98698e7cb3cb31c132ee206a972569f4dc8b65acbdd934d156b33",
+    strip_prefix = "rules_proto_grpc-2.0.0",
+    urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/refs/tags/2.0.0.tar.gz"],
 )
 
 load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")


### PR DESCRIPTION
## Describe your changes


Current version of rules_proto_grpc points to http_archive rule for io_grpc_grpc_java with a wrong SHA (as shown in the error below). In this change, we are updating version of rules_proto_grpc library to get around this issue

====

 bazel run @unpinned_maven//:pin
INFO: Invocation ID: fa555c56-476f-4744-aa9c-526e3f177c02
INFO: Repository io_grpc_grpc_java instantiated at:
  /Users/anurag/Harness/harness-core/WORKSPACE:384:28: in <toplevel>
  /private/var/tmp/_bazel_anurag/e26f4d2fee98875432d93c8aedb14e46/external/rules_proto_grpc/java/repositories.bzl:11:22: in java_repos
  /private/var/tmp/_bazel_anurag/e26f4d2fee98875432d93c8aedb14e46/external/rules_proto_grpc/repositories.bzl:517:24: in io_grpc_grpc_java
  /private/var/tmp/_bazel_anurag/e26f4d2fee98875432d93c8aedb14e46/external/rules_proto_grpc/repositories.bzl:321:25: in _generic_dependency
Repository rule http_archive defined at:
  /private/var/tmp/_bazel_anurag/e26f4d2fee98875432d93c8aedb14e46/external/bazel_tools/tools/build_defs/repo/http.bzl:364:31: in <toplevel>
WARNING: Download from https://github.com/grpc/grpc-java/archive/62e8655f1bc4dfb474afbf332ca7571c1454e6ef.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException Checksum was 6df4f306a11d5ebd8fc6ac839eb9ca57c1423cdd65808a4256bb063b3efedcb8 but wanted 920977aa6d5beeefdf6668848589319c85d5cf3570329bab4d1a04425546e9a1
ERROR: An error occurred during the fetch of repository 'io_grpc_grpc_java':
   Traceback (most recent call last):
        File "/private/var/tmp/_bazel_anurag/e26f4d2fee98875432d93c8aedb14e46/external/bazel_tools/tools/build_defs/repo/http.bzl", line 111, column 45, in _http_archive_impl
                download_info = ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Error downloading [https://github.com/grpc/grpc-java/archive/62e8655f1bc4dfb474afbf332ca7571c1454e6ef.tar.gz] to /private/var/tmp/_bazel_anurag/e26f4d2fee98875432d93c8aedb14e46/external/io_grpc_grpc_java/temp6346624608207619920/62e8655f1bc4dfb474afbf332ca7571c1454e6ef.tar.gz: Checksum was 6df4f306a11d5ebd8fc6ac839eb9ca57c1423cdd65808a4256bb063b3efedcb8 but wanted 920977aa6d5beeefdf6668848589319c85d5cf3570329bab4d1a04425546e9a1
ERROR: /Users/anurag/Harness/harness-core/WORKSPACE:384:28: fetching http_archive rule //external:io_grpc_grpc_java: Traceback (most recent call last):
        File "/private/var/tmp/_bazel_anurag/e26f4d2fee98875432d93c8aedb14e46/external/bazel_tools/tools/build_defs/repo/http.bzl", line 111, column 45, in _http_archive_impl
                download_info = ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Error downloading [https://github.com/grpc/grpc-java/archive/62e8655f1bc4dfb474afbf332ca7571c1454e6ef.tar.gz] to /private/var/tmp/_bazel_anurag/e26f4d2fee98875432d93c8aedb14e46/external/io_grpc_grpc_java/temp6346624608207619920/62e8655f1bc4dfb474afbf332ca7571c1454e6ef.tar.gz: Checksum was 6df4f306a11d5ebd8fc6ac839eb9ca57c1423cdd65808a4256bb063b3efedcb8 but wanted 920977aa6d5beeefdf6668848589319c85d5cf3570329bab4d1a04425546e9a1
ERROR: no such package '@io_grpc_grpc_java//': java.io.IOException: Error downloading [https://github.com/grpc/grpc-java/archive/62e8655f1bc4dfb474afbf332ca7571c1454e6ef.tar.gz] to /private/var/tmp/_bazel_anurag/e26f4d2fee98875432d93c8aedb14e46/external/io_grpc_grpc_java/temp6346624608207619920/62e8655f1bc4dfb474afbf332ca7571c1454e6ef.tar.gz: Checksum was 6df4f306a11d5ebd8fc6ac839eb9ca57c1423cdd65808a4256bb063b3efedcb8 but wanted 920977aa6d5beeefdf6668848589319c85d5cf3570329bab4d1a04425546e9a1
INFO: Elapsed time: 17.981s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
FAILED: Build did NOT complete successfully (0 packages loaded)


## Checklist
- [X] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/43258)
<!-- Reviewable:end -->
