### PR TITLE
fix: [CDS-48989]: fixed Nexus3 https requests to go through proxy

### DIFF
--- a/260-delegate/src/main/java/io/harness/delegate/app/DelegateAgentApplication.java
+++ b/260-delegate/src/main/java/io/harness/delegate/app/DelegateAgentApplication.java
@@ -10,7 +10,6 @@ package io.harness.delegate.app;
 import static io.harness.logging.LoggingInitializer.initializeLogging;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import io.harness.configuration.DeployMode;
 import io.harness.delegate.app.modules.DelegateAgentModule;
@@ -19,6 +18,7 @@ import io.harness.delegate.configuration.DelegateConfiguration;
 import io.harness.delegate.metrics.DelegateAgentMetricResource;
 import io.harness.delegate.metrics.DelegateAgentMetrics;
 import io.harness.delegate.service.DelegateAgentService;
+import io.harness.delegate.utils.ProxyUtils;
 import io.harness.event.client.EventPublisher;
 import io.harness.health.HealthMonitor;
 import io.harness.health.HealthService;
@@ -69,16 +69,7 @@ public class DelegateAgentApplication extends Application<DelegateAgentConfig> {
   }
 
   private static void setupProxyConfig() {
-    final String proxyUser = System.getenv("PROXY_USER");
-    if (isNotBlank(proxyUser)) {
-      System.setProperty("http.proxyUser", proxyUser);
-      System.setProperty("https.proxyUser", proxyUser);
-    }
-    final String proxyPassword = System.getenv("PROXY_PASSWORD");
-    if (isNotBlank(proxyPassword)) {
-      System.setProperty("http.proxyPassword", proxyPassword);
-      System.setProperty("https.proxyPassword", proxyPassword);
-    }
+    ProxyUtils.initProxyConfig();
   }
 
   @Override

--- a/260-delegate/src/main/java/io/harness/delegate/app/DelegateApplication.java
+++ b/260-delegate/src/main/java/io/harness/delegate/app/DelegateApplication.java
@@ -19,7 +19,6 @@ import static io.harness.delegate.message.MessengerType.WATCHER;
 import static io.harness.logging.LoggingInitializer.initializeLogging;
 
 import static com.google.common.base.Charsets.UTF_8;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import io.harness.annotations.dev.BreakDependencyOn;
 import io.harness.annotations.dev.TargetModule;
@@ -28,6 +27,7 @@ import io.harness.delegate.app.modules.DelegateAgentModule;
 import io.harness.delegate.configuration.DelegateConfiguration;
 import io.harness.delegate.message.MessageService;
 import io.harness.delegate.service.DelegateAgentService;
+import io.harness.delegate.utils.ProxyUtils;
 import io.harness.event.client.EventPublisher;
 import io.harness.serializer.YamlUtils;
 import io.harness.threading.ExecutorModule;
