### PR TITLE
[fix]: [SMP-914]: Support Redis Username and Password in sentinels 

### DIFF
--- a/120-ng-manager/container/scripts/replace_configs.sh
+++ b/120-ng-manager/container/scripts/replace_configs.sh
@@ -597,8 +597,23 @@ if [[ "$EVENTS_FRAMEWORK_USE_SENTINEL" == "true" ]]; then
   if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
         export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.sentinelServersConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $ENTERPRISE_REDISSON_CACHE_FILE
   fi
-  replace_key_value eventsFramework.redis.userName $EVENTS_FRAMEWORK_REDIS_USERNAME
-  replace_key_value eventsFramework.redis.password $EVENTS_FRAMEWORK_REDIS_PASSWORD
-  replace_key_value redisLockConfig.userName $LOCK_CONFIG_REDIS_USERNAME
-  replace_key_value redisLockConfig.password $LOCK_CONFIG_REDIS_PASSWORD
+else
+  yq -i 'del(.sentinelServersConfig)' $REDISSON_CACHE_FILE
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
+      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.singleServerConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $REDISSON_CACHE_FILE
+  fi
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
+        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.singleServerConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $REDISSON_CACHE_FILE
+  fi
+  yq -i 'del(.sentinelServersConfig)' $ENTERPRISE_REDISSON_CACHE_FILE
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
+      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.singleServerConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $ENTERPRISE_REDISSON_CACHE_FILE
+  fi
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
+        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.singleServerConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $ENTERPRISE_REDISSON_CACHE_FILE
+  fi
 fi
+replace_key_value eventsFramework.redis.userName $EVENTS_FRAMEWORK_REDIS_USERNAME
+replace_key_value eventsFramework.redis.password $EVENTS_FRAMEWORK_REDIS_PASSWORD
+replace_key_value redisLockConfig.userName $LOCK_CONFIG_REDIS_USERNAME
+replace_key_value redisLockConfig.password $LOCK_CONFIG_REDIS_PASSWORD

--- a/120-ng-manager/container/scripts/replace_configs.sh
+++ b/120-ng-manager/container/scripts/replace_configs.sh
@@ -581,3 +581,24 @@ replace_key_value subscriptionConfig.stripeApiKey "$STRIPE_API_KEY"
 replace_key_value enableOpentelemetry "$ENABLE_OPENTELEMETRY"
 
 replace_key_value chaosServiceClientConfig.baseUrl "$CHAOS_SERVICE_BASE_URL"
+
+if [[ "$EVENTS_FRAMEWORK_USE_SENTINEL" == "true" ]]; then
+  yq -i 'del(.singleServerConfig)' $REDISSON_CACHE_FILE
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
+      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.sentinelServersConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $REDISSON_CACHE_FILE
+  fi
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
+        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.sentinelServersConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $REDISSON_CACHE_FILE
+  fi
+  yq -i 'del(.singleServerConfig)' $ENTERPRISE_REDISSON_CACHE_FILE
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
+      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.sentinelServersConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $ENTERPRISE_REDISSON_CACHE_FILE
+  fi
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
+        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.sentinelServersConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $ENTERPRISE_REDISSON_CACHE_FILE
+  fi
+  replace_key_value eventsFramework.redis.userName $EVENTS_FRAMEWORK_REDIS_USERNAME
+  replace_key_value eventsFramework.redis.password $EVENTS_FRAMEWORK_REDIS_PASSWORD
+  replace_key_value redisLockConfig.userName $LOCK_CONFIG_REDIS_USERNAME
+  replace_key_value redisLockConfig.password $LOCK_CONFIG_REDIS_PASSWORD
+fi

--- a/120-ng-manager/container/scripts/replace_configs.sh
+++ b/120-ng-manager/container/scripts/replace_configs.sh
@@ -16,6 +16,15 @@ replace_key_value () {
   fi
 }
 
