### PR TITLE
[fix]: [PL-31422]: Fixing delegateTask.calcDescription call for task data v2

### DIFF
--- a/400-rest/src/main/java/software/wings/scheduler/ShellScriptApprovalService.java
+++ b/400-rest/src/main/java/software/wings/scheduler/ShellScriptApprovalService.java
@@ -96,7 +96,8 @@ public class ShellScriptApprovalService {
     stateExecutionService.appendDelegateTaskDetails(stateExecutionInstanceId,
         DelegateTaskDetails.builder()
             .delegateTaskId(delegateTask.getUuid())
-            .taskDescription(delegateTask.calcDescription())
+            .taskDescription(
+                delegateTask.getData() != null ? delegateTask.calcDescription() : delegateTask.calcDescriptionV2())
             .setupAbstractions(delegateTask.getSetupAbstractions())
             .build());
   }

--- a/400-rest/src/main/java/software/wings/sm/State.java
+++ b/400-rest/src/main/java/software/wings/sm/State.java
@@ -371,7 +371,8 @@ public abstract class State {
       stateExecutionService.appendDelegateTaskDetails(context.getStateExecutionInstanceId(),
           DelegateTaskDetails.builder()
               .delegateTaskId(delegateTask.getUuid())
-              .taskDescription(delegateTask.calcDescription())
+              .taskDescription(
+                  delegateTask.getData() != null ? delegateTask.calcDescription() : delegateTask.calcDescriptionV2())
               .setupAbstractions(delegateTask.getSetupAbstractions())
               .build());
     }

--- a/400-rest/src/main/java/software/wings/sm/states/EcsStateHelper.java
+++ b/400-rest/src/main/java/software/wings/sm/states/EcsStateHelper.java
@@ -406,7 +406,8 @@ public class EcsStateHelper {
     stateExecutionService.appendDelegateTaskDetails(stateExecutionInstanceId,
         DelegateTaskDetails.builder()
             .delegateTaskId(delegateTask.getUuid())
-            .taskDescription(delegateTask.calcDescription())
+            .taskDescription(
+                delegateTask.getData() != null ? delegateTask.calcDescription() : delegateTask.calcDescriptionV2())
             .setupAbstractions(delegateTask.getSetupAbstractions())
             .build());
   }

--- a/400-rest/src/main/java/software/wings/sm/states/pcf/PcfStateHelper.java
+++ b/400-rest/src/main/java/software/wings/sm/states/pcf/PcfStateHelper.java
@@ -390,7 +390,8 @@ public class PcfStateHelper {
     stateExecutionService.appendDelegateTaskDetails(stateExecutionInstanceId,
         DelegateTaskDetails.builder()
             .delegateTaskId(delegateTask.getUuid())
-            .taskDescription(delegateTask.calcDescription())
+            .taskDescription(
+                delegateTask.getData() != null ? delegateTask.calcDescription() : delegateTask.calcDescriptionV2())
             .setupAbstractions(delegateTask.getSetupAbstractions())
             .build());
   }

--- a/pipeline-service/modules/ng-triggers/src/test/java/io/harness/ngtriggers/service/NGTriggerServiceImplTest.java
+++ b/pipeline-service/modules/ng-triggers/src/test/java/io/harness/ngtriggers/service/NGTriggerServiceImplTest.java
@@ -703,4 +703,27 @@ public class NGTriggerServiceImplTest extends CategoryTest {
     assertThatThrownBy(() -> ngTriggerServiceImpl.validateInputSetsInternal(triggerDetails))
         .isInstanceOf(InvalidTriggerYamlException.class);
   }
+
+  @Test
+  @Owner(developers = MEET)
+  @Category(UnitTests.class)
+  public void testCronTriggerInterval() {
+    TriggerDetails triggerDetails =
+        TriggerDetails.builder()
+            .ngTriggerEntity(NGTriggerEntity.builder().identifier("id").name("name").build())
+            .ngTriggerConfigV2(
+                NGTriggerConfigV2.builder()
+                    .source(NGTriggerSourceV2.builder()
+                                .type(NGTriggerType.SCHEDULED)
+                                .spec(ScheduledTriggerConfig.builder()
+                                          .type("Cron")
+                                          .spec(CronTriggerSpec.builder().expression("0/2 * * * *").build())
+                                          .build())
+                                .build())
+                    .build())
+            .build();
+
+    assertThatThrownBy(() -> ngTriggerServiceImpl.validateTriggerConfig(triggerDetails))
+        .isInstanceOf(InvalidArgumentsException.class);
+  }
 }


### PR DESCRIPTION
## Describe your changes
After migrating delegate task request flow to v2 Cloud Formation pipelines are failing with UNKNOWN_ERROR. There is NPE 

logs
```
io.harness.exception.WingsException: UNKNOWN_ERROR
	at software.wings.sm.StateMachineExecutor.startStateExecution(StateMachineExecutor.java:658)
	at software.wings.sm.StateMachineExecutor.startExecution(StateMachineExecutor.java:617)
	at software.wings.sm.StateMachineExecutor$SmExecutionDispatcher.run(StateMachineExecutor.java:2626)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.NullPointerException: null
	at io.harness.beans.DelegateTask.calcDescription(DelegateTask.java:224)
	at software.wings.sm.State.appendDelegateTaskDetails(State.java:374)
	at software.wings.sm.states.provision.CloudFormationCreateStackState.queueFetchFileTask(CloudFormationCreateStackState.java:400)
	at software.wings.sm.states.provision.CloudFormationCreateStackState.buildAndQueueFetchS3FilesTask(CloudFormationCreateStackState.java:394)
	at software.wings.sm.states.provision.CloudFormationCreateStackState.buildAndQueueDelegateTask(CloudFormationCreateStackState.java:224)
	at software.wings.sm.states.provision.CloudFormationState.executeInternal(CloudFormationState.java:235)
	at software.wings.sm.states.provision.CloudFormationCreateStackState.executeInternal(CloudFormationCreateStackState.java:192)
	at software.wings.sm.states.provision.CloudFormationState.execute(CloudFormationState.java:162)
	at software.wings.sm.StateMachineExecutor.getExecutionResponseWithAdvise(StateMachineExecutor.java:707)
	at software.wings.sm.StateMachineExecutor.startStateExecution(StateMachineExecutor.java:649)
```

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/43758)
<!-- Reviewable:end -->
