### PR TITLE
[feat]: [PIE-8405]: Added default error message for BitBucket cloud provider

### DIFF
--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketCreateBranchScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketCreateBranchScmApiErrorHandler.java
@@ -37,8 +37,12 @@ public class BitbucketCreateBranchScmApiErrorHandler implements ScmApiErrorHandl
   public static final String CREATE_BRANCH_NOT_FOUND_ERROR_EXPLANATION = "Possible reasons can be:\n"
       + "1. The given bitbucket repository<REPO> is invalid.\n"
       + "2. The given base branch<BRANCH> does not exists.";
+  public static final String CREATE_BRANCH = "create branch";
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = EmptyPredicate.isEmpty(errorMessage)
+        ? String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, CREATE_BRANCH)
+        : errorMessage;
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketCreateFileScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketCreateFileScmApiErrorHandler.java
@@ -35,8 +35,13 @@ public class BitbucketCreateFileScmApiErrorHandler implements ScmApiErrorHandler
   public static final String CREATE_FILE_BAD_REQUEST_HINT =
       "Please use a pull request to create file<FILEPATH> in this branch<BRANCH>.";
 
+  public static final String CREATE_FILE = "create file";
+
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = EmptyPredicate.isEmpty(errorMessage)
+        ? String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, CREATE_FILE)
+        : errorMessage;
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketCreatePullRequestScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketCreatePullRequestScmApiErrorHandler.java
@@ -27,8 +27,13 @@ import lombok.extern.slf4j.Slf4j;
 public class BitbucketCreatePullRequestScmApiErrorHandler implements ScmApiErrorHandler {
   public static final String CREATE_PULL_REQUEST_FAILURE = "The pull request could not be created in Bitbucket. ";
 
+  public static final String CREATE_PULL_REQUEST = "create pull request";
+
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = EmptyPredicate.isEmpty(errorMessage)
+        ? String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, CREATE_PULL_REQUEST)
+        : errorMessage;
     switch (statusCode) {
       case 400:
         // bitbucket already throws well formatted error messages, so no need of any hints/explanations here

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketGetBranchHeadCommitScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketGetBranchHeadCommitScmApiErrorHandler.java
@@ -28,9 +28,13 @@ import lombok.extern.slf4j.Slf4j;
 public class BitbucketGetBranchHeadCommitScmApiErrorHandler implements ScmApiErrorHandler {
   public static final String GET_BRANCH_HEAD_COMMIT_FAILED_MESSAGE =
       "Failed to fetch branch head commit details from Bitbucket";
+  public static final String GET_BRANCH_HEAD_COMMIT = "getting branch head commit";
 
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = EmptyPredicate.isEmpty(errorMessage)
+        ? String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, GET_BRANCH_HEAD_COMMIT)
+        : errorMessage;
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketGetDefaultBranchScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketGetDefaultBranchScmApiErrorHandler.java
@@ -27,8 +27,13 @@ import lombok.extern.slf4j.Slf4j;
 public class BitbucketGetDefaultBranchScmApiErrorHandler implements ScmApiErrorHandler {
   public static final String GET_DEFAULT_BRANCH_FAILED_MESSAGE = "Fetching default branch from Bitbucket failed. ";
 
+  public static final String GET_DEFAULT_BRANCH = "getting default branch";
+
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = EmptyPredicate.isEmpty(errorMessage)
+        ? String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, GET_DEFAULT_BRANCH)
+        : errorMessage;
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketGetFileScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketGetFileScmApiErrorHandler.java
@@ -31,8 +31,13 @@ public class BitbucketGetFileScmApiErrorHandler implements ScmApiErrorHandler {
   public static final String GET_FILE_REQUEST_FAILURE =
       "The requested file<FILEPATH> could not be fetched from Bitbucket. ";
 
+  public static final String GET_FILE = "getting file";
+
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = EmptyPredicate.isEmpty(errorMessage)
+        ? String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, GET_FILE)
+        : errorMessage;
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketListBranchesScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketListBranchesScmApiErrorHandler.java
@@ -27,8 +27,13 @@ import lombok.extern.slf4j.Slf4j;
 public class BitbucketListBranchesScmApiErrorHandler implements ScmApiErrorHandler {
   public static final String LIST_BRANCH_FAILED_MESSAGE = "Listing branches from Bitbucket failed. ";
 
+  public static final String LIST_BRANCH = "listing branches";
+
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = EmptyPredicate.isEmpty(errorMessage)
+        ? String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, LIST_BRANCH)
+        : errorMessage;
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketListFilesScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketListFilesScmApiErrorHandler.java
@@ -36,8 +36,13 @@ public class BitbucketListFilesScmApiErrorHandler implements ScmApiErrorHandler 
       + "3. If the requested directory<FILEPATH> exists or not at ref<REF>.";
   public static final String LIST_FILES_FAILED_MESSAGE = "Listing files from Bitbucket failed. ";
 
+  public static final String LIST_FILES = "listing files";
+
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = EmptyPredicate.isEmpty(errorMessage)
+        ? String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, LIST_FILES)
+        : errorMessage;
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketListRepoScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketListRepoScmApiErrorHandler.java
@@ -26,8 +26,12 @@ import lombok.extern.slf4j.Slf4j;
 @OwnedBy(PL)
 public class BitbucketListRepoScmApiErrorHandler implements ScmApiErrorHandler {
   public static final String LIST_REPO_FAILED_MESSAGE = "Listing repositories from Github failed. ";
+  public static final String LISTING_REPOS = "listing repos";
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = EmptyPredicate.isEmpty(errorMessage)
+        ? String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, LISTING_REPOS)
+        : errorMessage;
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketUpdateFileScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketUpdateFileScmApiErrorHandler.java
@@ -43,8 +43,13 @@ public class BitbucketUpdateFileScmApiErrorHandler implements ScmApiErrorHandler
   public static final String UPDATE_FILE_BAD_REQUEST_HINT =
       "Please use a pull request to update file<FILEPATH> in this branch<BRANCH>.";
 
