### PR TITLE
[fix]: [PIE-8760] : added flag to stop notification template registrations in local

### DIFF
--- a/pipeline-service/config/config.yml
+++ b/pipeline-service/config/config.yml
@@ -307,6 +307,7 @@ orchestrationStepConfig:
 
 
 shouldDeployWithGitSync: true
+registerNotificationTemplates: true
 
 gitSdkConfiguration:
   gitSdkGrpcServerConfig:

--- a/pipeline-service/service/src/main/java/io/harness/NotificationTemplateRegistrar.java
+++ b/pipeline-service/service/src/main/java/io/harness/NotificationTemplateRegistrar.java
@@ -26,11 +26,12 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class NotificationTemplateRegistrar implements Runnable {
   @Inject NotificationClient notificationClient;
+  @Inject PipelineServiceConfiguration pipelineServiceConfiguration;
 
   @Override
   public void run() {
     try {
-      int timout = 1;
+      int timeout = 1;
       List<PredefinedTemplate> templates = new ArrayList<>(Arrays.asList(PredefinedTemplate.PIPELINE_PLAIN_SLACK,
           PredefinedTemplate.PIPELINE_PLAIN_EMAIL, PredefinedTemplate.PIPELINE_PLAIN_PAGERDUTY,
           PredefinedTemplate.PIPELINE_PLAIN_MSTEAMS, PredefinedTemplate.STAGE_PLAIN_SLACK,
@@ -43,7 +44,7 @@ public class NotificationTemplateRegistrar implements Runnable {
           PredefinedTemplate.HARNESS_APPROVAL_EXECUTION_NOTIFICATION_EMAIL,
           PredefinedTemplate.HARNESS_APPROVAL_NOTIFICATION_MSTEAMS,
           PredefinedTemplate.HARNESS_APPROVAL_EXECUTION_NOTIFICATION_MSTEAMS));
-      while (true) {
+      while (pipelineServiceConfiguration.isRegisterNotificationTemplates()) {
         List<PredefinedTemplate> unprocessedTemplate = new ArrayList<>();
         for (PredefinedTemplate template : templates) {
           log.info("Registering {} with NotificationService", template);
@@ -58,9 +59,9 @@ public class NotificationTemplateRegistrar implements Runnable {
           break;
         }
 
-        Thread.sleep(timout);
+        Thread.sleep(timeout);
 
-        timout *= 10;
+        timeout *= 10;
         templates = unprocessedTemplate;
       }
     } catch (InterruptedException e) {

--- a/pipeline-service/service/src/main/java/io/harness/PipelineServiceConfiguration.java
+++ b/pipeline-service/service/src/main/java/io/harness/PipelineServiceConfiguration.java
@@ -176,6 +176,7 @@ public class PipelineServiceConfiguration extends Configuration {
 
   private PipelineServiceIteratorsConfig iteratorsConfig;
   private boolean shouldDeployWithGitSync;
+  private boolean registerNotificationTemplates;
   private GitSdkConfiguration gitSdkConfiguration;
   private DelegatePollingConfig delegatePollingConfig;
   private ThreadPoolConfig


### PR DESCRIPTION
In local, we were running executor service to try registering multiple notification templates which were failing as template service was not running. Retries with exponential backoff was causing unnecessary logs making it harder to debug. Added a flag for the same

## Describe your changes

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/45238)
<!-- Reviewable:end -->
