### PR TITLE
fix: [PL-38512]: delegateType was missing

### DIFF
--- a/400-rest/src/main/java/software/wings/resources/DelegateAgentResource.java
+++ b/400-rest/src/main/java/software/wings/resources/DelegateAgentResource.java
@@ -393,7 +393,7 @@ public class DelegateAgentResource {
     try (AutoLogContext ignore1 = new AccountLogContext(accountId, OVERRIDE_ERROR);
          AutoLogContext ignore2 = new DelegateLogContext(delegateId, OVERRIDE_ERROR)) {
       return new RestResponse<>(delegateService.getDelegateScripts(accountId, version,
-          subdomainUrlHelper.getManagerUrl(request, accountId), getVerificationUrl(request), delegateName));
+          subdomainUrlHelper.getManagerUrl(request, accountId), getVerificationUrl(request), delegateName, null));
     }
   }
 
@@ -421,11 +421,11 @@ public class DelegateAgentResource {
   public RestResponse<DelegateScripts> getDelegateScripts(@Context HttpServletRequest request,
       @QueryParam("accountId") @NotEmpty String accountId,
       @QueryParam("delegateVersion") @NotEmpty String delegateVersion, @QueryParam("patchVersion") String patchVersion,
-      @QueryParam("delegateName") String delegateName) throws IOException {
+      @QueryParam("delegateName") String delegateName, @QueryParam("delegateType") String delegateType) throws IOException {
     try (AutoLogContext ignore1 = new AccountLogContext(accountId, OVERRIDE_ERROR)) {
       String fullVersion = isNotEmpty(patchVersion) ? delegateVersion + "-" + patchVersion : delegateVersion;
       return new RestResponse<>(delegateService.getDelegateScripts(accountId, fullVersion,
-          subdomainUrlHelper.getManagerUrl(request, accountId), getVerificationUrl(request), delegateName));
+          subdomainUrlHelper.getManagerUrl(request, accountId), getVerificationUrl(request), delegateName, delegateType));
     }
   }
 

--- a/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/DelegateServiceImpl.java
@@ -1300,6 +1300,7 @@ public class DelegateServiceImpl implements DelegateService {
             .verificationHost(verificationHost)
             .logStreamingServiceBaseUrl(mainConfiguration.getLogStreamingServiceConfig().getExternalUrl())
             .delegateXmx(getDelegateXmx(delegateType))
+            .delegateType(delegateType)
             .delegateTokenName(delegateTokenName.orElse(null))
             .build(),
         true);
@@ -1311,6 +1312,7 @@ public class DelegateServiceImpl implements DelegateService {
             .verificationHost(verificationHost)
             .logStreamingServiceBaseUrl(mainConfiguration.getLogStreamingServiceConfig().getExternalUrl())
             .delegateXmx(getDelegateXmx(delegateType))
+            .delegateType(delegateType)
             .delegateTokenName(delegateTokenName.orElse(null))
             .watcher(true)
             .build(),
@@ -1328,7 +1330,7 @@ public class DelegateServiceImpl implements DelegateService {
 
   @Override
   public DelegateScripts getDelegateScripts(String accountId, String version, String managerHost,
-      String verificationHost, String delegateName) throws IOException {
+      String verificationHost, String delegateName, String delegateType) throws IOException {
     Optional<String> delegateTokenName = getDelegateTokenNameFromGlobalContext();
     ImmutableMap<String, String> scriptParams = getJarAndScriptRunTimeParamMap(
         TemplateParameters.builder()
@@ -1338,6 +1340,7 @@ public class DelegateServiceImpl implements DelegateService {
             .verificationHost(verificationHost)
             .logStreamingServiceBaseUrl(mainConfiguration.getLogStreamingServiceConfig().getExternalUrl())
             .delegateTokenName(delegateTokenName.orElse(null))
+            .delegateType(delegateType)
             .delegateName(StringUtils.defaultString(delegateName))
             .build(),
         false);
@@ -1349,6 +1352,7 @@ public class DelegateServiceImpl implements DelegateService {
             .verificationHost(verificationHost)
             .logStreamingServiceBaseUrl(mainConfiguration.getLogStreamingServiceConfig().getExternalUrl())
             .delegateTokenName(delegateTokenName.orElse(null))
+            .delegateType(delegateType)
             .delegateName(StringUtils.defaultString(delegateName))
             .watcher(true)
             .build(),

--- a/400-rest/src/main/java/software/wings/service/intfc/DelegateService.java
+++ b/400-rest/src/main/java/software/wings/service/intfc/DelegateService.java
@@ -107,7 +107,7 @@ public interface DelegateService extends OwnedByAccount {
       String delegateType) throws IOException;
 
   DelegateScripts getDelegateScripts(String accountId, String version, String managerHost, String verificationHost,
-      String delegateName) throws IOException;
+      String delegateName, String delegateType) throws IOException;
 
   String getLatestDelegateVersion(String accountId);
 

--- a/400-rest/src/test/java/software/wings/resources/DelegateAgentResourceTest.java
+++ b/400-rest/src/test/java/software/wings/resources/DelegateAgentResourceTest.java
@@ -324,7 +324,7 @@ public class DelegateAgentResourceTest extends CategoryTest {
         + httpServletRequest.getServerPort();
     DelegateScripts delegateScripts = DelegateScripts.builder().build();
     when(delegateService.getDelegateScripts(ACCOUNT_ID, version,
-             subdomainUrlHelper.getManagerUrl(httpServletRequest, ACCOUNT_ID), verificationUrl, null))
+             subdomainUrlHelper.getManagerUrl(httpServletRequest, ACCOUNT_ID), verificationUrl, null, null))
         .thenReturn(delegateScripts);
     RestResponse<DelegateScripts> restResponse = RESOURCES.client()
                                                      .target("/agent/delegates/" + DELEGATE_ID + "/upgrade?delegateId="
@@ -335,7 +335,7 @@ public class DelegateAgentResourceTest extends CategoryTest {
 
     verify(delegateService, atLeastOnce())
         .getDelegateScripts(ACCOUNT_ID, version, subdomainUrlHelper.getManagerUrl(httpServletRequest, ACCOUNT_ID),
-            verificationUrl, null);
+            verificationUrl, null, null);
     assertThat(restResponse.getResource()).isInstanceOf(DelegateScripts.class).isNotNull();
   }
 
@@ -433,7 +433,7 @@ public class DelegateAgentResourceTest extends CategoryTest {
         + httpServletRequest.getServerPort();
     DelegateScripts delegateScripts = DelegateScripts.builder().build();
     when(delegateService.getDelegateScripts(ACCOUNT_ID, delegateVersion,
-             subdomainUrlHelper.getManagerUrl(httpServletRequest, ACCOUNT_ID), verificationUrl, null))
+             subdomainUrlHelper.getManagerUrl(httpServletRequest, ACCOUNT_ID), verificationUrl, null, null))
         .thenReturn(delegateScripts);
 
     RestResponse<DelegateScripts> restResponse =
@@ -444,7 +444,7 @@ public class DelegateAgentResourceTest extends CategoryTest {
 
     verify(delegateService, atLeastOnce())
         .getDelegateScripts(ACCOUNT_ID, delegateVersion,
-            subdomainUrlHelper.getManagerUrl(httpServletRequest, ACCOUNT_ID), verificationUrl, null);
+            subdomainUrlHelper.getManagerUrl(httpServletRequest, ACCOUNT_ID), verificationUrl, null, null);
     assertThat(restResponse.getResource()).isInstanceOf(DelegateScripts.class).isNotNull();
   }
 
@@ -458,7 +458,7 @@ public class DelegateAgentResourceTest extends CategoryTest {
         + httpServletRequest.getServerPort();
     DelegateScripts delegateScripts = DelegateScripts.builder().build();
     when(delegateService.getDelegateScripts(ACCOUNT_ID, delegateVersion,
-             subdomainUrlHelper.getManagerUrl(httpServletRequest, ACCOUNT_ID), verificationUrl, delegateName))
+             subdomainUrlHelper.getManagerUrl(httpServletRequest, ACCOUNT_ID), verificationUrl, delegateName, null))
         .thenReturn(delegateScripts);
 
     RestResponse<DelegateScripts> restResponse =