+  public static final String UPDATE_FILE = "updating file";
+
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = EmptyPredicate.isEmpty(errorMessage)
+        ? String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, UPDATE_FILE)
+        : errorMessage;
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/ScmErrorDefaultMessage.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/ScmErrorDefaultMessage.java
@@ -17,4 +17,6 @@ import lombok.experimental.UtilityClass;
 @OwnedBy(PIPELINE)
 public class ScmErrorDefaultMessage {
   public static final String RATE_LIMIT = "Too Many Requests.";
+
+  public static final String DEFAULT_ERROR_MESSAGE = "Encountered unexpected scm error during BitBucket %s operation";
 }

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketCreateBranchScmApiErrorHandlerTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketCreateBranchScmApiErrorHandlerTest.java
@@ -7,6 +7,7 @@
 
 package io.harness.gitsync.common.scmerrorhandling.handlers.bitbucket;
 
+import static io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketCreateBranchScmApiErrorHandler.CREATE_BRANCH;
 import static io.harness.rule.OwnerRule.ADITHYA;
 import static io.harness.rule.OwnerRule.BHAVYA;
 
@@ -21,6 +22,7 @@ import io.harness.exception.WingsException;
 import io.harness.gitsync.GitSyncTestBase;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketCreateBranchScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.ScmErrorDefaultMessage;
 import io.harness.rule.Owner;
 
 import com.google.inject.Inject;
@@ -113,6 +115,21 @@ public class BitbucketCreateBranchScmApiErrorHandlerTest extends GitSyncTestBase
       WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
       assertThat(exception).isNotNull();
       assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testHandleErrorWhenErrorMessageIsEmpty() {
+    try {
+      bitbucketCreateBranchScmApiErrorHandler.handleError(429, "", ErrorMetadata.builder().build());
+    } catch (Exception ex) {
+      WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
+      System.out.println("12345: " + exception.getMessage());
+      assertThat(exception).isNotNull();
+      assertThat(exception.getMessage())
+          .isEqualTo(String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, CREATE_BRANCH));
     }
   }
 }

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketCreateFileScmApiErrorHandlerTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketCreateFileScmApiErrorHandlerTest.java
@@ -7,6 +7,7 @@
 
 package io.harness.gitsync.common.scmerrorhandling.handlers.bitbucket;
 
