### PR TITLE
[feat]: [PIE-8662]: Updating the overlay inputset validation to perform metadata call

### DIFF
--- a/pipeline-service/service/src/main/java/io/harness/pms/ngpipeline/inputset/service/OverlayInputSetValidationHelper.java
+++ b/pipeline-service/service/src/main/java/io/harness/pms/ngpipeline/inputset/service/OverlayInputSetValidationHelper.java
@@ -146,17 +146,17 @@ public class OverlayInputSetValidationHelper {
               .gitBranchInfo(GitEntityInfo.builder().branch(baseBranch).yamlGitConfigId(repoIdentifier).build())
               .build();
       try (PmsGitSyncBranchContextGuard ignored = new PmsGitSyncBranchContextGuard(branchContext, true)) {
-        return findAllReferredInputSetsInternal(
+        return findAllReferredInputSetsMetadata(
             inputSetService, referencesInOverlay, accountId, orgIdentifier, projectIdentifier, pipelineIdentifier);
       }
     } else {
-      return findAllReferredInputSetsInternal(
+      return findAllReferredInputSetsMetadata(
           inputSetService, referencesInOverlay, accountId, orgIdentifier, projectIdentifier, pipelineIdentifier);
     }
   }
 
   // todo: optimise this
-  private List<Optional<InputSetEntity>> findAllReferredInputSetsInternal(PMSInputSetService inputSetService,
+  private List<Optional<InputSetEntity>> findAllReferredInputSetsMetadata(PMSInputSetService inputSetService,
       List<String> referencesInOverlay, String accountId, String orgIdentifier, String projectIdentifier,
       String pipelineIdentifier) {
     List<Optional<InputSetEntity>> inputSets = new ArrayList<>();
@@ -164,8 +164,8 @@ public class OverlayInputSetValidationHelper {
       if (EmptyPredicate.isEmpty(identifier)) {
         throw new InvalidRequestException("Empty Input Set Identifier not allowed in Input Set References");
       }
-      inputSets.add(inputSetService.getWithoutValidations(
-          accountId, orgIdentifier, projectIdentifier, pipelineIdentifier, identifier, false, false));
+      inputSets.add(inputSetService.getMetadataWithoutValidations(
+          accountId, orgIdentifier, projectIdentifier, pipelineIdentifier, identifier, false, false, true));
     });
     return inputSets;
   }
@@ -179,7 +179,7 @@ public class OverlayInputSetValidationHelper {
     String yaml = inputSetEntity.getYaml();
 
     List<String> currentReferences = InputSetYamlHelper.getReferencesFromOverlayInputSetYaml(yaml);
-    List<Optional<InputSetEntity>> inputSets = findAllReferredInputSetsInternal(
+    List<Optional<InputSetEntity>> inputSets = findAllReferredInputSetsMetadata(
         inputSetService, currentReferences, accountId, orgIdentifier, projectIdentifier, pipelineIdentifier);
     Map<String, String> invalidReferencesWithErrors =
         InputSetErrorsHelper.getInvalidInputSetReferences(inputSets, currentReferences, pipelineYaml);

--- a/pipeline-service/service/src/test/java/io/harness/pms/ngpipeline/inputset/service/OverlayInputSetValidationHelperTest.java
+++ b/pipeline-service/service/src/test/java/io/harness/pms/ngpipeline/inputset/service/OverlayInputSetValidationHelperTest.java
@@ -153,7 +153,7 @@ public class OverlayInputSetValidationHelperTest extends CategoryTest {
     InputSetEntity inputSetEntity1 = InputSetEntity.builder().inputSetEntityType(INPUT_SET).yaml(inputSetYaml1).build();
     doReturn(Optional.of(inputSetEntity1))
         .when(inputSetService)
-        .getWithoutValidations(accountId, orgId, projectId, pipelineId, identifier1, false, false);
+        .getMetadataWithoutValidations(accountId, orgId, projectId, pipelineId, identifier1, false, false, true);
 
     String inputSetFile2 = "inputSetWrong1.yml";
     String inputSetYaml2 = readFile(inputSetFile2);
@@ -161,7 +161,7 @@ public class OverlayInputSetValidationHelperTest extends CategoryTest {
     InputSetEntity inputSetEntity2 = InputSetEntity.builder().inputSetEntityType(INPUT_SET).yaml(inputSetYaml2).build();
     doReturn(Optional.of(inputSetEntity2))
         .when(inputSetService)
-        .getWithoutValidations(accountId, orgId, projectId, pipelineId, identifier2, false, false);
+        .getMetadataWithoutValidations(accountId, orgId, projectId, pipelineId, identifier2, false, false, true);
 
     String overlayInputSetYaml = getOverlayInputSetWithAllIds(true);
     InputSetEntity inputSetEntity = InputSetEntity.builder()
@@ -195,7 +195,8 @@ public class OverlayInputSetValidationHelperTest extends CategoryTest {
                                         .build();
     doReturn(Optional.empty())
         .when(inputSetService)
-        .getWithoutValidations(accountId, orgId, projectId, pipelineId, nonExistentReference, false, false);
+        .getMetadataWithoutValidations(
+            accountId, orgId, projectId, pipelineId, nonExistentReference, false, false, true);
     assertThatThrownBy(() -> OverlayInputSetValidationHelper.validateOverlayInputSet(inputSetService, inputSetEntity))
         .isInstanceOf(InvalidOverlayInputSetException.class);
   }
@@ -252,10 +253,11 @@ public class OverlayInputSetValidationHelperTest extends CategoryTest {
     String yaml = getOverlayInputSetWithAllIds(true);
     doReturn(Optional.of(InputSetEntity.builder().inputSetEntityType(INPUT_SET).isInvalid(false).build()))
         .when(inputSetService)
-        .getWithoutValidations(accountId, orgId, projectId, pipelineId, "input1", false, false);
+        .getMetadataWithoutValidations(accountId, orgId, projectId, pipelineId, "input1", false, false, true);
     doReturn(Optional.empty())
         .when(inputSetService)
-        .getWithoutValidations(accountId, orgId, projectId, pipelineId, "thisInputSetIsWrong", false, false);
+        .getMetadataWithoutValidations(
+            accountId, orgId, projectId, pipelineId, "thisInputSetIsWrong", false, false, true);
 
     MockedStatic<InputSetErrorsHelper> mockSettings = Mockito.mockStatic(InputSetErrorsHelper.class);
     when(InputSetErrorsHelper.getInvalidInputSetReferences(any(), any(), any())).thenCallRealMethod();
@@ -287,10 +289,11 @@ public class OverlayInputSetValidationHelperTest extends CategoryTest {
     String yaml = getOverlayInputSetWithAllIds(true);
     doReturn(Optional.empty())
         .when(inputSetService)
-        .getWithoutValidations(accountId, orgId, projectId, pipelineId, "input1", false, false);
+        .getMetadataWithoutValidations(accountId, orgId, projectId, pipelineId, "input1", false, false, true);
     doReturn(Optional.empty())
         .when(inputSetService)
-        .getWithoutValidations(accountId, orgId, projectId, pipelineId, "thisInputSetIsWrong", false, false);
+        .getMetadataWithoutValidations(
+            accountId, orgId, projectId, pipelineId, "thisInputSetIsWrong", false, false, true);
     doReturn(false).when(gitSyncSdkService).isGitSyncEnabled(accountId, orgId, projectId);
     doReturn(Collections.emptyList()).when(inputSetService).list(any());
     InputSetEntity inputSetEntity = InputSetEntity.builder()
@@ -355,7 +358,7 @@ public class OverlayInputSetValidationHelperTest extends CategoryTest {
                                          .build();
     doReturn(Optional.of(updatedInputSet))
         .when(inputSetService)
-        .getWithoutValidations(accountId, orgId, projectId, pipelineId, "i1", false, false);
+        .getMetadataWithoutValidations(accountId, orgId, projectId, pipelineId, "i1", false, false, true);
     OverlayInputSetValidationHelper.validateOverlayInputSetsForGivenInputSet(inputSetService, updatedInputSet);
     verify(inputSetService, times(1)).switchValidationFlag(overlay1, false);
     verify(inputSetService, times(0)).switchValidationFlag(overlay2, false);


### PR DESCRIPTION
## Describe your changes
In the overlay input set validation, changed the list of get input set remote call to metadata call as the validations were done on the metadata and not the yaml. Have tested out the create, update and get flows for overlay input sets.

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/44526)
<!-- Reviewable:end -->
