### PR TITLE
[fix]: [CDS-69745]: Removed null value for startedAt field from ECS Task

### DIFF
--- a/260-delegate/build.properties
+++ b/260-delegate/build.properties
@@ -1,1 +1,1 @@
-build.number=79306
+build.number=79307

--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/beans/ecs/EcsMapper.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/beans/ecs/EcsMapper.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.time.Instant;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.collections.CollectionUtils;
@@ -64,7 +65,7 @@ public class EcsMapper {
         .launchType(task.launchTypeAsString())
         .taskArn(task.taskArn())
         .taskDefinitionArn(task.taskDefinitionArn())
-        .startedAt(task.startedAt() != null ? task.startedAt().getEpochSecond() : null)
+        .startedAt(task.startedAt() != null ? task.startedAt().getEpochSecond() : Instant.now().getEpochSecond())
         .startedBy(task.startedBy())
         .version(task.version())
         .containers(CollectionUtils.isNotEmpty(task.containers())


### PR DESCRIPTION
## Describe your changes
NPE is coming in a very corner case when start Time for ECS Tasks is coming null from delegate. 
In EcsServerInstanceInfo class, this startedAt field is of Long Object but in EcsInstanceInfoDTO class, this field is of primitive long datatype and we have a mapper to get ECS instance details from ECS server Instance details. NPE is happening when Long object is null and we are converting that to long data type.
so, I removed null value from start time
<img width="1728" alt="Screenshot 2023-05-19 at 10 36 51 AM" src="https://github.com/harness/harness-core/assets/96037200/29d5b0f4-9ec1-4675-aaa7-37191d6d7f96">

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

<details>
  <summary>PR Check triggers</summary>

You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ti0, ti1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/48068)
<!-- Reviewable:end -->