+import static io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketCreateFileScmApiErrorHandler.CREATE_FILE;
 import static io.harness.rule.OwnerRule.ADITHYA;
 import static io.harness.rule.OwnerRule.MOHIT_GARG;
 
@@ -23,6 +24,7 @@ import io.harness.exception.WingsException;
 import io.harness.gitsync.GitSyncTestBase;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketCreateFileScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.ScmErrorDefaultMessage;
 import io.harness.rule.Owner;
 
 import com.google.inject.Inject;
@@ -104,6 +106,20 @@ public class BitbucketCreateFileScmApiErrorHandlerTest extends GitSyncTestBase {
       WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
       assertThat(exception).isNotNull();
       assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testHandleErrorWhenErrorMessageIsEmpty() {
+    try {
+      bitbucketCreateFileScmApiErrorHandler.handleError(429, "", ErrorMetadata.builder().build());
+    } catch (Exception ex) {
+      WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
+      assertThat(exception).isNotNull();
+      assertThat(exception.getMessage())
+          .isEqualTo(String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, CREATE_FILE));
     }
   }
 }

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketCreatePullRequestScmApiErrorHandlerTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketCreatePullRequestScmApiErrorHandlerTest.java
@@ -7,6 +7,7 @@
 
 package io.harness.gitsync.common.scmerrorhandling.handlers.bitbucket;
 
+import static io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketCreatePullRequestScmApiErrorHandler.CREATE_PULL_REQUEST;
 import static io.harness.rule.OwnerRule.ADITHYA;
 import static io.harness.rule.OwnerRule.MOHIT_GARG;
 
@@ -23,6 +24,7 @@ import io.harness.exception.WingsException;
 import io.harness.gitsync.GitSyncTestBase;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketCreatePullRequestScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.ScmErrorDefaultMessage;
 import io.harness.rule.Owner;
 
 import com.google.inject.Inject;
@@ -117,6 +119,20 @@ public class BitbucketCreatePullRequestScmApiErrorHandlerTest extends GitSyncTes
       WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
       assertThat(exception).isNotNull();
       assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testHandleErrorWhenErrorMessageIsEmpty() {
+    try {
+      bitbucketCreatePullRequestScmApiErrorHandler.handleError(429, "", ErrorMetadata.builder().build());
+    } catch (Exception ex) {
+      WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
+      assertThat(exception).isNotNull();
+      assertThat(exception.getMessage())
+          .isEqualTo(String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, CREATE_PULL_REQUEST));
     }
   }
 }

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketGetBranchHeadCommitScmApiErrorHandlerTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketGetBranchHeadCommitScmApiErrorHandlerTest.java
@@ -8,6 +8,7 @@
 package io.harness.gitsync.common.scmerrorhandling.handlers.bitbucket;
 
 import static io.harness.exception.SCMExceptionErrorMessages.BITBUCKET_REPOSITORY_OR_BRANCH_NOT_FOUND_ERROR;
+import static io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketGetBranchHeadCommitScmApiErrorHandler.GET_BRANCH_HEAD_COMMIT;
 import static io.harness.rule.OwnerRule.ADITHYA;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,6 +21,7 @@ import io.harness.exception.WingsException;
 import io.harness.gitsync.GitSyncTestBase;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketGetBranchHeadCommitScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.ScmErrorDefaultMessage;
 import io.harness.rule.Owner;
 
 import com.google.inject.Inject;
@@ -73,6 +75,20 @@ public class BitbucketGetBranchHeadCommitScmApiErrorHandlerTest extends GitSyncT
       WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
       assertThat(exception).isNotNull();
       assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testHandleErrorWhenErrorMessageIsEmpty() {
+    try {
+      bitbucketGetBranchHeadCommitScmApiErrorHandler.handleError(429, "", ErrorMetadata.builder().build());
+    } catch (Exception ex) {
+      WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
+      assertThat(exception).isNotNull();
+      assertThat(exception.getMessage())
+          .isEqualTo(String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, GET_BRANCH_HEAD_COMMIT));
     }
   }
 }

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketGetDefaultBranchScmApiErrorHandlerTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketGetDefaultBranchScmApiErrorHandlerTest.java
@@ -8,6 +8,7 @@
 package io.harness.gitsync.common.scmerrorhandling.handlers.bitbucket;
 
 import static io.harness.annotations.dev.HarnessTeam.PL;
