### PR TITLE
fix:[DEL-5969]: Failing all running task associated to a delegate if …

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
@@ -2604,6 +2604,17 @@ public class DelegateServiceImpl implements DelegateService {
     final Delegate existingDelegate = getExistingDelegate(delegateParams.getAccountId(), delegateParams.getHostName(),
         delegateParams.isNg(), delegateParams.getDelegateType(), delegateParams.getIp());
 
+    // this code is to mark all the task in running as failed if same delegate registration for immutable
+    // this should not impact any functionality wrt legacy delegate
+    if ((existingDelegate != null) && (existingDelegate.isImmutable())) {
+      try {
+        onDelegateDisconnected(delegateParams.getAccountId(), existingDelegate.getUuid());
+      } catch (Exception e) {
+        log.error(
+                "Couldn't delete the task associated with existing delegate: {}", existingDelegate.getUuid(), e);
+      }
+    }
+
     if (existingDelegate != null && existingDelegate.getStatus() == DelegateInstanceStatus.DELETED) {
       broadcasterFactory.lookup(STREAM_DELEGATE + delegateParams.getAccountId(), true)
           .broadcast(SELF_DESTRUCT + existingDelegate.getUuid());

--- a/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
@@ -2610,8 +2610,7 @@ public class DelegateServiceImpl implements DelegateService {
       try {
         onDelegateDisconnected(delegateParams.getAccountId(), existingDelegate.getUuid());
       } catch (Exception e) {
-        log.error(
-                "Couldn't delete the task associated with existing delegate: {}", existingDelegate.getUuid(), e);
+        log.error("Couldn't delete the task associated with existing delegate: {}", existingDelegate.getUuid(), e);
       }
     }
 


### PR DESCRIPTION
…same delegate registration happens

## Describe your changes
**Goal**: We want to fail/end all running task associated to a delegate if same delegate registration happens for imutable

**Solution**:
During execution of registration, if we find delegate already exists, we make a call to mark all task as failed.
We are catching the exception here as we don't want user to be blocked even if failing of task is not successful for some reason.

**Tests**: 
Install an Immutable k8 delegate and execute task and kill delegate process for it to come up again. Here new host came up.
Tested upgrade of delegate version and registration.
Tested upgrade and downgrade of legacy delegate during multiple task execution


<img width="1691" alt="a1" src="https://user-images.githubusercontent.com/95602529/221633174-c5c25593-dd01-4288-a2d9-772bb3539693.png">

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/44426)
<!-- Reviewable:end -->
