### PR TITLE
fix: [CDS-70386]: enable fabric8 backward compatibility interceptor

### DIFF
--- a/260-delegate/build.properties
+++ b/260-delegate/build.properties
@@ -1,1 +1,1 @@
-build.number=79309
+build.number=79310

--- a/960-api-services/src/main/java/io/harness/k8s/KubernetesHelperService.java
+++ b/960-api-services/src/main/java/io/harness/k8s/KubernetesHelperService.java
@@ -115,6 +115,9 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 @Slf4j
 @OwnedBy(HarnessTeam.CDP)
 public class KubernetesHelperService {
+  static {
+    System.setProperty("kubernetes.backwardsCompatibilityInterceptor.disable", "false");
+  }
   @Inject private OidcTokenRetriever oidcTokenRetriever;
 
   public static void validateCluster(String cluster) {


### PR DESCRIPTION
## Describe your changes
As part of the fabric8 upgrade from 5.12 to 6.5, we see that the fabric8 code has changed the default value of this system property/env var to true. This means that they are no longer using the backward compatibility interceptor which retries some specific errors by substituting the apiVersions of some objects.

Ref: https://github.com/fabric8io/kubernetes-client/blob/master/doc/MIGRATION-v6.md#backwards-compatibility-interceptor


## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/48419)
<!-- Reviewable:end -->
