### PR TITLE
fix:[CDS-58178]: Skip audit operation when the execution comes from an API call

### DIFF
--- a/400-rest/src/main/java/io/harness/delegate/resources/DelegateTagsResource.java
+++ b/400-rest/src/main/java/io/harness/delegate/resources/DelegateTagsResource.java
@@ -27,12 +27,14 @@ import software.wings.security.annotations.ApiKeyAuthorized;
 import software.wings.security.annotations.AuthRule;
 import software.wings.security.annotations.Scope;
 import software.wings.service.intfc.DelegateService;
+import software.wings.utils.HttpRequestUtils;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.inject.Inject;
 import io.swagger.annotations.Api;
 import java.util.List;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.DELETE;
@@ -43,6 +45,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
 import lombok.extern.slf4j.Slf4j;
 import retrofit2.http.Body;
 
@@ -81,11 +84,14 @@ public class DelegateTagsResource {
   @ExceptionMetered
   @AuthRule(permissionType = MANAGE_DELEGATES)
   @ApiKeyAuthorized(permissionType = MANAGE_DELEGATES)
-  public RestResponse<DelegateDTO> addTags(@PathParam("delegateId") @NotEmpty String delegateId,
-      @QueryParam("accountId") @NotEmpty String accountId, @Body @NotNull DelegateTags delegateTags) {
+  public RestResponse<DelegateDTO> addTags(@Context HttpServletRequest request,
+      @PathParam("delegateId") @NotEmpty String delegateId, @QueryParam("accountId") @NotEmpty String accountId,
+      @Body @NotNull DelegateTags delegateTags) {
     try (AutoLogContext ignore1 = new AccountLogContext(accountId, OVERRIDE_ERROR);
          AutoLogContext ignore2 = new DelegateLogContext(delegateId, OVERRIDE_ERROR)) {
-      return new RestResponse<>(delegateService.addDelegateTags(accountId, delegateId, delegateTags));
+      return new RestResponse<>(HttpRequestUtils.hasApiKey(request)
+              ? delegateService.addDelegateTagsFromApi(accountId, delegateId, delegateTags)
+              : delegateService.addDelegateTags(accountId, delegateId, delegateTags));
     }
   }
 
@@ -95,11 +101,14 @@ public class DelegateTagsResource {
   @ExceptionMetered
   @AuthRule(permissionType = MANAGE_DELEGATES)
   @ApiKeyAuthorized(permissionType = MANAGE_DELEGATES)
-  public RestResponse<DelegateDTO> updateTags(@PathParam("delegateId") @NotEmpty String delegateId,
-      @QueryParam("accountId") @NotEmpty String accountId, @Body @NotNull DelegateTags delegateTags) {
+  public RestResponse<DelegateDTO> updateTags(@Context HttpServletRequest request,
+      @PathParam("delegateId") @NotEmpty String delegateId, @QueryParam("accountId") @NotEmpty String accountId,
+      @Body @NotNull DelegateTags delegateTags) {
     try (AutoLogContext ignore1 = new AccountLogContext(accountId, OVERRIDE_ERROR);
          AutoLogContext ignore2 = new DelegateLogContext(delegateId, OVERRIDE_ERROR)) {
-      return new RestResponse<>(delegateService.updateDelegateTags(accountId, delegateId, delegateTags));
+      return new RestResponse<>(HttpRequestUtils.hasApiKey(request)
+              ? delegateService.updateDelegateTagsFromApi(accountId, delegateId, delegateTags)
+              : delegateService.updateDelegateTags(accountId, delegateId, delegateTags));
     }
   }
 
@@ -109,11 +118,13 @@ public class DelegateTagsResource {
   @ExceptionMetered
   @AuthRule(permissionType = MANAGE_DELEGATES)
   @ApiKeyAuthorized(permissionType = MANAGE_DELEGATES)
-  public RestResponse<DelegateDTO> deleteTags(
+  public RestResponse<DelegateDTO> deleteTags(@Context HttpServletRequest request,
       @PathParam("delegateId") @NotEmpty String delegateId, @QueryParam("accountId") @NotEmpty String accountId) {
     try (AutoLogContext ignore1 = new AccountLogContext(accountId, OVERRIDE_ERROR);
          AutoLogContext ignore2 = new DelegateLogContext(delegateId, OVERRIDE_ERROR)) {
-      return new RestResponse<>(delegateService.deleteDelegateTags(accountId, delegateId));
+      return new RestResponse<>(HttpRequestUtils.hasApiKey(request)
+              ? delegateService.deleteDelegateTagsFromApi(accountId, delegateId)
+              : delegateService.deleteDelegateTags(accountId, delegateId));
     }
   }
 

--- a/400-rest/src/main/java/software/wings/security/AuthRuleFilter.java
+++ b/400-rest/src/main/java/software/wings/security/AuthRuleFilter.java
@@ -17,6 +17,7 @@ import static io.harness.eraro.ErrorCode.NOT_WHITELISTED_IP;
 import static io.harness.exception.WingsException.USER;
 
 import static software.wings.security.AuthenticationFilter.API_KEY_HEADER;
+import static software.wings.utils.HttpRequestUtils.X_API_KEY;
 
 import static java.util.Arrays.asList;
 import static javax.ws.rs.HttpMethod.OPTIONS;
@@ -220,12 +221,12 @@ public class AuthRuleFilter implements ContainerRequestFilter {
     MultivaluedMap<String, String> queryParameters = requestContext.getUriInfo().getQueryParameters();
 
     String accountId = getRequestParamFromContext("accountId", pathParameters, queryParameters);
-    if (isNotEmpty(requestContext.getHeaderString("X-Api-Key"))) {
+    if (isNotEmpty(requestContext.getHeaderString(X_API_KEY))) {
       if (isEmpty(accountId)) {
-        accountId = apiKeyService.getAccountIdFromApiKey(requestContext.getHeaderString("X-Api-Key"));
+        accountId = apiKeyService.getAccountIdFromApiKey(requestContext.getHeaderString(X_API_KEY));
       }
       if (isNotEmpty(accountId)) {
-        ApiKeyEntry apiKeyEntry = apiKeyService.getByKey(requestContext.getHeaderString("X-Api-Key"), accountId);
+        ApiKeyEntry apiKeyEntry = apiKeyService.getByKey(requestContext.getHeaderString(X_API_KEY), accountId);
         auditServiceHelper.reportForAuditingUsingAccountId(accountId, null, apiKeyEntry, Event.Type.INVOKED);
       }
     }

--- a/400-rest/src/main/java/software/wings/service/intfc/DelegateService.java
+++ b/400-rest/src/main/java/software/wings/service/intfc/DelegateService.java
@@ -232,9 +232,15 @@ public interface DelegateService extends OwnedByAccount {
 
   DelegateDTO addDelegateTags(String accountId, String delegateId, DelegateTags delegateTags);
 
+  DelegateDTO addDelegateTagsFromApi(String accountId, String delegateId, DelegateTags delegateTags);
+
   DelegateDTO updateDelegateTags(String accountId, String delegateId, DelegateTags delegateTags);
 
+  DelegateDTO updateDelegateTagsFromApi(String accountId, String delegateId, DelegateTags delegateTags);
+
   DelegateDTO deleteDelegateTags(String accountId, String delegateId);
+
+  DelegateDTO deleteDelegateTagsFromApi(String accountId, String delegateId);
 
   DelegateApprovalResponse approveDelegatesUsingProfile(
       String accountId, String delegateProfileId, DelegateApproval action) throws InvalidRequestException;

--- a/400-rest/src/main/java/software/wings/utils/HttpRequestUtils.java
+++ b/400-rest/src/main/java/software/wings/utils/HttpRequestUtils.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package software.wings.utils;
+
+import io.harness.data.structure.EmptyPredicate;
+
+import javax.servlet.http.HttpServletRequest;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class HttpRequestUtils {
+  public static final String X_API_KEY = "X-Api-Key";
+
+  public static boolean hasApiKey(@NonNull HttpServletRequest request) {
+    return EmptyPredicate.isNotEmpty(request.getHeader(X_API_KEY));
+  }
+}

--- a/400-rest/src/test/java/software/wings/utils/HttpRequestUtilsTest.java
+++ b/400-rest/src/test/java/software/wings/utils/HttpRequestUtilsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package software.wings.utils;
+
+import static io.harness.rule.OwnerRule.FERNANDOD;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.rule.Owner;
+
+import javax.servlet.http.HttpServletRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+@OwnedBy(HarnessTeam.SPG)
+public class HttpRequestUtilsTest {
+  @Mock private HttpServletRequest request;
+
+  @Test
+  @Owner(developers = FERNANDOD)
+  @Category(UnitTests.class)
+  public void shouldHasApiKeyNotAcceptNullRequest() {
+    Assertions.assertThatCode(() -> HttpRequestUtils.hasApiKey(null)).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  @Owner(developers = FERNANDOD)
+  @Category(UnitTests.class)
+  public void shouldHasApiKeyFalseWhenValueIsEmpty() {
+    when(request.getHeader(HttpRequestUtils.X_API_KEY)).thenReturn("");
+    assertThat(HttpRequestUtils.hasApiKey(request)).isFalse();
+  }
+
+  @Test
+  @Owner(developers = FERNANDOD)
+  @Category(UnitTests.class)
+  public void shouldHasApiKeyFalseWhenValueIsNull() {
+    when(request.getHeader(HttpRequestUtils.X_API_KEY)).thenReturn(null);
+    assertThat(HttpRequestUtils.hasApiKey(request)).isFalse();
+  }
+
+  // CURRENT RULE FROM AuthRuleFilter USES EmptyPredicate.isEmpty
+  @Test
+  @Owner(developers = FERNANDOD)
+  @Category(UnitTests.class)
+  public void shouldHasApiKeyTrueWithSpaceContent() {
+    when(request.getHeader(HttpRequestUtils.X_API_KEY)).thenReturn("   ");
+    assertThat(HttpRequestUtils.hasApiKey(request)).isTrue();
+  }
+
+  @Test
+  @Owner(developers = FERNANDOD)
+  @Category(UnitTests.class)
+  public void shouldHasApiKeyTrue() {
+    when(request.getHeader(HttpRequestUtils.X_API_KEY)).thenReturn("any-content");
+    assertThat(HttpRequestUtils.hasApiKey(request)).isTrue();
+  }
+}


### PR DESCRIPTION
## Describe your changes
The audit operation of an API call is made from AuthRuleFilter without identifying which user made the call, then the service layer doesn't need to audit it again as we don't know which user made it. That is a CG design as the API token is related to a group of users instead of one user.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/45956)
<!-- Reviewable:end -->
