### PR TITLE
[feat]: [CDS-58214]: replace environmentRef field name to envIdentifer for serviceOverrideNG

### DIFF
--- a/120-ng-manager/src/main/java/io/harness/ng/core/environment/resources/EnvironmentResourceV2.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/core/environment/resources/EnvironmentResourceV2.java
@@ -28,6 +28,7 @@ import static io.harness.utils.PageUtils.getNGPageResponse;
 
 import static java.lang.Long.parseLong;
 import static javax.ws.rs.core.HttpHeaders.IF_MATCH;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isNumeric;
 
 import io.harness.NGCommonEntityConstants;
@@ -719,12 +720,15 @@ public class EnvironmentResourceV2 {
         serviceOverridesEntity.getProjectIdentifier(), serviceOverridesEntity.getAccountId());
     environmentValidationHelper.checkThatEnvExists(serviceOverridesEntity.getAccountId(),
         serviceOverridesEntity.getOrgIdentifier(), serviceOverridesEntity.getProjectIdentifier(),
-        serviceOverridesEntity.getEnvironmentRef());
+        isNotBlank(serviceOverridesEntity.getEnvIdentifier()) ? serviceOverridesEntity.getEnvIdentifier()
+                                                              : serviceOverridesEntity.getEnvironmentRef());
     serviceEntityValidationHelper.checkThatServiceExists(serviceOverridesEntity.getAccountId(),
         serviceOverridesEntity.getOrgIdentifier(), serviceOverridesEntity.getProjectIdentifier(),
         serviceOverridesEntity.getServiceRef());
     checkForServiceOverrideUpdateAccess(accountId, serviceOverridesEntity.getOrgIdentifier(),
-        serviceOverridesEntity.getProjectIdentifier(), serviceOverridesEntity.getEnvironmentRef(),
+        serviceOverridesEntity.getProjectIdentifier(),
+        isNotBlank(serviceOverridesEntity.getEnvIdentifier()) ? serviceOverridesEntity.getEnvIdentifier()
+                                                              : serviceOverridesEntity.getEnvironmentRef(),
         serviceOverridesEntity.getServiceRef());
     validateServiceOverrides(serviceOverridesEntity);
 
