### PR TITLE
feat: [DEL-5892]: enable immutable for all ng customers

### DIFF
--- a/390-db-migration/src/main/java/io/harness/migrations/MigrationList.java
+++ b/390-db-migration/src/main/java/io/harness/migrations/MigrationList.java
@@ -99,6 +99,7 @@ import io.harness.migrations.all.DropUniqueIndexOnImportedTemplate;
 import io.harness.migrations.all.DropUniqueIndexOnTemplateGallery;
 import io.harness.migrations.all.DropYamlGitSyncCollectionMigration;
 import io.harness.migrations.all.DuplicateGlobalAccountMigration;
+import io.harness.migrations.all.EnableImmutableDelegateForNG;
 import io.harness.migrations.all.EnableIteratorsForLdapSync;
 import io.harness.migrations.all.EntityNameValidationMigration_All_00;
 import io.harness.migrations.all.EntityNameValidationMigration_All_01;
@@ -467,6 +468,7 @@ public class MigrationList {
         .add(Pair.of(381, AddRingDetailsToDelegateRing.class))
         .add(Pair.of(382, InitTerraformProvisionersSourceType.class))
         .add(Pair.of(383, CreateLongerDataRetention.class))
+        .add(Pair.of(384, EnableImmutableDelegateForNG.class))
         .build();
   }
 }

--- a/390-db-migration/src/main/java/io/harness/migrations/all/EnableImmutableDelegateForNG.java
+++ b/390-db-migration/src/main/java/io/harness/migrations/all/EnableImmutableDelegateForNG.java
@@ -1,0 +1,27 @@
+package io.harness.migrations.all;
+
+import io.harness.migrations.Migration;
+
+import software.wings.beans.Account;
+import software.wings.beans.Account.AccountKeys;
+import software.wings.dl.WingsPersistence;
+
+import com.google.inject.Inject;
+import dev.morphia.query.Query;
+import dev.morphia.query.UpdateOperations;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class EnableImmutableDelegateForNG implements Migration {
+  @Inject private WingsPersistence wingsPersistence;
+
+  @Override
+  public void migrate() {
+    Query<Account> query = wingsPersistence.createQuery(Account.class).field(AccountKeys.nextGenEnabled).equal(true);
+    UpdateOperations<Account> updateOperations =
+        wingsPersistence.createUpdateOperations(Account.class).set(AccountKeys.immutableDelegateEnabled, true);
+    wingsPersistence.update(query, updateOperations);
+
+    log.info("immutableDelegateEnabled set for all NG accounts");
+  }
+}


### PR DESCRIPTION
NG Customers (accounts with nextGenEnabled = true) will by default use immutable delegate.

**Note**: Since we have same flag for both NG and CG, that means if NG user goes to CG then also they will get immutable delegate only.

Testing:
Tested on local by running manager. Migration got executed, adding ss below. immutableDelegateEnabled flag is set when nextGenEnabled is set.

Before:
<img width="1728" alt="Screenshot 2023-02-01 at 3 55 05 PM" src="https://user-images.githubusercontent.com/102655013/216022514-fefb8b86-a6cb-4418-9099-9a9de46421d7.png">

After migration execution:
<img width="1728" alt="Screenshot 2023-02-01 at 4 01 18 PM" src="https://user-images.githubusercontent.com/102655013/216022545-e55c0608-a96b-4d8f-ad65-305f56b93c89.png">


## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/43351)
<!-- Reviewable:end -->