+replace_key_value () {
+  CONFIG_KEY="$1";
+  CONFIG_VALUE="$2";
+  FILE="$3";
+  if [[ "" != "$CONFIG_VALUE" ]]; then
+    export CONFIG_VALUE; export CONFIG_KEY; export CONFIG_KEY=.$CONFIG_KEY; yq -i 'eval(strenv(CONFIG_KEY))=env(CONFIG_VALUE)' $FILE
+  fi
+}
+
 write_mongo_hosts_and_ports() {
   IFS=',' read -ra HOST_AND_PORT <<< "$2"
   for INDEX in "${!HOST_AND_PORT[@]}"; do
@@ -584,34 +593,18 @@ replace_key_value chaosServiceClientConfig.baseUrl "$CHAOS_SERVICE_BASE_URL"
 
 if [[ "$EVENTS_FRAMEWORK_USE_SENTINEL" == "true" ]]; then
   yq -i 'del(.singleServerConfig)' $REDISSON_CACHE_FILE
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
-      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.sentinelServersConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $REDISSON_CACHE_FILE
-  fi
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
-        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.sentinelServersConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $REDISSON_CACHE_FILE
-  fi
+  replace_key_value sentinelServersConfig.userName $EVENTS_FRAMEWORK_REDIS_USERNAME $REDISSON_CACHE_FILE
+  replace_key_value sentinelServersConfig.password $EVENTS_FRAMEWORK_REDIS_PASSWORD $REDISSON_CACHE_FILE
   yq -i 'del(.singleServerConfig)' $ENTERPRISE_REDISSON_CACHE_FILE
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
-      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.sentinelServersConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $ENTERPRISE_REDISSON_CACHE_FILE
-  fi
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
-        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.sentinelServersConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $ENTERPRISE_REDISSON_CACHE_FILE
-  fi
+  replace_key_value sentinelServersConfig.userName $EVENTS_FRAMEWORK_REDIS_USERNAME $ENTERPRISE_REDISSON_CACHE_FILE
+  replace_key_value sentinelServersConfig.password $EVENTS_FRAMEWORK_REDIS_PASSWORD $ENTERPRISE_REDISSON_CACHE_FILE
 else
   yq -i 'del(.sentinelServersConfig)' $REDISSON_CACHE_FILE
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
-      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.singleServerConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $REDISSON_CACHE_FILE
-  fi
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
-        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.singleServerConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $REDISSON_CACHE_FILE
-  fi
+  replace_key_value singleServerConfig.userName $EVENTS_FRAMEWORK_REDIS_USERNAME $REDISSON_CACHE_FILE
+  replace_key_value singleServerConfig.password $EVENTS_FRAMEWORK_REDIS_PASSWORD $REDISSON_CACHE_FILE
   yq -i 'del(.sentinelServersConfig)' $ENTERPRISE_REDISSON_CACHE_FILE
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
-      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.singleServerConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $ENTERPRISE_REDISSON_CACHE_FILE
-  fi
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
-        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.singleServerConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $ENTERPRISE_REDISSON_CACHE_FILE
-  fi
+  replace_key_value singleServerConfig.userName $EVENTS_FRAMEWORK_REDIS_USERNAME $ENTERPRISE_REDISSON_CACHE_FILE
+  replace_key_value singleServerConfig.password $EVENTS_FRAMEWORK_REDIS_PASSWORD $ENTERPRISE_REDISSON_CACHE_FILE
 fi
 replace_key_value eventsFramework.redis.userName $EVENTS_FRAMEWORK_REDIS_USERNAME
 replace_key_value eventsFramework.redis.password $EVENTS_FRAMEWORK_REDIS_PASSWORD

--- a/dockerization/ng-manager/scripts/replace_configs.sh
+++ b/dockerization/ng-manager/scripts/replace_configs.sh
@@ -592,3 +592,25 @@ replace_key_value gitopsResourceClientConfig.config.baseUrl "$GITOPS_SERVICE_CLI
 replace_key_value gitopsResourceClientConfig.secret "$GITOPS_SERVICE_SECRET"
 
 replace_key_value enableOpentelemetry "$ENABLE_OPENTELEMETRY"
+
+if [[ "$EVENTS_FRAMEWORK_USE_SENTINEL" == "true" ]]; then
+  yq -i 'del(.singleServerConfig)' $REDISSON_CACHE_FILE
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
+      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.sentinelServersConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $REDISSON_CACHE_FILE
+  fi
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
+        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.sentinelServersConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $REDISSON_CACHE_FILE
+  fi
+  yq -i 'del(.singleServerConfig)' $ENTERPRISE_REDISSON_CACHE_FILE
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
+      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.sentinelServersConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $ENTERPRISE_REDISSON_CACHE_FILE
+  fi
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
+        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.sentinelServersConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $ENTERPRISE_REDISSON_CACHE_FILE
+  fi
+  replace_key_value eventsFramework.redis.userName $EVENTS_FRAMEWORK_REDIS_USERNAME
+  replace_key_value eventsFramework.redis.password $EVENTS_FRAMEWORK_REDIS_PASSWORD
+  replace_key_value redisLockConfig.userName $LOCK_CONFIG_REDIS_USERNAME
+  replace_key_value redisLockConfig.password $LOCK_CONFIG_REDIS_PASSWORD
+fi
+

--- a/dockerization/ng-manager/scripts/replace_configs.sh
+++ b/dockerization/ng-manager/scripts/replace_configs.sh
@@ -608,9 +608,24 @@ if [[ "$EVENTS_FRAMEWORK_USE_SENTINEL" == "true" ]]; then
   if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
         export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.sentinelServersConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $ENTERPRISE_REDISSON_CACHE_FILE
   fi
-  replace_key_value eventsFramework.redis.userName $EVENTS_FRAMEWORK_REDIS_USERNAME
-  replace_key_value eventsFramework.redis.password $EVENTS_FRAMEWORK_REDIS_PASSWORD
-  replace_key_value redisLockConfig.userName $LOCK_CONFIG_REDIS_USERNAME
-  replace_key_value redisLockConfig.password $LOCK_CONFIG_REDIS_PASSWORD
+else
+  yq -i 'del(.sentinelServersConfig)' $REDISSON_CACHE_FILE
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
+      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.singleServerConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $REDISSON_CACHE_FILE
+  fi
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
+        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.singleServerConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $REDISSON_CACHE_FILE
+  fi
+  yq -i 'del(.sentinelServersConfig)' $ENTERPRISE_REDISSON_CACHE_FILE
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
+      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.singleServerConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $ENTERPRISE_REDISSON_CACHE_FILE
+  fi
+  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
+        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.singleServerConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $ENTERPRISE_REDISSON_CACHE_FILE
+  fi
 fi
+replace_key_value eventsFramework.redis.userName $EVENTS_FRAMEWORK_REDIS_USERNAME
+replace_key_value eventsFramework.redis.password $EVENTS_FRAMEWORK_REDIS_PASSWORD
+replace_key_value redisLockConfig.userName $LOCK_CONFIG_REDIS_USERNAME
+replace_key_value redisLockConfig.password $LOCK_CONFIG_REDIS_PASSWORD
 

--- a/dockerization/ng-manager/scripts/replace_configs.sh
+++ b/dockerization/ng-manager/scripts/replace_configs.sh
@@ -16,6 +16,15 @@ replace_key_value () {
   fi
 }
 
+replace_key_value () {
+  CONFIG_KEY="$1";
+  CONFIG_VALUE="$2";
+  FILE="$3";
+  if [[ "" != "$CONFIG_VALUE" ]]; then
+    export CONFIG_VALUE; export CONFIG_KEY; export CONFIG_KEY=.$CONFIG_KEY; yq -i 'eval(strenv(CONFIG_KEY))=env(CONFIG_VALUE)' $FILE
+  fi
+}
+
 write_mongo_hosts_and_ports() {
   IFS=',' read -ra HOST_AND_PORT <<< "$2"
   for INDEX in "${!HOST_AND_PORT[@]}"; do
@@ -595,34 +604,18 @@ replace_key_value enableOpentelemetry "$ENABLE_OPENTELEMETRY"
 
 if [[ "$EVENTS_FRAMEWORK_USE_SENTINEL" == "true" ]]; then
   yq -i 'del(.singleServerConfig)' $REDISSON_CACHE_FILE
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
-      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.sentinelServersConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $REDISSON_CACHE_FILE
-  fi
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
-        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.sentinelServersConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $REDISSON_CACHE_FILE
-  fi
+  replace_key_value sentinelServersConfig.userName $EVENTS_FRAMEWORK_REDIS_USERNAME $REDISSON_CACHE_FILE
+  replace_key_value sentinelServersConfig.password $EVENTS_FRAMEWORK_REDIS_PASSWORD $REDISSON_CACHE_FILE
   yq -i 'del(.singleServerConfig)' $ENTERPRISE_REDISSON_CACHE_FILE
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
-      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.sentinelServersConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $ENTERPRISE_REDISSON_CACHE_FILE
-  fi
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
-        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.sentinelServersConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $ENTERPRISE_REDISSON_CACHE_FILE
-  fi
+  replace_key_value sentinelServersConfig.userName $EVENTS_FRAMEWORK_REDIS_USERNAME $ENTERPRISE_REDISSON_CACHE_FILE
+  replace_key_value sentinelServersConfig.password $EVENTS_FRAMEWORK_REDIS_PASSWORD $ENTERPRISE_REDISSON_CACHE_FILE
 else
   yq -i 'del(.sentinelServersConfig)' $REDISSON_CACHE_FILE
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
-      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.singleServerConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $REDISSON_CACHE_FILE
-  fi
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
-        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.singleServerConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $REDISSON_CACHE_FILE
-  fi
+  replace_key_value singleServerConfig.userName $EVENTS_FRAMEWORK_REDIS_USERNAME $REDISSON_CACHE_FILE
+  replace_key_value singleServerConfig.password $EVENTS_FRAMEWORK_REDIS_PASSWORD $REDISSON_CACHE_FILE
   yq -i 'del(.sentinelServersConfig)' $ENTERPRISE_REDISSON_CACHE_FILE
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_USERNAME" ]]; then
-      export EVENTS_FRAMEWORK_REDIS_USERNAME; yq -i '.singleServerConfig.userName=env(EVENTS_FRAMEWORK_REDIS_USERNAME)' $ENTERPRISE_REDISSON_CACHE_FILE
-  fi
-  if [[ "" != "$EVENTS_FRAMEWORK_REDIS_PASSWORD" ]]; then
-        export EVENTS_FRAMEWORK_REDIS_PASSWORD; yq -i '.singleServerConfig.userName=env($EVENTS_FRAMEWORK_REDIS_PASSWORD)' $ENTERPRISE_REDISSON_CACHE_FILE
-  fi
+  replace_key_value singleServerConfig.userName $EVENTS_FRAMEWORK_REDIS_USERNAME $ENTERPRISE_REDISSON_CACHE_FILE
+  replace_key_value singleServerConfig.password $EVENTS_FRAMEWORK_REDIS_PASSWORD $ENTERPRISE_REDISSON_CACHE_FILE
 fi
 replace_key_value eventsFramework.redis.userName $EVENTS_FRAMEWORK_REDIS_USERNAME
 replace_key_value eventsFramework.redis.password $EVENTS_FRAMEWORK_REDIS_PASSWORD


### PR DESCRIPTION
Redis is used in 3 ways: Distributed Locking, Events Framework and Caching.
Currently, redis Username and password is exposed in config.yaml for locking and events. However, for caching it is expecting to store the username and password under redisson-jcache.yaml or enterprise-redisson-jcache.yaml.
However, the current implementation stores the username and password under singleServerConfig and no variable is exposed to be used to be under sentinelServerConfig. 
This PR puts username and password under sentinelServerConfig so redis is properly supporting sentinels with username and password.

- Support Redis Username and Password in sentinels in ng-manager

## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- TI-ALL: `trigger tiAll`
- TI-bootstrap: `trigger ti0`
- TI-bootstrap1: `trigger ti1`
- TI-bootstrap2: `trigger ti2`
- TI-bootstrap3: `trigger ti3`
- TI-bootstrap4: `trigger ti4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/44040)
<!-- Reviewable:end -->