+import static io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketGetDefaultBranchScmApiErrorHandler.GET_DEFAULT_BRANCH;
 import static io.harness.rule.OwnerRule.ADITHYA;
 import static io.harness.rule.OwnerRule.BHAVYA;
 
@@ -22,6 +23,7 @@ import io.harness.exception.WingsException;
 import io.harness.gitsync.GitSyncTestBase;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketGetDefaultBranchScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.ScmErrorDefaultMessage;
 import io.harness.rule.Owner;
 
 import com.google.inject.Inject;
@@ -89,6 +91,20 @@ public class BitbucketGetDefaultBranchScmApiErrorHandlerTest extends GitSyncTest
       WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
       assertThat(exception).isNotNull();
       assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testHandleErrorWhenErrorMessageIsEmpty() {
+    try {
+      bitbucketGetDefaultBranchScmApiErrorHandler.handleError(429, "", ErrorMetadata.builder().build());
+    } catch (Exception ex) {
+      WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
+      assertThat(exception).isNotNull();
+      assertThat(exception.getMessage())
+          .isEqualTo(String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, GET_DEFAULT_BRANCH));
     }
   }
 }

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketGetFileScmApiErrorHandlerTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketGetFileScmApiErrorHandlerTest.java
@@ -7,6 +7,7 @@
 
 package io.harness.gitsync.common.scmerrorhandling.handlers.bitbucket;
 
+import static io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketGetFileScmApiErrorHandler.GET_FILE;
 import static io.harness.rule.OwnerRule.ADITHYA;
 import static io.harness.rule.OwnerRule.MOHIT_GARG;
 
@@ -24,6 +25,7 @@ import io.harness.exception.WingsException;
 import io.harness.gitsync.GitSyncTestBase;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketGetFileScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.ScmErrorDefaultMessage;
 import io.harness.rule.Owner;
 
 import com.google.inject.Inject;
@@ -105,6 +107,20 @@ public class BitbucketGetFileScmApiErrorHandlerTest extends GitSyncTestBase {
       WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
       assertThat(exception).isNotNull();
       assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testHandleErrorWhenErrorMessageIsEmpty() {
+    try {
+      bitbucketGetFileScmApiErrorHandler.handleError(429, "", ErrorMetadata.builder().build());
+    } catch (Exception ex) {
+      WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
+      assertThat(exception).isNotNull();
+      assertThat(exception.getMessage())
+          .isEqualTo(String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, GET_FILE));
     }
   }
 }

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketListBranchesScmApiErrorHandlerTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketListBranchesScmApiErrorHandlerTest.java
@@ -8,6 +8,7 @@
 package io.harness.gitsync.common.scmerrorhandling.handlers.bitbucket;
 
 import static io.harness.annotations.dev.HarnessTeam.PL;
+import static io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketListBranchesScmApiErrorHandler.LIST_BRANCH;
 import static io.harness.rule.OwnerRule.ADITHYA;
 import static io.harness.rule.OwnerRule.BHAVYA;
 
@@ -23,6 +24,7 @@ import io.harness.exception.WingsException;
 import io.harness.gitsync.GitSyncTestBase;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketListBranchesScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.ScmErrorDefaultMessage;
 import io.harness.rule.Owner;
 
 import com.google.inject.Inject;
@@ -62,6 +64,20 @@ public class BitbucketListBranchesScmApiErrorHandlerTest extends GitSyncTestBase
       WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
       assertThat(exception).isNotNull();
       assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testHandleErrorWhenErrorMessageIsEmpty() {
+    try {
+      bitbucketListBranchesScmApiErrorHandler.handleError(429, "", ErrorMetadata.builder().build());
+    } catch (Exception ex) {
+      WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
+      assertThat(exception).isNotNull();
+      assertThat(exception.getMessage())
+          .isEqualTo(String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, LIST_BRANCH));
     }
   }
 }

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketListFilesScmApiErrorHandlerTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketListFilesScmApiErrorHandlerTest.java
@@ -7,6 +7,7 @@
 
 package io.harness.gitsync.common.scmerrorhandling.handlers.bitbucket;
 
