### PR TITLE
feat: [PL-38974]: Allow deletion of SCIM users

### DIFF
--- a/123-ng-core-user/src/main/java/io/harness/ng/core/user/remote/UserResource.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/core/user/remote/UserResource.java
@@ -614,7 +614,7 @@ public class UserResource {
           NGCommonEntityConstants.PROJECT_KEY) String projectIdentifier) {
     if ((ScopeLevel.ACCOUNT.equals(ScopeLevel.of(accountIdentifier, orgIdentifier, projectIdentifier)))
         && isUserExternallyManaged(userId, accountIdentifier)) {
-      log.error("Externally managed user with userId: {} is being deleted from account: {}", userId, accountIdentifier);
+      log.warn("Externally managed user with userId: {} is being deleted from account: {}", userId, accountIdentifier);
     }
     ResponseDTO<Boolean> userRemovalResponse = removeUserInternal(
         userId, accountIdentifier, orgIdentifier, projectIdentifier, NGRemoveUserFilter.ACCOUNT_LAST_ADMIN_CHECK);

--- a/123-ng-core-user/src/main/java/io/harness/ng/core/user/remote/UserResource.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/core/user/remote/UserResource.java
@@ -614,20 +614,16 @@ public class UserResource {
           NGCommonEntityConstants.PROJECT_KEY) String projectIdentifier) {
     if ((ScopeLevel.ACCOUNT.equals(ScopeLevel.of(accountIdentifier, orgIdentifier, projectIdentifier)))
         && isUserExternallyManaged(userId, accountIdentifier)) {
-      // throw error when an externally managed user is being removed from account
-      log.error("User is externally managed, cannot delete user - userId: {}", userId);
-      throw new InvalidRequestException(
-          "User is externally managed by your Identity Provider and cannot be deleted via UI / API. To delete the user from Harness, delete it from your Identity Provider.");
-    } else {
-      ResponseDTO<Boolean> userRemovalResponse = removeUserInternal(
-          userId, accountIdentifier, orgIdentifier, projectIdentifier, NGRemoveUserFilter.ACCOUNT_LAST_ADMIN_CHECK);
-      if (ngFeatureFlagHelperService.isEnabled(accountIdentifier, FeatureName.PL_USER_DELETION_V2)
-          && !ngUserService.isUserAtScope(userId, Scope.builder().accountIdentifier(accountIdentifier).build())) {
-        ngUserService.removeUser(userId, accountIdentifier);
-      }
-
-      return userRemovalResponse;
+      log.error("Externally managed user with userId: {} is being deleted from account: {}", userId, accountIdentifier);
     }
+    ResponseDTO<Boolean> userRemovalResponse = removeUserInternal(
+        userId, accountIdentifier, orgIdentifier, projectIdentifier, NGRemoveUserFilter.ACCOUNT_LAST_ADMIN_CHECK);
+    if (ngFeatureFlagHelperService.isEnabled(accountIdentifier, FeatureName.PL_USER_DELETION_V2)
+        && !ngUserService.isUserAtScope(userId, Scope.builder().accountIdentifier(accountIdentifier).build())) {
+      ngUserService.removeUser(userId, accountIdentifier);
+    }
+
+    return userRemovalResponse;
   }
 
   @DELETE

--- a/123-ng-core-user/src/test/java/io/harness/ng/core/user/remote/UserResourceTest.java
+++ b/123-ng-core-user/src/test/java/io/harness/ng/core/user/remote/UserResourceTest.java
@@ -26,7 +26,6 @@ import io.harness.accesscontrol.clients.AccessControlClient;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.beans.FeatureName;
 import io.harness.category.element.UnitTests;
-import io.harness.exception.InvalidRequestException;
 import io.harness.ng.beans.PageRequest;
 import io.harness.ng.beans.PageResponse;
 import io.harness.ng.core.dto.ProjectDTO;
@@ -82,14 +81,19 @@ public class UserResourceTest extends CategoryTest {
     verify(projectService).listProjectsForUser(any(), eq(ACCOUNT), eq(pageRequest));
   }
 
