### PR TITLE
fix: [CDS-55062]: NG commit changes when SCM FF is off

### DIFF
--- a/932-connector-task/src/main/java/io/harness/connector/service/git/NGGitServiceImpl.java
+++ b/932-connector-task/src/main/java/io/harness/connector/service/git/NGGitServiceImpl.java
@@ -136,7 +136,7 @@ public class NGGitServiceImpl implements NGGitService {
             .repoType(YAML)
             .repoUrl(gitConfigDTO.getUrl())
             .build();
-    return gitClientV2.fetchFilesByPath(fetchFilesByPathRequest);
+    return gitClientV2.fetchFilesByPath(identifier, fetchFilesByPathRequest);
   }
 
   @Override

--- a/960-api-services/src/main/java/io/harness/git/GitClientV2Impl.java
+++ b/960-api-services/src/main/java/io/harness/git/GitClientV2Impl.java
@@ -19,6 +19,7 @@ import static io.harness.exception.WingsException.USER;
 import static io.harness.exception.WingsException.USER_ADMIN;
 import static io.harness.filesystem.FileIo.deleteDirectoryAndItsContentIfExists;
 import static io.harness.git.Constants.COMMIT_MESSAGE;
+import static io.harness.git.Constants.DEFAULT_FETCH_IDENTIFIER;
 import static io.harness.git.Constants.EXCEPTION_STRING;
 import static io.harness.git.Constants.GIT_YAML_LOG_PREFIX;
 import static io.harness.git.Constants.HARNESS_IO_KEY_;
@@ -150,7 +151,6 @@ public class GitClientV2Impl implements GitClientV2 {
   private static final String REDIRECTION_BLOCKED_ERROR = "Redirection blocked";
   private static final String TIMEOUT_ERROR = "Connection time out";
   private static final int SOCKET_CONNECTION_READ_TIMEOUT_SECONDS = 60;
-  private static final String DEFAULT_FETCH_IDENTIFIER = "--default";
 
   @Inject private GitClientHelper gitClientHelper;
   /**

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=78702
+build.number=78703
 build.patch=000
 delegate.version=23.03.10
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes
Somehow removed the logic for identifier for normal fetch.
## Testing 
![Screenshot 2023-03-10 at 12 44 59 PM](https://user-images.githubusercontent.com/106597485/224252584-f6cffc65-02e7-4343-b781-d5f60dc188e3.png)
![Screenshot 2023-03-10 at 12 45 07 PM](https://user-images.githubusercontent.com/106597485/224252593-4c20652c-3033-413e-9eb1-1dc4ebe64a4b.png)

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/44956)
<!-- Reviewable:end -->
