### PR TITLE
fix: [SRM-14089]: Fixing NPE issue for Rolling verification type with no baseline data.

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
 build.number=78510
-build.patch=001
+build.patch=002
 delegate.version=23.02.10
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes
In CG verification step, when the verification type is Rolling (Previous) and there is no baseline data, the current test data should be analysed and recorded as baseline for future verifications. 
This flow was broken due to a recent commit. When accessing the control data records, there was no check if the records existed for a verification or not, leading to numerous NPEs for every such verification.
This PR fixes that by ensuring if there are no control data records, the null collection is converted to an empty collection and handled gracefully.

Tests-

The issue was reproduced in the QA env with a build without the fix
https://qa.harness.io/#/account/zEaak-FLS425IEO7OLzMUg/app/Wk6TjV-FTruiZMRfhyxSDQ/env/jaACgnxtSkqaRstcnuV_zQ/executions/8cA4QxvPTI2x8wf7upgkPw/details

After deploying the fix to the QA, the same workflow was able to execute normally.
https://qa.harness.io/#/account/zEaak-FLS425IEO7OLzMUg/app/Wk6TjV-FTruiZMRfhyxSDQ/env/jaACgnxtSkqaRstcnuV_zQ/executions/IhVtnU0XSrqOIfKjphg6OQ/details

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/44669)
<!-- Reviewable:end -->
