### PR TITLE
[feat]: [PIE-5963]: Add RollbackSteps node in Abstract Stage Plan Creator

### DIFF
--- a/125-cd-nextgen/src/main/java/io/harness/cdng/creator/plan/execution/CDExecutionPMSPlanCreator.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/creator/plan/execution/CDExecutionPMSPlanCreator.java
@@ -10,7 +10,6 @@ package io.harness.cdng.creator.plan.execution;
 import static io.harness.annotations.dev.HarnessTeam.CDC;
 
 import io.harness.annotations.dev.OwnedBy;
-import io.harness.cdng.creator.plan.rollback.RollbackPlanCreator;
 import io.harness.data.structure.EmptyPredicate;
 import io.harness.plancreator.NGCommonUtilPlanCreationConstants;
 import io.harness.plancreator.execution.ExecutionElementConfig;
@@ -36,7 +35,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 @OwnedBy(CDC)
@@ -57,15 +55,6 @@ public class CDExecutionPMSPlanCreator extends ChildrenPlanCreator<ExecutionElem
           PlanCreationResponse.builder()
               .dependencies(DependenciesUtils.toDependenciesProto(stepsYamlFieldMap))
               .build());
-    }
-
-    // TODO: NEED TO CREATE A ROLLBACK PLAN CREATOR
-    // add rollback dependency
-    YamlField executionStepsField = ctx.getCurrentField().getNode().getField(YAMLFieldNameConstants.STEPS);
-    PlanCreationResponse planForRollback = RollbackPlanCreator.createPlanForRollback(ctx, ctx.getCurrentField());
-    if (EmptyPredicate.isNotEmpty(planForRollback.getNodes())) {
-      responseMap.put(
-          Objects.requireNonNull(executionStepsField).getNode().getUuid() + "_combinedRollback", planForRollback);
     }
 
     return responseMap;

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/creator/plan/rollback/DeploymentStageRollbackPlanCreator.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/creator/plan/rollback/DeploymentStageRollbackPlanCreator.java
@@ -24,7 +24,6 @@ import io.harness.pms.contracts.facilitators.FacilitatorType;
 import io.harness.pms.contracts.steps.SkipType;
 import io.harness.pms.execution.OrchestrationFacilitatorType;
 import io.harness.pms.sdk.core.plan.PlanNode;
-import io.harness.pms.sdk.core.plan.creation.beans.PlanCreationContext;
 import io.harness.pms.sdk.core.plan.creation.beans.PlanCreationResponse;
 import io.harness.pms.yaml.YAMLFieldNameConstants;
 import io.harness.pms.yaml.YamlField;
@@ -35,8 +34,14 @@ import lombok.experimental.UtilityClass;
 
 @UtilityClass
 @OwnedBy(HarnessTeam.CDC)