@@ -776,7 +780,9 @@ public class EnvironmentResourceV2 {
           && serviceOverrideInfoConfig.getConnectionStrings() == null) {
         final Optional<NGServiceOverridesEntity> optionalNGServiceOverrides =
             serviceOverrideService.get(serviceOverridesEntity.getAccountId(), serviceOverridesEntity.getOrgIdentifier(),
-                serviceOverridesEntity.getProjectIdentifier(), serviceOverridesEntity.getEnvironmentRef(),
+                serviceOverridesEntity.getProjectIdentifier(),
+                isNotBlank(serviceOverridesEntity.getEnvIdentifier()) ? serviceOverridesEntity.getEnvIdentifier()
+                                                                      : serviceOverridesEntity.getEnvironmentRef(),
                 serviceOverridesEntity.getServiceRef());
         if (optionalNGServiceOverrides.isEmpty()) {
           throw new InvalidRequestException("No overrides found in request");

--- a/120-ng-manager/src/main/java/io/harness/ng/core/migration/background/ChangeEnvironmentRefFieldNameToEnvIdentifierMigration.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/core/migration/background/ChangeEnvironmentRefFieldNameToEnvIdentifierMigration.java
@@ -1,0 +1,64 @@
+package io.harness.ng.core.migration.background;
+
+import io.harness.account.AccountClient;
+import io.harness.migration.NGMigration;
+import io.harness.ng.core.dto.AccountDTO;
+import io.harness.remote.client.CGRestUtils;
+
+import com.google.inject.Inject;
+import com.mongodb.client.result.UpdateResult;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+@Slf4j
+public class ChangeEnvironmentRefFieldNameToEnvIdentifierMigration implements NGMigration {
+  @Inject private MongoTemplate mongoTemplate;
+  @Inject private AccountClient accountClient;
+  private static final String DEBUG_LOG = "[ChangeEnvironmentRefFieldNameToEnvIdentifierMigration]: ";
+  private static final String OLD_FIELD_NAME = "environmentRef";
+  private static final String NEW_FIELD_NAME = "envIdentifier";
+  private static final String COLLECTION_NAME = "serviceOverridesNG";
+
+  @Override
+  public void migrate() {
+    try {
+      log.info(
+          DEBUG_LOG + "Starting migration of changing environmentRef field name to envIdentifier in serviceOverrideNG");
+      List<AccountDTO> allAccounts = CGRestUtils.getResponse(accountClient.getAllAccounts());
+      List<String> accountIdentifiers = allAccounts.stream()
+                                            .filter(AccountDTO::isNextGenEnabled)
+                                            .map(AccountDTO::getIdentifier)
+                                            .collect(Collectors.toList());
+
+      accountIdentifiers.forEach(accountId -> {
+        try {
+          log.info(DEBUG_LOG
+              + "Starting migration of changing environmentRef field name to envIdentifier in serviceOverrideNG for account : "
+              + accountId);
+
+          Update update = new Update().rename(OLD_FIELD_NAME, NEW_FIELD_NAME);
+          UpdateResult updateResult = mongoTemplate.updateMulti(new Query(), update, COLLECTION_NAME);
+
+          log.info("{} Migration successful for account : {} ,Successfully updated records {}", DEBUG_LOG, accountId,
+              updateResult.getModifiedCount());
+        } catch (Exception e) {
+          log.error(DEBUG_LOG
+                  + "Migration of changing environmentRef field name to envIdentifier in serviceOverrideNG failed for account: "
+                  + accountId,
+              e);
+        }
+      });
+
+      log.info(DEBUG_LOG
+          + "Migration of changing environmentRef field name to envIdentifier in serviceOverrideNG completed");
+    } catch (Exception e) {
+      log.error(
+          DEBUG_LOG + "Migration of changing environmentRef field name to envIdentifier in serviceOverrideNG failed.",
+          e);
+    }
+  }
+}

--- a/120-ng-manager/src/main/java/io/harness/ng/core/migration/background/ChangeEnvironmentRefFieldNameToEnvIdentifierMigration.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/core/migration/background/ChangeEnvironmentRefFieldNameToEnvIdentifierMigration.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
 package io.harness.ng.core.migration.background;
 
 import io.harness.account.AccountClient;

--- a/120-ng-manager/src/main/java/io/harness/ng/migration/NGCoreBackgroundMigrationDetails.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/migration/NGCoreBackgroundMigrationDetails.java
@@ -15,6 +15,7 @@ import io.harness.ng.core.migration.CreateDefaultGcpKmsSMInNGMigration;
 import io.harness.ng.core.migration.NGWebhookMendateSettingsCategoryUpdateMigration;
 import io.harness.ng.core.migration.PopulateYamlFieldInNGEnvironmentMigration;
 import io.harness.ng.core.migration.background.AddDeploymentTypeToInfrastructureEntityMigration;
+import io.harness.ng.core.migration.background.ChangeEnvironmentRefFieldNameToEnvIdentifierMigration;
 import io.harness.ng.core.migration.background.DeleteSoftDeletedConnectorsMigration;
 import io.harness.ng.core.migration.background.PopulateYamlAuthFieldInNGJiraConnectorMigration;
 import io.harness.ng.core.migration.background.PopulateYamlAuthFieldInNGServiceNowConnectorMigration;
@@ -49,6 +50,7 @@ public class NGCoreBackgroundMigrationDetails implements MigrationDetails {
         .add(Pair.of(8, PopulateYamlAuthFieldInNGJiraConnectorMigration.class))
         .add(Pair.of(9, CreateDefaultGcpKmsSMInNGMigration.class))
         .add(Pair.of(10, UserMetadataTwoFactorAuthenticationMigration.class))
+        .add(Pair.of(11, ChangeEnvironmentRefFieldNameToEnvIdentifierMigration.class))
         .build();
   }
 }

--- a/120-ng-manager/src/test/resources/mongo/indexes.txt
+++ b/120-ng-manager/src/test/resources/mongo/indexes.txt
@@ -143,7 +143,7 @@ secrets {"name": "migratedFromManager_1", "background": true} {"migratedFromMana
 secrets {"name": "unique_identification", "unique": true} {"accountIdentifier": 1, "orgIdentifier": 1, "projectIdentifier": 1, "identifier": 1}
 serviceAccounts {"name": "list_accounts_idx", "background": true} {"accountIdentifier": 1, "orgIdentifier": 1, "projectIdentifier": 1}
 serviceAccounts {"name": "unique_sa_idx", "unique": true, "collation": {"locale": "en", "strength": 1}} {"accountIdentifier": 1, "identifier": 1}
-serviceOverridesNG {"name": "unique_accountId_organizationIdentifier_projectIdentifier_environmentRef_serviceRef", "unique": true} {"accountId": 1, "orgIdentifier": 1, "projectIdentifier": 1, "environmentRef": 1, "serviceRef": 1}
+serviceOverridesNG {"name": "unique_accountId_organizationIdentifier_projectIdentifier_envIdentifier_serviceRef", "unique": true} {"accountId": 1, "orgIdentifier": 1, "projectIdentifier": 1, "envIdentifier": 1, "serviceRef": 1}
 servicesNG {"name": "index_accountId_orgId_projectId_createdAt_deleted_deletedAt", "background": true} {"accountId": 1, "orgIdentifier": 1, "projectIdentifier": 1, "createdAt": 1, "deleted": 1, "deletedAt": 1}
 servicesNG {"name": "unique_accountId_organizationIdentifier_projectIdentifier_serviceIdentifier", "unique": true} {"accountId": 1, "orgIdentifier": 1, "projectIdentifier": 1, "identifier": 1}
 settingConfigurations {"name": "category_idx", "background": true} {"category": 1}

--- a/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/environment/mappers/EnvironmentFilterHelper.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/environment/mappers/EnvironmentFilterHelper.java
@@ -313,13 +313,19 @@ public class EnvironmentFilterHelper {
         org.apache.commons.lang3.StringUtils.split(environmentRef, ".", MAX_RESULT_THRESHOLD_FOR_SPLIT);
     if (envRefSplit == null || envRefSplit.length == 1) {
       criteria = CoreCriteriaUtils.createCriteriaForGetList(accountId, orgIdentifier, projectIdentifier);
-      criteria.and(NGServiceOverridesEntityKeys.environmentRef).is(environmentRef);
+      Criteria envIdOrRefCriteria =
+          new Criteria().orOperator(Criteria.where(NGServiceOverridesEntityKeys.environmentRef).is(environmentRef),
+              Criteria.where(NGServiceOverridesEntityKeys.envIdentifier).is(environmentRef));
+      criteria.andOperator(envIdOrRefCriteria);
     } else {
       IdentifierRef envIdentifierRef =
           IdentifierRefHelper.getIdentifierRef(environmentRef, accountId, orgIdentifier, projectIdentifier);
       criteria = CoreCriteriaUtils.createCriteriaForGetList(envIdentifierRef.getAccountIdentifier(),
           envIdentifierRef.getOrgIdentifier(), envIdentifierRef.getProjectIdentifier());
-      criteria.and(NGServiceOverridesEntityKeys.environmentRef).is(envIdentifierRef.getIdentifier());
+      Criteria envIdOrRefCriteria = new Criteria().orOperator(
+          Criteria.where(NGServiceOverridesEntityKeys.environmentRef).is(envIdentifierRef.getIdentifier()),
+          Criteria.where(NGServiceOverridesEntityKeys.envIdentifier).is(envIdentifierRef.getIdentifier()));
+      criteria.andOperator(envIdOrRefCriteria);
     }
 
     if (isNotBlank(serviceRef)) {
@@ -358,7 +364,9 @@ public class EnvironmentFilterHelper {
     update.set(NGServiceOverridesEntityKeys.accountId, serviceOverridesEntity.getAccountId());
     update.set(NGServiceOverridesEntityKeys.orgIdentifier, serviceOverridesEntity.getOrgIdentifier());
     update.set(NGServiceOverridesEntityKeys.projectIdentifier, serviceOverridesEntity.getProjectIdentifier());
-    update.set(NGServiceOverridesEntityKeys.environmentRef, serviceOverridesEntity.getEnvironmentRef());
+    update.set(NGServiceOverridesEntityKeys.envIdentifier,
+        isNotBlank(serviceOverridesEntity.getEnvIdentifier()) ? serviceOverridesEntity.getEnvIdentifier()
+                                                              : serviceOverridesEntity.getEnvironmentRef());
     update.set(NGServiceOverridesEntityKeys.serviceRef, serviceOverridesEntity.getServiceRef());
     update.set(NGServiceOverridesEntityKeys.yaml, serviceOverridesEntity.getYaml());
     update.setOnInsert(NGServiceOverridesEntityKeys.createdAt, System.currentTimeMillis());

--- a/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/events/EnvironmentUpdatedEvent.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/events/EnvironmentUpdatedEvent.java
@@ -15,6 +15,8 @@ import static io.harness.ng.core.ResourceConstants.RESOURCE_TYPE;
 import static io.harness.ng.core.ResourceConstants.SERVICE_OVERRIDE_NAME;
 import static io.harness.ng.core.ResourceConstants.STATUS;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.event.Event;
 import io.harness.ng.core.AccountScope;
@@ -133,7 +135,8 @@ public class EnvironmentUpdatedEvent implements Event {
       case SERVICE_OVERRIDE:
         NGServiceOverridesEntity ngServiceOverridesEntity =
             newServiceOverridesEntity == null ? oldServiceOverridesEntity : newServiceOverridesEntity;
-        return ngServiceOverridesEntity.getEnvironmentRef();
+        return isNotBlank(ngServiceOverridesEntity.getEnvIdentifier()) ? ngServiceOverridesEntity.getEnvIdentifier()
+                                                                       : ngServiceOverridesEntity.getEnvironmentRef();
       case INFRASTRUCTURE:
         InfrastructureEntity infrastructure =
             newInfrastructureEntity == null ? oldInfrastructureEntity : newInfrastructureEntity;

--- a/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/beans/NGServiceOverridesEntity.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/beans/NGServiceOverridesEntity.java
@@ -47,7 +47,7 @@ public class NGServiceOverridesEntity implements PersistentEntity, ScopeAware {
   public static List<MongoIndex> mongoIndexes() {
     return ImmutableList.<MongoIndex>builder()
         .add(CompoundMongoIndex.builder()
-                 .name("unique_accountId_organizationIdentifier_projectIdentifier_environmentRef_serviceRef")
+                 .name("unique_accountId_organizationIdentifier_projectIdentifier_envIdentifier_serviceRef")
                  .unique(true)
                  .field(NGServiceOverridesEntityKeys.accountId)
                  .field(NGServiceOverridesEntityKeys.orgIdentifier)

--- a/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/beans/NGServiceOverridesEntity.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/beans/NGServiceOverridesEntity.java
@@ -64,8 +64,8 @@ public class NGServiceOverridesEntity implements PersistentEntity, ScopeAware {
   @Trimmed String orgIdentifier;
   @Trimmed String projectIdentifier;
   @NotNull @Trimmed String serviceRef;
-  @NotNull @Trimmed String environmentRef;
-  @NotNull @Trimmed String envIdentifier;
+  @Trimmed String environmentRef;
+  @Trimmed String envIdentifier;
 
   String yaml;
 

--- a/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/beans/NGServiceOverridesEntity.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/beans/NGServiceOverridesEntity.java
@@ -52,7 +52,7 @@ public class NGServiceOverridesEntity implements PersistentEntity, ScopeAware {
                  .field(NGServiceOverridesEntityKeys.accountId)
                  .field(NGServiceOverridesEntityKeys.orgIdentifier)
                  .field(NGServiceOverridesEntityKeys.projectIdentifier)
-                 .field(NGServiceOverridesEntityKeys.environmentRef)
+                 .field(NGServiceOverridesEntityKeys.envIdentifier)
                  .field(NGServiceOverridesEntityKeys.serviceRef)
                  .build())
         .build();

--- a/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/beans/NGServiceOverridesEntity.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/beans/NGServiceOverridesEntity.java
@@ -65,6 +65,7 @@ public class NGServiceOverridesEntity implements PersistentEntity, ScopeAware {
   @Trimmed String projectIdentifier;
   @NotNull @Trimmed String serviceRef;
   @NotNull @Trimmed String environmentRef;
+  @NotNull @Trimmed String envIdentifier;
 
   String yaml;
 

--- a/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/mapper/NGServiceOverrideEntityConfigMapper.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/mapper/NGServiceOverrideEntityConfigMapper.java
@@ -10,6 +10,8 @@ package io.harness.ng.core.serviceoverride.mapper;
 import static io.harness.annotations.dev.HarnessTeam.CDC;
 import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.cdng.azure.config.yaml.ApplicationSettingsConfiguration;
 import io.harness.cdng.azure.config.yaml.ConnectionStringsConfiguration;
@@ -60,7 +62,9 @@ public class NGServiceOverrideEntityConfigMapper {
     }
     return NGServiceOverrideConfig.builder()
         .serviceOverrideInfoConfig(NGServiceOverrideInfoConfig.builder()
-                                       .environmentRef(serviceOverridesEntity.getEnvironmentRef())
+                                       .environmentRef(isNotBlank(serviceOverridesEntity.getEnvIdentifier())
+                                               ? serviceOverridesEntity.getEnvIdentifier()
+                                               : serviceOverridesEntity.getEnvironmentRef())
                                        .serviceRef(serviceOverridesEntity.getServiceRef())
                                        .variables(variableOverride)
                                        .manifests(manifestsList)

--- a/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/mapper/ServiceOverridesMapper.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/mapper/ServiceOverridesMapper.java
@@ -7,6 +7,8 @@
 
 package io.harness.ng.core.serviceoverride.mapper;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.exception.InvalidRequestException;
@@ -30,7 +32,7 @@ public class ServiceOverridesMapper {
             .accountId(accountId)
             .orgIdentifier(serviceOverrideRequestDTO.getOrgIdentifier())
             .projectIdentifier(serviceOverrideRequestDTO.getProjectIdentifier())
-            .environmentRef(serviceOverrideRequestDTO.getEnvironmentIdentifier())
+            .envIdentifier(serviceOverrideRequestDTO.getEnvironmentIdentifier())
             .serviceRef(serviceOverrideRequestDTO.getServiceIdentifier())
             .yaml(serviceOverrideRequestDTO.getYaml())
             .build();
@@ -45,7 +47,9 @@ public class ServiceOverridesMapper {
         .accountId(serviceOverridesEntity.getAccountId())
         .orgIdentifier(serviceOverridesEntity.getOrgIdentifier())
         .projectIdentifier(serviceOverridesEntity.getProjectIdentifier())
-        .environmentRef(serviceOverridesEntity.getEnvironmentRef())
+        .environmentRef(isNotBlank(serviceOverridesEntity.getEnvIdentifier())
+                ? serviceOverridesEntity.getEnvIdentifier()
+                : serviceOverridesEntity.getEnvironmentRef())
         .serviceRef(serviceOverridesEntity.getServiceRef())
         .yaml(serviceOverridesEntity.getYaml())
         .build();

--- a/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/services/impl/ServiceOverrideServiceImpl.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/serviceoverride/services/impl/ServiceOverrideServiceImpl.java
@@ -97,16 +97,26 @@ public class ServiceOverrideServiceImpl implements ServiceOverrideService {
       String accountId, String orgIdentifier, String projectIdentifier, String environmentRef, String serviceRef) {
     String[] environmentRefSplit = StringUtils.split(environmentRef, ".", MAX_RESULT_THRESHOLD_FOR_SPLIT);
     if (environmentRefSplit == null || environmentRefSplit.length == 1) {
-      return serviceOverrideRepository
-          .findByAccountIdAndOrgIdentifierAndProjectIdentifierAndEnvironmentRefAndServiceRef(
+      Optional<NGServiceOverridesEntity> entityOptionalByEnvIdentifier =
+          serviceOverrideRepository.findByAccountIdAndOrgIdentifierAndProjectIdentifierAndEnvIdentifierAndServiceRef(
+              accountId, orgIdentifier, projectIdentifier, environmentRef, serviceRef);
+
+      return entityOptionalByEnvIdentifier.isPresent()
+          ? entityOptionalByEnvIdentifier
+          : serviceOverrideRepository.findByAccountIdAndOrgIdentifierAndProjectIdentifierAndEnvironmentRefAndServiceRef(
               accountId, orgIdentifier, projectIdentifier, environmentRef, serviceRef);
     } else {
       IdentifierRef envIdentifierRef =
           IdentifierRefHelper.getIdentifierRef(environmentRef, accountId, orgIdentifier, projectIdentifier);
-      return serviceOverrideRepository
-          .findByAccountIdAndOrgIdentifierAndProjectIdentifierAndEnvironmentRefAndServiceRef(
+      Optional<NGServiceOverridesEntity> entityOptionalByEnvIdentifier =
+          serviceOverrideRepository.findByAccountIdAndOrgIdentifierAndProjectIdentifierAndEnvIdentifierAndServiceRef(
               envIdentifierRef.getAccountIdentifier(), envIdentifierRef.getOrgIdentifier(),
               envIdentifierRef.getProjectIdentifier(), envIdentifierRef.getIdentifier(), serviceRef);
+
+      return entityOptionalByEnvIdentifier.isPresent()
+          ? entityOptionalByEnvIdentifier
+          : serviceOverrideRepository.findByAccountIdAndOrgIdentifierAndProjectIdentifierAndEnvironmentRefAndServiceRef(
+              accountId, orgIdentifier, projectIdentifier, environmentRef, serviceRef);
     }
   }
 

--- a/127-cd-nextgen-entities/src/main/java/io/harness/repositories/serviceoverride/spring/ServiceOverrideRepository.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/repositories/serviceoverride/spring/ServiceOverrideRepository.java
@@ -19,4 +19,7 @@ public interface ServiceOverrideRepository
     extends PagingAndSortingRepository<NGServiceOverridesEntity, String>, ServiceOverrideRepositoryCustom {
   Optional<NGServiceOverridesEntity> findByAccountIdAndOrgIdentifierAndProjectIdentifierAndEnvironmentRefAndServiceRef(
       String accountId, String orgIdentifier, String projectIdentifier, String environmentRef, String serviceRef);
+
+  Optional<NGServiceOverridesEntity> findByAccountIdAndOrgIdentifierAndProjectIdentifierAndEnvIdentifierAndServiceRef(
+      String accountId, String orgIdentifier, String projectIdentifier, String environmentRef, String serviceRef);
 }

--- a/127-cd-nextgen-entities/src/test/java/io/harness/ng/core/serviceoverride/services/impl/ServiceOverrideServiceImplTest.java
+++ b/127-cd-nextgen-entities/src/test/java/io/harness/ng/core/serviceoverride/services/impl/ServiceOverrideServiceImplTest.java
@@ -120,8 +120,7 @@ public class ServiceOverrideServiceImplTest extends NGCoreTestBase {
     assertThat(upsertedServiceOverridesEntity.getProjectIdentifier())
         .isEqualTo(serviceOverridesEntity.getProjectIdentifier());
     assertThat(upsertedServiceOverridesEntity.getServiceRef()).isEqualTo(serviceOverridesEntity.getServiceRef());
-    assertThat(upsertedServiceOverridesEntity.getEnvironmentRef())
-        .isEqualTo(serviceOverridesEntity.getEnvironmentRef());
+    assertThat(upsertedServiceOverridesEntity.getEnvIdentifier()).isEqualTo(serviceOverridesEntity.getEnvironmentRef());
     assertThat(upsertedServiceOverridesEntity.getYaml()).isNotNull();
 
     // list
@@ -393,8 +392,7 @@ public class ServiceOverrideServiceImplTest extends NGCoreTestBase {
     assertThat(upsertedServiceOverridesEntity.getProjectIdentifier())
         .isEqualTo(serviceOverridesEntity.getProjectIdentifier());
     assertThat(upsertedServiceOverridesEntity.getServiceRef()).isEqualTo(serviceOverridesEntity.getServiceRef());
-    assertThat(upsertedServiceOverridesEntity.getEnvironmentRef())
-        .isEqualTo(serviceOverridesEntity.getEnvironmentRef());
+    assertThat(upsertedServiceOverridesEntity.getEnvIdentifier()).isEqualTo(serviceOverridesEntity.getEnvironmentRef());
     assertThat(upsertedServiceOverridesEntity.getYaml()).isNotNull();
 
     NGServiceOverridesEntity serviceOverridesEntity2 =


### PR DESCRIPTION
## Describe your changes
1. Migration to in-place change environtmentRef field name to envIdentifier
2. Added new envIdentifier in NGServiceOverridesEntity.java, updated index in java file as well in index.txt (Keeping the old field to be safegurad for migration failure)
3. Removing javax NotNull from environtmentRef & envIdentifier fields in NGServiceOverridesEntity
4. Not changing any internal POJO class yet, Only change in NGServiceOverridesEntity
5. Any upsert query will only update envIdentifier
6. Every Criteria for get or update will contain orOperation of Criteria.where(environmentRef), Criteria.where(envIdentifier)

**Sanity test plan**
Project, org, Account level cruds
Delete all on project delete
Older entities with envRef exist in DB
New entities with envId exist in DB
Mixed entities with envId, environmentRef exist in DB
ServiceOverride View page
One pipeline execution involving overrides





## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/45893)
<!-- Reviewable:end -->