-  @Test(expected = InvalidRequestException.class)
+  @Test
   @Owner(developers = BOOPESH)
   @Category(UnitTests.class)
   public void testRemoveExternallyManagedUser() {
     String userId = randomAlphabetic(10);
     Optional<UserInfo> userInfo = Optional.ofNullable(UserInfo.builder().externallyManaged(true).uuid(userId).build());
     doReturn(userInfo).when(ngUserService).getUserByIdAndAccount(userId, ACCOUNT);
+    doReturn(true).when(ngFeatureFlagHelperService).isEnabled(ACCOUNT, FeatureName.PL_USER_DELETION_V2);
+
     userResource.removeUser(userId, ACCOUNT, null, null);
+
+    verify(userResource).removeUserInternal(userId, ACCOUNT, null, null, NGRemoveUserFilter.ACCOUNT_LAST_ADMIN_CHECK);
+    verify(ngUserService).removeUser(userId, ACCOUNT);
   }
 
   @Test

--- a/400-rest/src/main/java/software/wings/resources/UserResource.java
+++ b/400-rest/src/main/java/software/wings/resources/UserResource.java
@@ -420,17 +420,6 @@ public class UserResource {
   @ExceptionMetered
   @AuthRule(permissionType = USER_PERMISSION_MANAGEMENT)
   public RestResponse delete(@QueryParam("accountId") @NotEmpty String accountId, @PathParam("userId") String userId) {
-    User user = userService.get(userId);
-    // If user doesn't exists, userService.get throws exception, so we don't have to handle it.
-    InvalidRequestException exception = new InvalidRequestException("Can not delete user added via SCIM", USER);
-    if (featureFlagService.isEnabled(FeatureName.PL_USER_ACCOUNT_LEVEL_DATA_FLOW, accountId)
-        && userServiceHelper.validationForUserAccountLevelDataFlow(user, accountId)) {
-      if (userServiceHelper.isSCIMManagedUser(accountId, user, CG)) {
-        throw exception;
-      }
-    } else if (user.isImported()) {
-      throw exception;
-    }
     userService.delete(accountId, userId);
     if (featureFlagService.isEnabled(FeatureName.PL_USER_DELETION_V2, accountId) && userService.isUserPresent(userId)
         && !userService.isUserPartOfAnyUserGroupInCG(userId, accountId)) {

--- a/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
+++ b/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
@@ -602,8 +602,6 @@ public enum FeatureName {
 
   PL_ENABLE_BASIC_ROLE_FOR_PROJECTS_ORGS(
       "Enable Basic Role assignment  Default User Group in Orgs and Projects", HarnessTeam.PL),
-  PL_REMOVE_EXTERNAL_USER_ORG_PROJECT(
-      "Allow deletion of externally managed user from orgs and projects", HarnessTeam.PL),
   CDP_AWS_SAM("FF for enabling AWS SAM deployments", HarnessTeam.CDP),
   CDS_TERRAFORM_CLOUD("Enable support of Terraform Cloud in the NG", HarnessTeam.CDP),
   CI_REMOTE_DEBUG("Enable the option for remote debug for CI users.", HarnessTeam.CI),


### PR DESCRIPTION
## Describe your changes
We will now support deletion of externallyManaged user from the UI with a warning. Hence, to support this, we are removing the externallyManaged check from the backend API for user deletion.

Testing (the below scenarios are tried with the FF- "PL_USER_DELETION_V2" enabled):-
1. Tested deleting a SCIM managed user in NG, who is not SCIM managed in CG -> User deletion successful from NG.
2. Tested deleting a SCIM managed user in NG, who is also SCIM managed in CG -> User deletion successful from NG.
3. Tested deleting a SCIM managed user in CG, who is also present in NG -> User is not deleted. However, they get removed from all the userGroups in CG (which is the current behaviour).
4. Tested deleting a SCIM managed user in CG, who is not present in NG -> User deletion successful from CG.

The UI modal for SCIM user deletion:-
<img width="1728" alt="Screenshot 2023-05-26 at 2 27 31 PM" src="https://github.com/harness/harness-core/assets/97941439/75cddf8f-b7ef-4eb3-bb0d-0681271b707e">

<img width="1728" alt="Screenshot 2023-05-26 at 5 01 11 PM" src="https://github.com/harness/harness-core/assets/97941439/34ebe920-ff1a-489e-bbe4-340a8bfafe0d">


## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [x] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/48404)
<!-- Reviewable:end -->