@@ -69,16 +69,7 @@ public class DelegateApplication {
 
   public static void main(String... args) throws IOException {
     try {
-      String proxyUser = System.getenv("PROXY_USER");
-      if (isNotBlank(proxyUser)) {
-        System.setProperty("http.proxyUser", proxyUser);
-        System.setProperty("https.proxyUser", proxyUser);
-      }
-      String proxyPassword = System.getenv("PROXY_PASSWORD");
-      if (isNotBlank(proxyPassword)) {
-        System.setProperty("http.proxyPassword", proxyPassword);
-        System.setProperty("https.proxyPassword", proxyPassword);
-      }
+      ProxyUtils.initProxyConfig();
 
       File configFile = new File(args[0]);
       configuration = new YamlUtils().read(FileUtils.readFileToString(configFile, UTF_8), DelegateConfiguration.class);

--- a/260-delegate/src/main/java/io/harness/delegate/utils/ProxyUtils.java
+++ b/260-delegate/src/main/java/io/harness/delegate/utils/ProxyUtils.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.delegate.utils;
+
+import static io.harness.data.structure.EmptyPredicate.isEmpty;
+import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
+import static io.harness.network.Http.getProxyHostName;
+import static io.harness.network.Http.getProxyPassword;
+import static io.harness.network.Http.getProxyPort;
+import static io.harness.network.Http.getProxyUserName;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+
+@OwnedBy(HarnessTeam.DEL)
+public class ProxyUtils {
+  public static void initProxyConfig() {
+    String proxyUserEnv = System.getenv("PROXY_USER");
+    if (isNotBlank(proxyUserEnv)) {
+      System.setProperty("http.proxyUser", proxyUserEnv);
+      System.setProperty("https.proxyUser", proxyUserEnv);
+    }
+
+    String proxyPasswordEnv = System.getenv("PROXY_PASSWORD");
+    if (isNotBlank(proxyPasswordEnv)) {
+      System.setProperty("http.proxyPassword", proxyPasswordEnv);
+      System.setProperty("https.proxyPassword", proxyPasswordEnv);
+    }
+
+    String proxyHost = getProxyHostName();
+    String proxyPort = getProxyPort();
+    String proxyUser = getProxyUserName();
+    String proxyPassword = getProxyPassword();
+
+    validateProxyProperties(proxyHost, proxyPort, proxyUser, proxyPassword);
+
+    if (isProxyAuthUsed()) {
+      /**
+       * If url to be proxied is `https` protocol
+       * and one of these system properties is present using System#getProperty():
+       * [https.proxyUser, https.proxyPassword, https.proxyHost, https.proxyPort]
+       * then URL#openConnection() fails with error: Unable to tunnel through proxy. Proxy returns “HTTP/1.1 407”
+       *
+       * This scenario is possible if one of these env vars PROXY_USER or PROXY_PASSWORD is not empty
+       * or if System.getProperty("proxyScheme") is NOT "http", refer io.harness.network.Http#getHttpProxyHost() logic.
+       *
+       * In order a https request to be proxied correctly Proxy should be provided as argument URL#openConnection(Proxy
+       * proxy) A custom Authenticator should be used and disable these properties:
+       * jdk.http.auth.tunneling.disabledSchemes, jdk.http.auth.proxying.disabledSchemes
+       * refer https://www.oracle.com/java/technologies/javase/8u111-relnotes.html
+       */
+
+      Authenticator.setDefault(new Authenticator() {
+        @Override
+        protected PasswordAuthentication getPasswordAuthentication() {
+          if (getRequestorType().equals(RequestorType.PROXY)) {
+            return new PasswordAuthentication(proxyUser, proxyPassword.toCharArray());
+          }
+          return super.getPasswordAuthentication();
+        }
+      });
+
+      System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
+      System.setProperty("jdk.http.auth.proxying.disabledSchemes", "");
+    }
+  }
+
+  static boolean isProxyAuthUsed() {
+    return isNotEmpty(getProxyUserName());
+  }
+
+  static void validateProxyProperties(String proxyHost, String proxyPort, String proxyUser, String proxyPassword) {
+    if (isNotEmpty(proxyHost) && isEmpty(proxyPort)) {
+      throw new IllegalArgumentException("proxyHost provided, but proxyPort is empty");
+    }
+    if (isNotEmpty(proxyPort) && isEmpty(proxyHost)) {
+      throw new IllegalArgumentException("proxyPort provided, but proxyHost is empty");
+    }
+
+    if (isNotEmpty(proxyPort)) {
+      try {
+        Integer.parseInt(proxyPort);
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException(format("Invalid proxyPort provided %s", proxyPort));
+      }
+    }
+
+    if (isNotEmpty(proxyUser) && isEmpty(proxyPassword)) {
+      throw new IllegalArgumentException("proxyUser provided, but proxyPassword is empty");
+    }
+    if (isNotEmpty(proxyPassword) && isEmpty(proxyUser)) {
+      throw new IllegalArgumentException("proxyPassword provided, but proxyUser is empty");
+    }
+
+    if (isNotEmpty(proxyUser) && isEmpty(proxyHost)) {
+      throw new IllegalArgumentException("proxyUser provided, but proxyHost is empty");
+    }
+  }
+}


### PR DESCRIPTION
## Describe your changes
There are 2 issues at the moment when using `URL#openConnection()`
1. **https** requests are not proxied
2. If one of these properties is not empty [https.proxyUser, https.proxyPassword, https.proxyHost, https.proxyPort] and a 
    **https** request is made it fails with error: Unable to tunnel through proxy. Proxy returns “HTTP/1.1 407” 

Second scenario is possible if one of these env vars PROXY_USER or PROXY_PASSWORD is not empty
or if System.getProperty("proxyScheme") is NOT "http", refer io.harness.network.Http#getHttpProxyHost() logic.

In order a **https** request to be proxied correctly a custom Authenticator should be used and disable these properties:
`jdk.http.auth.tunneling.disabledSchemes`, `jdk.http.auth.proxying.disabledSchemes` 
This will whitelist `Basic` authentication for **https** requests
refer https://www.oracle.com/java/technologies/javase/8u111-relnotes.html (Disable Basic authentication for HTTPS tunneling)
    

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/44302)
<!-- Reviewable:end -->
