### PR TITLE
fix: [PL-32027]: Redisson fix lock release condition

### DIFF
--- a/120-ng-manager/src/main/resources/logback.xml
+++ b/120-ng-manager/src/main/resources/logback.xml
@@ -21,7 +21,7 @@
 
     <logger name="software.wings" level="INFO"/>
     <logger name="org.zeroturnaround" level="WARN"/>
-
+    <logger name="org.redisson" level="TRACE" />
     <root level="${LOGGING_LEVEL:-INFO}">
         <appender-ref ref="stdout"/>
     </root>

--- a/960-persistence/src/main/java/io/harness/lock/redis/RedisAcquiredLock.java
+++ b/960-persistence/src/main/java/io/harness/lock/redis/RedisAcquiredLock.java
@@ -40,6 +40,14 @@ public class RedisAcquiredLock implements AcquiredLock<RLock> {
 
   /**
    * This is implemented only as workaround for handling race condition in sentinel mode.
+   * In sentinel mode after redisson library upgrade from 3.13.3 to 3.17.7 we started facing issue where lock was
+   * hanging forever on lock.unlock() method call. During our investigation we found open bugs found on Redisson lib
+   * with similar behaviour See below for more details
+   * https://harness.atlassian.net/jira/software/c/projects/PL/issues/PL-31692
+   * https://github.com/redisson/redisson/issues/4822
+   * https://github.com/redisson/redisson/issues/4878
+   * Based on multiple trials we found that checking lock.isHeldByCurrentThread() along with lock.forceUnlock() is a
+   * feasible workaround considering Factors like Senitinel mode only being used in SMP, Load in SMP etc.
    */
   private void releaseInSentinelMode() {
     if (lock != null && (lock.isHeldByCurrentThread() || isLeaseInfinite)) {

--- a/960-persistence/src/main/java/io/harness/lock/redis/RedisAcquiredLock.java
+++ b/960-persistence/src/main/java/io/harness/lock/redis/RedisAcquiredLock.java
@@ -25,7 +25,7 @@ public class RedisAcquiredLock implements AcquiredLock<RLock> {
 
   @Override
   public void release() {
-    if (lock != null && (lock.isLocked() || isLeaseInfinite)) {
+    if (lock != null && (lock.isHeldByCurrentThread() || isLeaseInfinite)) {
       lock.unlock();
     }
   }

--- a/960-persistence/src/main/java/io/harness/lock/redis/RedisAcquiredLock.java
+++ b/960-persistence/src/main/java/io/harness/lock/redis/RedisAcquiredLock.java
@@ -26,7 +26,7 @@ public class RedisAcquiredLock implements AcquiredLock<RLock> {
   @Override
   public void release() {
     if (lock != null && (lock.isHeldByCurrentThread() || isLeaseInfinite)) {
-      lock.unlock();
+      lock.forceUnlock();
     }
   }
 

--- a/960-persistence/src/main/java/io/harness/lock/redis/RedisPersistentLocker.java
+++ b/960-persistence/src/main/java/io/harness/lock/redis/RedisPersistentLocker.java
@@ -65,7 +65,7 @@ public class RedisPersistentLocker implements PersistentLocker, HealthMonitor, M
       boolean locked = lock.tryLock(0, timeout.toMillis(), TimeUnit.MILLISECONDS);
       if (locked) {
         log.debug("Lock acquired on {} for timeout {}", name, timeout);
-        return RedisAcquiredLock.builder().lock(lock).build();
+        return RedisAcquiredLock.builder().lock(lock).isSentinelMode(client.getConfig().isSentinelConfig()).build();
       }
     } catch (Exception ex) {
       throw new UnexpectedException(format(ERROR_MESSAGE, name), ex);
@@ -113,7 +113,11 @@ public class RedisPersistentLocker implements PersistentLocker, HealthMonitor, M
       RLock lock = client.getLock(name);
       boolean locked = lock.tryLock(waitTime.toMillis(), -1, TimeUnit.MILLISECONDS);
       if (locked) {
-        return RedisAcquiredLock.builder().lock(lock).isLeaseInfinite(true).build();
+        return RedisAcquiredLock.builder()
+            .lock(lock)
+            .isLeaseInfinite(true)
+            .isSentinelMode(client.getConfig().isSentinelConfig())
+            .build();
       }
     } catch (Exception ex) {
       throw new UnexpectedException(format(ERROR_MESSAGE, name), ex);
@@ -140,7 +144,7 @@ public class RedisPersistentLocker implements PersistentLocker, HealthMonitor, M
       boolean locked = lock.tryLock(waitTimeout.toMillis(), lockTimeout.toMillis(), TimeUnit.MILLISECONDS);
       if (locked) {
         log.debug("Acquired lock on {} for {} having a wait Timeout of {}", name, lockTimeout, waitTimeout);
-        return RedisAcquiredLock.builder().lock(lock).build();
+        return RedisAcquiredLock.builder().lock(lock).isSentinelMode(client.getConfig().isSentinelConfig()).build();
       }
     } catch (Exception ex) {
       throw new UnexpectedException(format(ERROR_MESSAGE, name), ex);


### PR DESCRIPTION
## Describe your changes

In sentinel mode RLock implementation was getting stuck at unlock() and causing OutboxPollJob to hang forever due to race condition.
Please see for details - https://harness.atlassian.net/jira/software/c/projects/PL/issues/PL-31692

We have ran the Automation Sanity for 2 days continuously after applying this fix and we have not faced the issue again.
This will not have any side effects because we are checking if the thread is owner of lock before forceUnlocking it.

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/45143)
<!-- Reviewable:end -->