-public class RollbackPlanCreator {
-  public PlanCreationResponse createPlanForRollback(PlanCreationContext ctx, YamlField executionField) {
+public class DeploymentStageRollbackPlanCreator {
+  public PlanCreationResponse createPlanForRollbackFromStageField(YamlField stageField) {
+    YamlField executionField =
+        stageField.getNode().getField(YAMLFieldNameConstants.SPEC).getNode().getField(YAMLFieldNameConstants.EXECUTION);
+    return createPlanForRollback(executionField);
+  }
+
+  public PlanCreationResponse createPlanForRollback(YamlField executionField) {
     YamlField executionStepsField = executionField.getNode().getField(YAMLFieldNameConstants.STEPS);
 
     if (executionStepsField == null || executionStepsField.getNode().asArray().size() == 0) {

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/creator/plan/stage/DeploymentStagePMSPlanCreatorV2.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/creator/plan/stage/DeploymentStagePMSPlanCreatorV2.java
@@ -17,6 +17,7 @@ import io.harness.beans.FeatureName;
 import io.harness.cdng.creator.plan.envGroup.EnvGroupPlanCreatorHelper;
 import io.harness.cdng.creator.plan.environment.EnvironmentPlanCreatorHelper;
 import io.harness.cdng.creator.plan.infrastructure.InfrastructurePmsPlanCreator;
+import io.harness.cdng.creator.plan.rollback.DeploymentStageRollbackPlanCreator;
 import io.harness.cdng.creator.plan.service.ServiceAllInOnePlanCreatorUtils;
 import io.harness.cdng.creator.plan.service.ServicePlanCreatorHelper;
 import io.harness.cdng.envGroup.yaml.EnvGroupPlanCreatorConfig;
@@ -212,6 +213,11 @@ public class DeploymentStagePMSPlanCreatorV2 extends AbstractStagePlanCreator<De
       builder.executionInputTemplate(ctx.getExecutionInputTemplate());
     }
     return builder.build();
+  }
+
+  @Override
+  protected PlanCreationResponse createPlanForRollback(PlanCreationContext ctx, DeploymentStageNode config) {
+    return DeploymentStageRollbackPlanCreator.createPlanForRollbackFromStageField(ctx.getCurrentField());
   }
 
   public String getIdentifierWithExpression(PlanCreationContext ctx, DeploymentStageNode node, String identifier) {

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/creator/plan/stage/DeploymentStagePMSPlanCreatorV2Test.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/creator/plan/stage/DeploymentStagePMSPlanCreatorV2Test.java
@@ -8,6 +8,7 @@
 package io.harness.cdng.creator.plan.stage;
 
 import static io.harness.cdng.service.beans.ServiceDefinitionType.KUBERNETES;
+import static io.harness.rule.OwnerRule.NAMAN;
 import static io.harness.rule.OwnerRule.PRASHANTSHARMA;
 
 import static java.util.Arrays.asList;
@@ -28,6 +29,7 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.FeatureName;
 import io.harness.category.element.UnitTests;
 import io.harness.cdng.CDNGTestBase;
+import io.harness.cdng.creator.plan.rollback.DeploymentStageRollbackPlanCreator;
 import io.harness.cdng.envgroup.yaml.EnvironmentGroupYaml;
 import io.harness.cdng.environment.filters.Entity;
 import io.harness.cdng.environment.filters.FilterType;
@@ -92,6 +94,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 @OwnedBy(HarnessTeam.CDC)
@@ -546,5 +550,22 @@ public class DeploymentStagePMSPlanCreatorV2Test extends CDNGTestBase {
                .build();
     assertThat(deploymentStagePMSPlanCreator.getIdentifierWithExpression(context, node, "id1"))
         .isEqualTo("id1<+strategy.identifierPostFix>");
+  }
+
+  @Test
+  @Owner(developers = NAMAN)
+  @Category(UnitTests.class)
+  public void testCreatePlanForRollback() throws IOException {
+    String yaml = "Pipeline: YAML";
+    YamlField yamlField = YamlUtils.injectUuidInYamlField(yaml);
+    PlanCreationContext ctx = PlanCreationContext.builder().build();
+    ctx.setCurrentField(yamlField);
+    MockedStatic<DeploymentStageRollbackPlanCreator> mockSettings =
+        Mockito.mockStatic(DeploymentStageRollbackPlanCreator.class);
+    PlanCreationResponse dummy =
+        PlanCreationResponse.builder().planNode(PlanNode.builder().uuid("uuid").build()).build();
+    when(DeploymentStageRollbackPlanCreator.createPlanForRollbackFromStageField(yamlField)).thenReturn(dummy);
+    assertThat(deploymentStagePMSPlanCreator.createPlanForRollback(ctx, null)).isEqualTo(dummy);
+    mockSettings.close();
   }
 }

--- a/clients/pipeline-service/pms-sdk-core/src/main/java/io/harness/plancreator/steps/GenericStepsNodePlanCreator.java
+++ b/clients/pipeline-service/pms-sdk-core/src/main/java/io/harness/plancreator/steps/GenericStepsNodePlanCreator.java
@@ -20,7 +20,9 @@ import io.harness.pms.yaml.DependenciesUtils;
 import io.harness.pms.yaml.PipelineVersion;
 import io.harness.pms.yaml.YAMLFieldNameConstants;
 import io.harness.pms.yaml.YamlField;
+import io.harness.serializer.KryoSerializer;
 
+import com.google.inject.Inject;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -30,6 +32,8 @@ import java.util.Set;
 
 @OwnedBy(PIPELINE)
 public abstract class GenericStepsNodePlanCreator extends ChildrenPlanCreator<StepsExecutionConfig> {
+  @Inject protected KryoSerializer kryoSerializer;
+
   @Override
   public LinkedHashMap<String, PlanCreationResponse> createPlanForChildrenNodes(
       PlanCreationContext ctx, StepsExecutionConfig config) {


### PR DESCRIPTION
Each stage will now have a rollback steps node. By default they'll be a noop node. If any stage wants to add their special implementation, they can override the method accordingly. To begin with, Deploy stages will do this. With this, the deploy stage plan creator will create the rollback steps node instead of the Execution Plan Creator.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/43338)
<!-- Reviewable:end -->
