### PR TITLE
[fix]: [PIE-8405]: Added default error message handler

### DIFF
--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/ScmErrorMessageHelper.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/ScmErrorMessageHelper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.gitsync.common.scmerrorhandling.handlers;
+
+import static io.harness.annotations.dev.HarnessTeam.PIPELINE;
+
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.data.structure.EmptyPredicate;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+@OwnedBy(PIPELINE)
+public class ScmErrorMessageHelper {
+  public final String DEFAULT_ERROR_MESSAGE = "Failed to perform GIT operation.";
+
+  public String validateErrorMessage(String errorMessage) {
+    return EmptyPredicate.isEmpty(errorMessage) ? DEFAULT_ERROR_MESSAGE : errorMessage;
+  }
+}

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketCreateBranchScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketCreateBranchScmApiErrorHandler.java
@@ -18,6 +18,7 @@ import io.harness.exception.ScmUnexpectedException;
 import io.harness.exception.WingsException;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.ScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.ScmErrorMessageHelper;
 import io.harness.gitsync.common.scmerrorhandling.util.ErrorMessageFormatter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +40,7 @@ public class BitbucketCreateBranchScmApiErrorHandler implements ScmApiErrorHandl
       + "2. The given base branch<BRANCH> does not exists.";
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = ScmErrorMessageHelper.validateErrorMessage(errorMessage);
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketCreateFileScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketCreateFileScmApiErrorHandler.java
@@ -21,6 +21,7 @@ import io.harness.exception.ScmUnexpectedException;
 import io.harness.exception.WingsException;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.ScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.ScmErrorMessageHelper;
 import io.harness.gitsync.common.scmerrorhandling.util.ErrorMessageFormatter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +38,7 @@ public class BitbucketCreateFileScmApiErrorHandler implements ScmApiErrorHandler
 
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = ScmErrorMessageHelper.validateErrorMessage(errorMessage);
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketCreatePullRequestScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketCreatePullRequestScmApiErrorHandler.java
@@ -18,6 +18,7 @@ import io.harness.exception.ScmUnexpectedException;
 import io.harness.exception.WingsException;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.ScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.ScmErrorMessageHelper;
 import io.harness.gitsync.common.scmerrorhandling.util.ErrorMessageFormatter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ public class BitbucketCreatePullRequestScmApiErrorHandler implements ScmApiError
 
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = ScmErrorMessageHelper.validateErrorMessage(errorMessage);
     switch (statusCode) {
       case 400:
         // bitbucket already throws well formatted error messages, so no need of any hints/explanations here

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketGetBranchHeadCommitScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketGetBranchHeadCommitScmApiErrorHandler.java
@@ -19,6 +19,7 @@ import io.harness.exception.ScmUnexpectedException;
 import io.harness.exception.WingsException;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.ScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.ScmErrorMessageHelper;
 import io.harness.gitsync.common.scmerrorhandling.util.ErrorMessageFormatter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,7 @@ public class BitbucketGetBranchHeadCommitScmApiErrorHandler implements ScmApiErr
 
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = ScmErrorMessageHelper.validateErrorMessage(errorMessage);
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketGetDefaultBranchScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketGetDefaultBranchScmApiErrorHandler.java
@@ -18,6 +18,7 @@ import io.harness.exception.ScmUnexpectedException;
 import io.harness.exception.WingsException;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.ScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.ScmErrorMessageHelper;
 import io.harness.gitsync.common.scmerrorhandling.util.ErrorMessageFormatter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ public class BitbucketGetDefaultBranchScmApiErrorHandler implements ScmApiErrorH
 
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = ScmErrorMessageHelper.validateErrorMessage(errorMessage);
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketGetFileScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketGetFileScmApiErrorHandler.java
@@ -21,6 +21,7 @@ import io.harness.exception.ScmUnexpectedException;
 import io.harness.exception.WingsException;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.ScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.ScmErrorMessageHelper;
 import io.harness.gitsync.common.scmerrorhandling.util.ErrorMessageFormatter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +34,7 @@ public class BitbucketGetFileScmApiErrorHandler implements ScmApiErrorHandler {
 
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = ScmErrorMessageHelper.validateErrorMessage(errorMessage);
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketListBranchesScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketListBranchesScmApiErrorHandler.java
@@ -18,6 +18,7 @@ import io.harness.exception.ScmUnexpectedException;
 import io.harness.exception.WingsException;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.ScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.ScmErrorMessageHelper;
 import io.harness.gitsync.common.scmerrorhandling.util.ErrorMessageFormatter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ public class BitbucketListBranchesScmApiErrorHandler implements ScmApiErrorHandl
 
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = ScmErrorMessageHelper.validateErrorMessage(errorMessage);
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketListFilesScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketListFilesScmApiErrorHandler.java
@@ -18,6 +18,7 @@ import io.harness.exception.ScmUnexpectedException;
 import io.harness.exception.WingsException;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.ScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.ScmErrorMessageHelper;
 import io.harness.gitsync.common.scmerrorhandling.util.ErrorMessageFormatter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +39,7 @@ public class BitbucketListFilesScmApiErrorHandler implements ScmApiErrorHandler 
 
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = ScmErrorMessageHelper.validateErrorMessage(errorMessage);
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketListRepoScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketListRepoScmApiErrorHandler.java
@@ -18,6 +18,7 @@ import io.harness.exception.ScmUnexpectedException;
 import io.harness.exception.WingsException;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.ScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.ScmErrorMessageHelper;
 import io.harness.gitsync.common.scmerrorhandling.util.ErrorMessageFormatter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,7 @@ public class BitbucketListRepoScmApiErrorHandler implements ScmApiErrorHandler {
   public static final String LIST_REPO_FAILED_MESSAGE = "Listing repositories from Github failed. ";
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = ScmErrorMessageHelper.validateErrorMessage(errorMessage);
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketUpdateFileScmApiErrorHandler.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucketcloud/BitbucketUpdateFileScmApiErrorHandler.java
@@ -22,6 +22,7 @@ import io.harness.exception.ScmUnexpectedException;
 import io.harness.exception.WingsException;
 import io.harness.gitsync.common.scmerrorhandling.dtos.ErrorMetadata;
 import io.harness.gitsync.common.scmerrorhandling.handlers.ScmApiErrorHandler;
+import io.harness.gitsync.common.scmerrorhandling.handlers.ScmErrorMessageHelper;
 import io.harness.gitsync.common.scmerrorhandling.util.ErrorMessageFormatter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +46,7 @@ public class BitbucketUpdateFileScmApiErrorHandler implements ScmApiErrorHandler
 
   @Override
   public void handleError(int statusCode, String errorMessage, ErrorMetadata errorMetadata) throws WingsException {
+    errorMessage = ScmErrorMessageHelper.validateErrorMessage(errorMessage);
     switch (statusCode) {
       case 401:
       case 403:

--- a/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketCreateBranchScmApiErrorHandlerTest.java
+++ b/136-git-sync-manager/src/test/java/io/harness/gitsync/common/scmerrorhandling/handlers/bitbucket/BitbucketCreateBranchScmApiErrorHandlerTest.java
@@ -7,6 +7,7 @@
 
 package io.harness.gitsync.common.scmerrorhandling.handlers.bitbucket;
 
+import static io.harness.gitsync.common.scmerrorhandling.handlers.ScmErrorMessageHelper.DEFAULT_ERROR_MESSAGE;
 import static io.harness.rule.OwnerRule.ADITHYA;
 import static io.harness.rule.OwnerRule.BHAVYA;
 
@@ -113,6 +114,19 @@ public class BitbucketCreateBranchScmApiErrorHandlerTest extends GitSyncTestBase
       WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
       assertThat(exception).isNotNull();
       assertThat(exception.getMessage()).isEqualTo(errorMessage);
+    }
+  }
+
+  @Test
+  @Owner(developers = ADITHYA)
+  @Category(UnitTests.class)
+  public void testHandleErrorWhenErrorMessageIsEmpty() {
+    try {
+      bitbucketCreateBranchScmApiErrorHandler.handleError(429, "", ErrorMetadata.builder().build());
+    } catch (Exception ex) {
+      WingsException exception = ExceptionUtils.cause(ScmBadRequestException.class, ex);
+      assertThat(exception).isNotNull();
+      assertThat(exception.getMessage()).isEqualTo(DEFAULT_ERROR_MESSAGE);
     }
   }
 }


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/45276)
<!-- Reviewable:end -->
