### PR TITLE
fix:[DEL-6041]: Updating messaging for Immutable to restarted then di…

### DIFF
--- a/400-rest/src/main/java/io/harness/ccm/KubernetesClusterHandler.java
+++ b/400-rest/src/main/java/io/harness/ccm/KubernetesClusterHandler.java
@@ -55,7 +55,7 @@ public class KubernetesClusterHandler implements DelegateObserver {
   }
 
   @Override
-  public void onDisconnected(String accountId, String delegateId) {
+  public void onDisconnected(String accountId, String delegateId, String reasonOfDisconnection) {
     // do nothing
   }
 

--- a/400-rest/src/main/java/io/harness/iterator/DelegateDisconnectDetectorIterator.java
+++ b/400-rest/src/main/java/io/harness/iterator/DelegateDisconnectDetectorIterator.java
@@ -7,6 +7,7 @@
 
 package io.harness.iterator;
 
+import static io.harness.delegate.utils.DelegateServiceConstants.EMPTY_STR;
 import static io.harness.logging.AutoLogContext.OverrideBehavior.OVERRIDE_ERROR;
 import static io.harness.mongo.iterator.MongoPersistenceIterator.SchedulingType.REGULAR;
 
@@ -112,7 +113,7 @@ public class DelegateDisconnectDetectorIterator
     try (AutoLogContext ignore1 = new DelegateLogContext(delegate.getUuid(), OVERRIDE_ERROR);
          AccountLogContext ignore2 = new AccountLogContext(delegate.getAccountId(), OVERRIDE_ERROR)) {
       // trigger disconnect event which marks started delegate task as expired and PT's as unassigned
-      delegateService.onDelegateDisconnected(delegate.getAccountId(), delegate.getUuid());
+      delegateService.onDelegateDisconnected(delegate.getAccountId(), delegate.getUuid(), EMPTY_STR);
       // mark delegate as disconnected
       delegateDao.delegateDisconnected(delegate.getAccountId(), delegate.getUuid());
       delegateService.updateLastExpiredEventHeartbeatTime(

--- a/400-rest/src/main/java/io/harness/perpetualtask/PerpetualTaskServiceImpl.java
+++ b/400-rest/src/main/java/io/harness/perpetualtask/PerpetualTaskServiceImpl.java
@@ -398,7 +398,7 @@ public class PerpetualTaskServiceImpl implements PerpetualTaskService, DelegateO
   }
 
   @Override
-  public void onDisconnected(String accountId, String delegateId) {
+  public void onDisconnected(String accountId, String delegateId, String reasonOfDisconnection) {
     perpetualTaskRecordDao.markAllTasksOnDelegateForReassignment(accountId, delegateId);
   }
 

--- a/400-rest/src/main/java/software/wings/scheduler/DelegateDisconnectAlertHelper.java
+++ b/400-rest/src/main/java/software/wings/scheduler/DelegateDisconnectAlertHelper.java
@@ -92,7 +92,7 @@ public class DelegateDisconnectAlertHelper implements DelegateObserver {
   }
 
   @Override
-  public void onDisconnected(String accountId, String delegateId) {
+  public void onDisconnected(String accountId, String delegateId, String reasonOfDisconnection) {
     Delegate delegate = delegateCache.get(accountId, delegateId, true);
     if (delegate == null) {
       return;

--- a/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
@@ -333,7 +333,6 @@ public class DelegateServiceImpl implements DelegateService {
   private static final String deployVersion = System.getenv(DEPLOY_VERSION);
   private static final String DELEGATES_UPDATED_RESPONSE = "Following delegates have been updated";
   private static final String NO_DELEGATES_UPDATED_RESPONSE = "No delegate is waiting for approval/rejection";
-  //private static final String REASON_OF_DISCONNECTION = "Delegate restarted";
 
   private static final long MAX_GRPC_HB_TIMEOUT = TimeUnit.MINUTES.toMillis(15);
 

--- a/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
@@ -3134,7 +3134,7 @@ public class DelegateServiceImpl implements DelegateService {
     Delegate delegate = delegateCache.get(accountId, delegateId, false);
     delegateMetricsService.recordDelegateMetrics(delegate, DELEGATE_DISCONNECTED);
     remoteObserverInformer.sendEvent(
-        ReflectionUtils.getMethod(DelegateObserver.class, "onDisconnected", String.class, String.class),
+        ReflectionUtils.getMethod(DelegateObserver.class, "onDisconnected", String.class, String.class, String.class),
         DelegateServiceImpl.class, accountId, delegateId);
   }
 

--- a/400-rest/src/main/java/software/wings/service/impl/DelegateTaskServiceClassicImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateTaskServiceClassicImpl.java
@@ -2008,7 +2008,7 @@ public class DelegateTaskServiceClassicImpl implements DelegateTaskServiceClassi
     if (delegate.isImmutable() && reasonOfDisconnection.equals("RESTARTED")) {
       errorSubMsg = "restarted while executing the task";
     }
-    final String errorMessage = "Delegate [" + delegate.getDelegateName() + "] "+ errorSubMsg;
+    final String errorMessage = "Delegate [" + delegate.getDelegateName() + "] " + errorSubMsg;
     final DelegateTaskResponse delegateTaskResponse =
         DelegateTaskResponse.builder()
             .responseCode(ResponseCode.FAILED)

--- a/400-rest/src/main/java/software/wings/service/impl/DelegateTaskServiceClassicImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateTaskServiceClassicImpl.java
@@ -2005,10 +2005,10 @@ public class DelegateTaskServiceClassicImpl implements DelegateTaskServiceClassi
         delegateTasks.stream().map(DelegateTask::getUuid).collect(Collectors.toList()));
     Delegate delegate = delegateCache.get(accountId, delegateId, false);
     String errorSubMsg = "disconnected while executing the task";
-    if (delegate.isImmutable() && reasonOfDisconnection.equals("RESTARTED")){
+    if (delegate.isImmutable() && reasonOfDisconnection.equals("RESTARTED")) {
       errorSubMsg = "restarted while executing the task";
     }
-    final String errorMessage = "Delegate [" + delegate.getDelegateName() + "] "+errorSubMsg;
+    final String errorMessage = "Delegate [" + delegate.getDelegateName() + "] "+ errorSubMsg;
     final DelegateTaskResponse delegateTaskResponse =
         DelegateTaskResponse.builder()
             .responseCode(ResponseCode.FAILED)

--- a/400-rest/src/main/java/software/wings/service/impl/DelegateTaskServiceClassicImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateTaskServiceClassicImpl.java
@@ -2005,7 +2005,7 @@ public class DelegateTaskServiceClassicImpl implements DelegateTaskServiceClassi
         delegateTasks.stream().map(DelegateTask::getUuid).collect(Collectors.toList()));
     Delegate delegate = delegateCache.get(accountId, delegateId, false);
     String errorSubMsg = "disconnected while executing the task";
-    if(delegate.isImmutable() && reasonOfDisconnection == "RESTARTED"){
+    if (delegate.isImmutable() && reasonOfDisconnection.equals("RESTARTED")){
       errorSubMsg = "restarted while executing the task";
     }
     final String errorMessage = "Delegate [" + delegate.getDelegateName() + "] "+errorSubMsg;

--- a/400-rest/src/main/java/software/wings/service/intfc/DelegateService.java
+++ b/400-rest/src/main/java/software/wings/service/intfc/DelegateService.java
@@ -186,7 +186,7 @@ public interface DelegateService extends OwnedByAccount {
 
   void delegateDisconnected(String accountId, String delegateId, String delegateConnectionId);
 
-  void onDelegateDisconnected(String accountId, String delegateId);
+  void onDelegateDisconnected(String accountId, String delegateId, String reasonOfDisconnection);
 
   void deleteAllDelegatesExceptOne(String accountId, long shutdownInterval);
 

--- a/400-rest/src/test/java/software/wings/scheduler/DelegateDisconnectDetectorIteratorTest.java
+++ b/400-rest/src/test/java/software/wings/scheduler/DelegateDisconnectDetectorIteratorTest.java
@@ -136,7 +136,7 @@ public class DelegateDisconnectDetectorIteratorTest extends WingsBaseTest {
     createAndAssignDelegateTasks(delegate);
     assertThat(getAlreadyStartedDelegateTask(ACCOUNT_ID, delegate.getUuid())).hasSize(3);
     delegateDisconnectDetectorIterator.handle(delegate);
-    delegateTaskServiceClassic.markAllTasksFailedForDelegate(ACCOUNT_ID, delegate.getUuid());
+    delegateTaskServiceClassic.markAllTasksFailedForDelegate(ACCOUNT_ID, delegate.getUuid(), "delegate disconnected");
     assertThat(getAlreadyStartedDelegateTask(ACCOUNT_ID, delegate.getUuid())).hasSize(0);
   }
 

--- a/400-rest/src/test/java/software/wings/scheduler/DelegateDisconnectDetectorIteratorTest.java
+++ b/400-rest/src/test/java/software/wings/scheduler/DelegateDisconnectDetectorIteratorTest.java
@@ -12,6 +12,7 @@ import static io.harness.beans.DelegateTask.Status.STARTED;
 import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
 import static io.harness.delegate.beans.TaskData.DEFAULT_SYNC_CALL_TIMEOUT;
 import static io.harness.delegate.task.mixin.HttpConnectionExecutionCapabilityGenerator.buildHttpConnectionExecutionCapability;
+import static io.harness.delegate.utils.DelegateServiceConstants.EMPTY_STR;
 import static io.harness.rule.OwnerRule.JENNY;
 
 import static software.wings.utils.WingsTestConstants.ACCOUNT_ID;
@@ -170,7 +171,7 @@ public class DelegateDisconnectDetectorIteratorTest extends WingsBaseTest {
     createPerpetualTaskRecordAndAssign(delegate.getUuid());
     assertThat(perpetualTaskService.listAssignedTasks(delegate.getUuid(), ACCOUNT_ID)).hasSize(1);
     delegateDisconnectDetectorIterator.handle(delegate);
-    verify(delegateObserver).onDisconnected(ACCOUNT_ID, delegate.getUuid());
+    verify(delegateObserver).onDisconnected(ACCOUNT_ID, delegate.getUuid(), EMPTY_STR);
   }
 
   private DelegateTask createDelegateTask(Delegate delegate) throws ExecutionException {

--- a/400-rest/src/test/java/software/wings/service/impl/DelegateServiceImplTest.java
+++ b/400-rest/src/test/java/software/wings/service/impl/DelegateServiceImplTest.java
@@ -11,6 +11,7 @@ import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
 import static io.harness.data.structure.UUIDGenerator.generateUuid;
 import static io.harness.delegate.beans.DelegateType.KUBERNETES;
 import static io.harness.delegate.beans.TaskData.DEFAULT_ASYNC_CALL_TIMEOUT;
+import static io.harness.delegate.utils.DelegateServiceConstants.EMPTY_STR;
 import static io.harness.rule.OwnerRule.ADWAIT;
 import static io.harness.rule.OwnerRule.ANUPAM;
 import static io.harness.rule.OwnerRule.ARPIT;
@@ -689,8 +690,8 @@ public class DelegateServiceImplTest extends WingsBaseTest {
     delegateService.getSubject().register(delegateObserver);
     String delegateId = generateUuid();
     String accountId = generateUuid();
-    delegateService.onDelegateDisconnected(accountId, delegateId);
-    verify(delegateObserver).onDisconnected(accountId, delegateId);
+    delegateService.onDelegateDisconnected(accountId, delegateId, EMPTY_STR);
+    verify(delegateObserver).onDisconnected(accountId, delegateId, EMPTY_STR);
   }
 
   @Test

--- a/420-delegate-service/src/main/java/io/harness/delegate/utils/DelegateServiceConstants.java
+++ b/420-delegate-service/src/main/java/io/harness/delegate/utils/DelegateServiceConstants.java
@@ -24,4 +24,9 @@ public interface DelegateServiceConstants {
   Duration HEARTBEAT_EXPIRY_TIME_FIVE_MINS = ofMinutes(5);
 
   String ACCOUNT_ID = "ACCOUNT_ID";
+
+  String REASON_OF_DISCONNECTION = "RESTARTED";
+
+  String EMPTY_STR = "";
+
 }

--- a/420-delegate-service/src/main/java/io/harness/delegate/utils/DelegateServiceConstants.java
+++ b/420-delegate-service/src/main/java/io/harness/delegate/utils/DelegateServiceConstants.java
@@ -28,5 +28,4 @@ public interface DelegateServiceConstants {
   String REASON_OF_DISCONNECTION = "RESTARTED";
 
   String EMPTY_STR = "";
-
 }

--- a/420-delegate-service/src/main/java/software/wings/service/impl/DelegateObserver.java
+++ b/420-delegate-service/src/main/java/software/wings/service/impl/DelegateObserver.java
@@ -11,7 +11,7 @@ import io.harness.delegate.beans.Delegate;
 
 public interface DelegateObserver {
   void onAdded(Delegate delegate);
-  void onDisconnected(String accountId, String delegateId);
+  void onDisconnected(String accountId, String delegateId, String reasonOfDisconnection);
   void onReconnected(Delegate delegate);
 
   void onDelegateTagsUpdated(String accountId);

--- a/420-delegate-service/src/main/java/software/wings/service/intfc/DelegateTaskServiceClassic.java
+++ b/420-delegate-service/src/main/java/software/wings/service/intfc/DelegateTaskServiceClassic.java
@@ -84,7 +84,7 @@ public interface DelegateTaskServiceClassic extends OwnedByAccount {
 
   boolean checkDelegateConnected(String accountId, String delegateId);
 
-  void markAllTasksFailedForDelegate(String accountId, String delegateId);
+  void markAllTasksFailedForDelegate(String accountId, String delegateId, String reasonOfDisconnection);
 
   void addToTaskActivityLog(DelegateTask task, String message);
 


### PR DESCRIPTION
…sconnected

## Describe your changes
**Goal**: We want to differentiate and show messages accordingly if an Immutable delegate is either restarted or disconnected.
This change is to take care of the same.

Test: 
1. Tested execution of task during upgrade, for failed task disconnected error is displayed as not same immutable del is registered
2. Tested Restart message in local via hardcoding and ensuring code flow goes through the change.
3. Validated No changes for legacy delegate in terms of messaging


## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/44623)
<!-- Reviewable:end -->