+import static io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketListFilesScmApiErrorHandler.LIST_FILES;
 import static io.harness.rule.OwnerRule.ADITHYA;
 import static io.harness.rule.OwnerRule.MOHIT_GARG;
 
@@ -21,6 +22,7 @@ import io.harness.exception.WingsException;
 import io.harness.gitsync.GitSyncTestBase;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketListFilesScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.ScmErrorDefaultMessage;
 import io.harness.rule.Owner;
 
 import com.google.inject.Inject;
@@ -100,6 +102,20 @@ public class BitbucketListFilesScmApiErrorHandlerTest extends GitSyncTestBase {
       WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
       assertThat(exception).isNotNull();
       assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testHandleErrorWhenErrorMessageIsEmpty() {
+    try {
+      bitbucketListFilesScmApiErrorHandler.handleError(429, "", ErrorMetadata.builder().build());
+    } catch (Exception ex) {
+      WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
+      assertThat(exception).isNotNull();
+      assertThat(exception.getMessage())
+          .isEqualTo(String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, LIST_FILES));
     }
   }
 }

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketListRepoScmApiErrorHandlerTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketListRepoScmApiErrorHandlerTest.java
@@ -8,6 +8,7 @@
 package io.harness.gitsync.common.scmerrorhandling.handlers.bitbucket;
 
 import static io.harness.annotations.dev.HarnessTeam.PL;
+import static io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketListRepoScmApiErrorHandler.LISTING_REPOS;
 import static io.harness.rule.OwnerRule.ADITHYA;
 import static io.harness.rule.OwnerRule.BHAVYA;
 
@@ -23,6 +24,7 @@ import io.harness.exception.WingsException;
 import io.harness.gitsync.GitSyncTestBase;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketListRepoScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.ScmErrorDefaultMessage;
 import io.harness.rule.Owner;
 
 import com.google.inject.Inject;
@@ -61,6 +63,20 @@ public class BitbucketListRepoScmApiErrorHandlerTest extends GitSyncTestBase {
       WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
       assertThat(exception).isNotNull();
       assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testHandleErrorWhenErrorMessageIsEmpty() {
+    try {
+      bitbucketListRepoScmApiErrorHandler.handleError(429, "", ErrorMetadata.builder().build());
+    } catch (Exception ex) {
+      WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
+      assertThat(exception).isNotNull();
+      assertThat(exception.getMessage())
+          .isEqualTo(String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, LISTING_REPOS));
     }
   }
 }

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketUpdateFileScmApiErrorHandlerTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketUpdateFileScmApiErrorHandlerTest.java
@@ -7,6 +7,7 @@
 
 package io.harness.gitsync.common.scmerrorhandling.handlers.bitbucket;
 
+import static io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketUpdateFileScmApiErrorHandler.UPDATE_FILE;
 import static io.harness.rule.OwnerRule.ADITHYA;
 import static io.harness.rule.OwnerRule.MOHIT_GARG;
 
@@ -24,6 +25,7 @@ import io.harness.exception.WingsException;
 import io.harness.gitsync.GitSyncTestBase;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.BitbucketUpdateFileScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.bitbucketcloud.ScmErrorDefaultMessage;
 import io.harness.rule.Owner;
 
 import com.google.inject.Inject;
@@ -118,6 +120,20 @@ public class BitbucketUpdateFileScmApiErrorHandlerTest extends GitSyncTestBase {
       WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
       assertThat(exception).isNotNull();
       assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testHandleErrorWhenErrorMessageIsEmpty() {
+    try {
+      bitbucketUpdateFileScmApiErrorHandler.handleError(429, "", ErrorMetadata.builder().build());
+    } catch (Exception ex) {
+      WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
+      assertThat(exception).isNotNull();
+      assertThat(exception.getMessage())
+          .isEqualTo(String.format(ScmErrorDefaultMessage.DEFAULT_ERROR_MESSAGE, UPDATE_FILE));
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/45123)
<!-- Reviewable:end -->
