### PR TITLE
[fix]: [PL-31746]: Fix flaky test //960-persistence:io.harness.iterator.PersistenceRegularIteratorTest testLoopWakeup

### DIFF
--- a/960-persistence/src/main/java/io/harness/mongo/MongoPersistence.java
+++ b/960-persistence/src/main/java/io/harness/mongo/MongoPersistence.java
@@ -203,13 +203,17 @@ public class MongoPersistence implements HPersistence {
 
   @Override
   public AdvancedDatastore getDatastore(Store store) {
-    return datastoreMap.computeIfAbsent(store.getName(), key -> {
-      Info info = storeInfo.get(store.getName());
-      if (info == null || isEmpty(info.getUri())) {
-        return getDatastore(DEFAULT_STORE);
-      }
-      return MongoModule.createDatastore(morphia, info.getUri(), store.getName(), harnessConnectionPoolListener);
-    });
+    if (datastoreMap.containsKey(store.getName())) {
+      return datastoreMap.get(store.getName());
+    }
+    Info info = storeInfo.get(store.getName());
+    if (info == null || isEmpty(info.getUri())) {
+      return getDatastore(DEFAULT_STORE);
+    }
+
+    datastoreMap.put(store.getName(),
+        MongoModule.createDatastore(morphia, info.getUri(), store.getName(), harnessConnectionPoolListener));
+    return datastoreMap.get(store.getName());
   }
 
   @Override

--- a/960-persistence/src/main/java/io/harness/mongo/MongoPersistence.java
+++ b/960-persistence/src/main/java/io/harness/mongo/MongoPersistence.java
@@ -203,16 +203,15 @@ public class MongoPersistence implements HPersistence {
 
   @Override
   public AdvancedDatastore getDatastore(Store store) {
-    if (datastoreMap.containsKey(store.getName())) {
-      return datastoreMap.get(store.getName());
-    }
-    Info info = storeInfo.get(store.getName());
-    if (info == null || isEmpty(info.getUri())) {
-      return getDatastore(DEFAULT_STORE);
-    }
+    if (!datastoreMap.containsKey(store.getName())) {
+      Info info = storeInfo.get(store.getName());
+      if (info == null || isEmpty(info.getUri())) {
+        return getDatastore(DEFAULT_STORE);
+      }
 
-    datastoreMap.put(store.getName(),
-        MongoModule.createDatastore(morphia, info.getUri(), store.getName(), harnessConnectionPoolListener));
+      datastoreMap.put(store.getName(),
+          MongoModule.createDatastore(morphia, info.getUri(), store.getName(), harnessConnectionPoolListener));
+    }
     return datastoreMap.get(store.getName());
   }
 


### PR DESCRIPTION
## Describe your changes
Fixing flaky test which is leading to developer productivity impact. The issue is with the use of java 8 Maps `computeIfAbsent()`, this was fixed in Java version 9 and above (The mapping function should not modify this map during computation): https://bugs.openjdk.org/browse/JDK-8071667 

Failing test stack trace: 
`03:41:07.528 [testLoopWakeup] ERROR io.harness.rule.InjectorRuleMixin - Test exception 
java.util.ConcurrentModificationException: null
	at java.base/java.util.HashMap.computeIfAbsent(hashmap.java:1135)
	at io.harness.mongo.MongoPersistence.getDatastore(mongopersistence.java:206)
	at io.harness.persistence.HPersistence.getDatastore(hpersistence.java:115)
	at io.harness.persistence.HPersistence.getDatastore(hpersistence.java:82)
	at [io.harness.mongo.MongoPersistence.save](https://app.harness.io/ng/io.harness.mongo.MongoPersistence.save)(mongopersistence.java:394)
	at io.harness.iterator.PersistenceRegularIteratorTest.testLoopWakeup(persistenceregulariteratortest.java:136)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(nativemethodaccessorimpl.java:62)`
[link](https://app.harness.io/ng/#/account/VRuJ8-dqQH6QZgAtoBr66g/ci/orgs/default/projects/PRCHECKS/pipelines/TIAll/executions/1rGgoxwNT4WLCTvufF7p0A/pipeline?connectorRef=wingssoftware&repoName=build-tools-utility&branch=main&storeType=REMOTE&stage=M43mDu0sQoGknZcofvMKDw&step=Oa3UgfDKTASeS7KdR6Fk8g&childStage=&stageExecId=) of failure pipeline
To circumvent the issue, we have used another approach of checking if key exists and then using it for further computation. Verified the unit tests.

## Checklist
- [x] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger utAll`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- FunctionalTest1: `trigger ft1`
- FunctionalTest2: `trigger ft2`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/46416)
<!-- Reviewable:end -->
