### PR TITLE
fix: [CDS-56631]: removing spaces and hyphen from identifier

### DIFF
--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/git/GitFetchTaskNG.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/git/GitFetchTaskNG.java
@@ -155,7 +155,7 @@ public class GitFetchTaskNG extends AbstractDelegateRunnableTask {
 
   private FetchFilesResult fetchFilesFromRepo(GitFetchFilesConfig gitFetchFilesConfig, LogCallback executionLogCallback,
       String accountId, boolean closeLogStream) throws IOException {
-    String identifier = gitFetchFilesConfig.getIdentifier();
+    String identifier = modifyIdentifier(gitFetchFilesConfig.getIdentifier());
     GitStoreDelegateConfig gitStoreDelegateConfig = gitFetchFilesConfig.getGitStoreDelegateConfig();
     executionLogCallback.saveExecutionLog("Git connector Url: " + gitStoreDelegateConfig.getGitConfigDTO().getUrl());
     String fetchTypeInfo = gitStoreDelegateConfig.getFetchType() == FetchType.BRANCH
@@ -204,5 +204,11 @@ public class GitFetchTaskNG extends AbstractDelegateRunnableTask {
   @Override
   public boolean isSupportingErrorFramework() {
     return true;
+  }
+
+  private String modifyIdentifier(String identifier) {
+    identifier = identifier.replaceAll("\\s", "");
+    identifier = identifier.replaceAll("-", "");
+    return identifier;
   }
 }


### PR DESCRIPTION
## Describe your changes
Expression for commitId in case the identifier contains spaces or hyphen were failing. Removing them from identifier prevents this error
## Testing 
<img width="671" alt="Screenshot 2023-03-21 at 11 31 58 AM" src="https://user-images.githubusercontent.com/106597485/226531432-7d4bea12-6a02-4c14-8211-729ae0b337cd.png">
<img width="278" alt="Screenshot 2023-03-21 at 11 35 14 AM" src="https://user-images.githubusercontent.com/106597485/226531444-0c4da110-937c-448e-8533-ccef0917fb89.png">
<img width="249" alt="Screenshot 2023-03-21 at 11 35 20 AM" src="https://user-images.githubusercontent.com/106597485/226531446-2767d8c3-f44b-4982-89d0-3945ea3f9536.png">
<img width="1278" alt="Screenshot 2023-03-21 at 11 49 14 AM" src="https://user-images.githubusercontent.com/106597485/226531581-8b24ba03-b7df-4310-b637-b80ee0ecfbcd.png">


## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/45400)
<!-- Reviewable:end -->
