### PR TITLE
fix: [PL-38575]: Handle all runtime exceptions thrown from Redis in Iterator module

### DIFF
--- a/960-persistence/src/main/java/io/harness/mongo/iterator/MongoPersistenceIterator.java
+++ b/960-persistence/src/main/java/io/harness/mongo/iterator/MongoPersistenceIterator.java
@@ -362,6 +362,8 @@ public class MongoPersistenceIterator<T extends PersistentIterable, F extends Fi
         // Update the documents next iteration field
         updateDocumentNextIteration(docIds, base);
 
+      } catch (Exception ex) {
+        log.error("Received an exception in redisBatchProcess {} ", ex);
       } finally {
         // Release the distributed lock - acquiredLock cannot be null
         releaseLock(acquiredLock);
@@ -461,8 +463,12 @@ public class MongoPersistenceIterator<T extends PersistentIterable, F extends Fi
           // Got the lock, proceed further.
           return acquiredLock;
         } else {
-          log.warn("Failed to acquire distributed lock - attempting to reacquire");
+          log.warn("Failed to acquire distributed lock - attempting to reacquire after 5 secs");
+          sleep(ofSeconds(REDIS_BATCH_PAUSE_DURATION));
         }
+      } catch (Exception ex) {
+        log.error("Received an exception while acquiring lock - attempting to reacquire after 5 secs {} ", ex);
+        sleep(ofSeconds(REDIS_BATCH_PAUSE_DURATION));
       }
     }
   }

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=79216
+build.number=79217
 build.patch=000
 delegate.version=23.04.11
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes

In prod-1 and prod-2 we encountered Redis out of memory and as a result the iterators (ArtifactCollection, ArtifactCleanup and PerpetualTaskAssignment) running in RedisBatchMode stopped working. This was because the Redisson library was throwing a RedisOutOfMemoryException which was not being caught in the code. This PR fixes it by adding the necessary handling for any exceptions thrown from Redis.

Reproduced the issue locally and tested the fix by making Redis go OOM.

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/47586)
<!-- Reviewable:end -->
