### PR TITLE
fix: [PL-31906]: ng api for gen docker compose file will always return immutable delegate

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
@@ -268,6 +268,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -1723,7 +1724,7 @@ public class DelegateServiceImpl implements DelegateService {
       if (isNg) {
         var tokenDetails =
             delegateNgTokenService.getDelegateToken(inquiry.getAccountId(), inquiry.getDelegateTokenName(), false);
-        if (Objects.nonNull(tokenDetails) && tokenDetails.getStatus().equals(REVOKED)) {
+        if (Objects.isNull(tokenDetails) && tokenDetails.getStatus().equals(REVOKED)) {
           return null;
         }
         return delegateNgTokenService.getDelegateTokenValue(inquiry.getAccountId(), inquiry.getDelegateTokenName());

--- a/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
@@ -1467,8 +1467,8 @@ public class DelegateServiceImpl implements DelegateService {
     final String accountSecret = getAccountSecret(templateParameters, isNgDelegate);
     final String base64Secret = Base64.getEncoder().encodeToString(accountSecret.getBytes());
     // Ng helm delegates always use immutable image irrespective of FF
-    final String delegateDockerImage =
-        immutableDelegateEnabled ? delegateVersionService.getImmutableDelegateImageTag(templateParameters.getAccountId())
+    final String delegateDockerImage = immutableDelegateEnabled
+        ? delegateVersionService.getImmutableDelegateImageTag(templateParameters.getAccountId())
         : delegateVersionService.getDelegateImageTag(templateParameters.getAccountId(), immutableDelegateEnabled);
     ImmutableMap.Builder<String, String> params =
         ImmutableMap.<String, String>builder()
@@ -1721,7 +1721,8 @@ public class DelegateServiceImpl implements DelegateService {
     final Account account = accountService.get(inquiry.getAccountId());
     if (isNotBlank(inquiry.getDelegateTokenName())) {
       if (isNg) {
-        var tokenDetails = delegateNgTokenService.getDelegateToken(inquiry.getAccountId(), inquiry.getDelegateTokenName(), false);
+        var tokenDetails =
+            delegateNgTokenService.getDelegateToken(inquiry.getAccountId(), inquiry.getDelegateTokenName(), false);
         if (Objects.nonNull(tokenDetails) && tokenDetails.getStatus().equals(REVOKED)) {
           return null;
         }
@@ -3273,7 +3274,8 @@ public class DelegateServiceImpl implements DelegateService {
 
   private boolean shouldInstallImmutableDelegate(
       final String accountId, final String delegateType, final boolean isNgDelegate) {
-    if (isNgDelegate) return true;
+    if (isNgDelegate)
+      return true;
     if (KUBERNETES.equals(delegateType) || CE_KUBERNETES.equals(delegateType) || DOCKER.equals(delegateType)) {
       return accountService.isImmutableDelegateEnabled(accountId);
     }
@@ -4183,29 +4185,29 @@ public class DelegateServiceImpl implements DelegateService {
 
       final boolean isNgDelegate = true;
       final boolean isImmutable = shouldInstallImmutableDelegate(accountId, KUBERNETES, isNgDelegate);
-      TemplateParametersBuilder templateParametersBuilder = TemplateParameters.builder()
-          .accountId(accountId)
-          .version(version)
-          .managerHost(managerHost)
-          .verificationHost(verificationServiceUrl)
-          .delegateName(delegateSetupDetails.getName())
-          .delegateType(KUBERNETES)
-          .ciEnabled(isCiEnabled)
-          .delegateDescription(delegateSetupDetails.getDescription())
-          .delegateSize(sizeDetails.getSize().name())
-          .delegateReplicas(sizeDetails.getReplicas())
-          .delegateRam(sizeDetails.getRam() / sizeDetails.getReplicas())
-          .delegateCpu(sizeDetails.getCpu() / sizeDetails.getReplicas())
-          .delegateRequestsRam(sizeDetails.getRam() / sizeDetails.getReplicas())
-          .delegateRequestsCpu(sizeDetails.getCpu() / sizeDetails.getReplicas())
-          .delegateTags(isNotEmpty(delegateSetupDetails.getTags())
-              ? String.join(",", delegateSetupDetails.getTags())
-              : "")
-          .delegateNamespace(delegateSetupDetails.getK8sConfigDetails().getNamespace())
-          .k8sPermissionsType(delegateSetupDetails.getK8sConfigDetails().getK8sPermissionType())
-          .logStreamingServiceBaseUrl(mainConfiguration.getLogStreamingServiceConfig().getExternalUrl())
-          .runAsRoot(delegateSetupDetails.getRunAsRoot() == null || delegateSetupDetails.getRunAsRoot())
-          .delegateTokenName(delegateSetupDetails.getTokenName());
+      TemplateParametersBuilder templateParametersBuilder =
+          TemplateParameters.builder()
+              .accountId(accountId)
+              .version(version)
+              .managerHost(managerHost)
+              .verificationHost(verificationServiceUrl)
+              .delegateName(delegateSetupDetails.getName())
+              .delegateType(KUBERNETES)
+              .ciEnabled(isCiEnabled)
+              .delegateDescription(delegateSetupDetails.getDescription())
+              .delegateSize(sizeDetails.getSize().name())
+              .delegateReplicas(sizeDetails.getReplicas())
+              .delegateRam(sizeDetails.getRam() / sizeDetails.getReplicas())
+              .delegateCpu(sizeDetails.getCpu() / sizeDetails.getReplicas())
+              .delegateRequestsRam(sizeDetails.getRam() / sizeDetails.getReplicas())
+              .delegateRequestsCpu(sizeDetails.getCpu() / sizeDetails.getReplicas())
+              .delegateTags(
+                  isNotEmpty(delegateSetupDetails.getTags()) ? String.join(",", delegateSetupDetails.getTags()) : "")
+              .delegateNamespace(delegateSetupDetails.getK8sConfigDetails().getNamespace())
+              .k8sPermissionsType(delegateSetupDetails.getK8sConfigDetails().getK8sPermissionType())
+              .logStreamingServiceBaseUrl(mainConfiguration.getLogStreamingServiceConfig().getExternalUrl())
+              .runAsRoot(delegateSetupDetails.getRunAsRoot() == null || delegateSetupDetails.getRunAsRoot())
+              .delegateTokenName(delegateSetupDetails.getTokenName());
 
       TemplateParameters templateParameters;
       if (isImmutable) {
@@ -4213,8 +4215,7 @@ public class DelegateServiceImpl implements DelegateService {
       } else {
         templateParameters = templateParametersBuilder.build();
       }
-      ImmutableMap<String, String> scriptParams =
-          getJarAndScriptRunTimeParamMap(templateParameters, true, isImmutable);
+      ImmutableMap<String, String> scriptParams = getJarAndScriptRunTimeParamMap(templateParameters, true, isImmutable);
 
       File yaml = File.createTempFile(HARNESS_DELEGATE, YAML);
       String templateName = IMMUTABLE_DELEGATE_YAML;


### PR DESCRIPTION
## Describe your changes
NG UI should always provide immutable delegate regardless of db flag. Currently docker is the last one not doing this 
Due to the legacy code problem, this PR had to refactor some codes so touched different functions. 
Please review by compare this code with old codes, you will find it's actually not big change

Test
Local: done 
![image](https://user-images.githubusercontent.com/109999795/224464552-170a7d35-bc03-4217-a955-d127486dbdf4.png)
<img width="923" alt="image" src="https://user-images.githubusercontent.com/109999795/224464590-31f4825a-7681-4a49-ac4f-03ad80c5c8f1.png">


## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/45006)
<!-- Reviewable:end -->
