### PR TITLE
fix:[CDS-54086]: Add validation to avoid ClassCastException

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/GitFileConfigHelperService.java
+++ b/400-rest/src/main/java/software/wings/service/impl/GitFileConfigHelperService.java
@@ -151,6 +151,13 @@ public class GitFileConfigHelperService {
       throw new InvalidRequestException("Invalid git connector provided.", USER);
     }
 
+    if (!(settingAttribute.getValue() instanceof GitConfig)) {
+      throw new InvalidRequestException(
+          String.format("Invalid git connector provided [connectorId=%s, name=%s, type=%s]",
+              gitFileConfig.getConnectorId(), settingAttribute.getName(), settingAttribute.getValue().getType()),
+          USER);
+    }
+
     GitConfig gitConfig = (GitConfig) settingAttribute.getValue();
     if (GitConfig.UrlType.ACCOUNT == gitConfig.getUrlType() && isBlank(gitFileConfig.getRepoName())) {
       throw new InvalidRequestException("Repository name not provided for Account level git connector.", USER);

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
 build.number=77631
-build.patch=000
+build.patch=001
 delegate.version=22.11.11
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes
- When YAML has a reference to an invalid connector it throws a ClassCastException.
- Now we identify the wrong setting and provide a better message

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/44316)
<!-- Reviewable:end -->
