### PR TITLE
fix:[CDS-53786]: Add support to query specific tag from quay registry.

### DIFF
--- a/960-api-services/src/main/java/io/harness/artifacts/docker/DockerRegistryRestClient.java
+++ b/960-api-services/src/main/java/io/harness/artifacts/docker/DockerRegistryRestClient.java
@@ -12,6 +12,7 @@ import static io.harness.annotations.dev.HarnessTeam.CDC;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.artifacts.docker.beans.DockerImageManifestResponse;
 import io.harness.artifacts.docker.beans.DockerPublicImageTagResponse;
+import io.harness.artifacts.docker.beans.QuayImageTagResponse;
 
 import retrofit2.Call;
 import retrofit2.http.GET;
@@ -69,4 +70,9 @@ public interface DockerRegistryRestClient {
   Call<DockerPublicImageTagResponse.Result> getPublicImageTag(
       @Path(value = "imageName", encoded = true) String imageName,
       @Path(value = "tagNumber", encoded = true) String tagNumber);
+
+  // https://quay.io/api/v1/repository/${imageName}/tag/?specificTag=${tag}
+  @GET("/api/v1/repository/{imageName}/tag")
+  Call<QuayImageTagResponse> getImageTagFromQuay(
+      @Path(value = "imageName", encoded = true) String imageName, @Query("specificTag") String tag);
 }

--- a/960-api-services/src/main/java/io/harness/artifacts/docker/beans/QuayImageTag.java
+++ b/960-api-services/src/main/java/io/harness/artifacts/docker/beans/QuayImageTag.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.artifacts.docker.beans;
+
+import static io.harness.annotations.dev.HarnessTeam.CDC;
+
+import io.harness.annotations.dev.OwnedBy;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@OwnedBy(CDC)
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class QuayImageTag {
+  private String name;
+  private String manifestDigest;
+}

--- a/960-api-services/src/main/java/io/harness/artifacts/docker/beans/QuayImageTagResponse.java
+++ b/960-api-services/src/main/java/io/harness/artifacts/docker/beans/QuayImageTagResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.artifacts.docker.beans;
+
+import static io.harness.annotations.dev.HarnessTeam.CDC;
+
+import io.harness.annotations.dev.OwnedBy;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@OwnedBy(CDC)
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class QuayImageTagResponse {
+  private List<QuayImageTag> tags;
+}


### PR DESCRIPTION
## Describe your changes
- More details when the final PR comes.
- Btw, we can use the same API to retrieve the list of tags increasing the customer experience.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/44857)
<!-- Reviewable:end -->