@@ -470,7 +470,7 @@ public class DelegateAgentResourceTest extends CategoryTest {
 
     verify(delegateService, atLeastOnce())
         .getDelegateScripts(ACCOUNT_ID, delegateVersion,
-            subdomainUrlHelper.getManagerUrl(httpServletRequest, ACCOUNT_ID), verificationUrl, delegateName);
+            subdomainUrlHelper.getManagerUrl(httpServletRequest, ACCOUNT_ID), verificationUrl, delegateName, null);
     assertThat(restResponse.getResource()).isInstanceOf(DelegateScripts.class).isNotNull();
   }
 

--- a/960-watcher/src/main/java/io/harness/managerclient/ManagerClientV2.java
+++ b/960-watcher/src/main/java/io/harness/managerclient/ManagerClientV2.java
@@ -21,7 +21,7 @@ public interface ManagerClientV2 {
   @GET("agent/delegates/delegateScripts")
   Call<RestResponse<DelegateScripts>> getDelegateScripts(@Query("accountId") String accountId,
       @Query("delegateVersion") String delegateVersion, @Query("patchVersion") String patchVersion,
-      @Query("delegateName") String delegateName);
+      @Query("delegateName") String delegateName, @Query("delegateType") String delegateType);
 
   @GET("agent/delegates/delegateScriptsNg")
   Call<RestResponse<DelegateScripts>> getDelegateScriptsNg(@Query("accountId") String accountId,

--- a/960-watcher/src/main/java/io/harness/watcher/service/WatcherServiceImpl.java
+++ b/960-watcher/src/main/java/io/harness/watcher/service/WatcherServiceImpl.java
@@ -1020,7 +1020,7 @@ public class WatcherServiceImpl implements WatcherService {
       restResponse = callInterruptible21(timeLimiter, ofMinutes(1),
           ()
               -> SafeHttpCall.execute(managerClient.getDelegateScripts(
-                  watcherConfiguration.getAccountId(), updatedVersion, patchVersion, DELEGATE_NAME)));
+                  watcherConfiguration.getAccountId(), updatedVersion, patchVersion, DELEGATE_NAME, DELEGATE_TYPE)));
     } else {
       log.info(format("Calling getDelegateScriptsNg with version %s and patch %s", updatedVersion, patchVersion));
       restResponse = callInterruptible21(timeLimiter, ofMinutes(1),


### PR DESCRIPTION
## Describe your changes
When watcher downloads the start.sh and delegate.sh, the delegateType was missing in the scripts. Then for shell delegates, what happened was, the first time (after downloading from UI) run start.sh, the delegate registers with "SHELL_SCRIPT", but during the time of run, a new start.sh overwrites the old one. This new start.sh doesn't have delegateType set. Later, when user run stop.sh and start.sh again, the delegate registers with an empty delegate type 

This problem doesn't exit for k8s nor docker, because DELEGATE_TYPE env is set on the container. 



## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/47397)
<!-- Reviewable:end -->
