### PR TITLE
feat: [CDS-70928]: Avoid scaling/deleting of duplicate/ non color coded resources

### DIFF
--- a/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sBlueGreenStageScaleDownRequestHandlerTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sBlueGreenStageScaleDownRequestHandlerTest.java
@@ -39,7 +39,6 @@ import io.harness.exception.InvalidArgumentsException;
 import io.harness.helpers.k8s.releasehistory.K8sReleaseHandler;
 import io.harness.k8s.kubectl.Kubectl;
 import io.harness.k8s.model.K8sDelegateTaskParams;
-import io.harness.k8s.model.K8sSteadyStateDTO;
 import io.harness.k8s.model.KubernetesConfig;
 import io.harness.k8s.model.KubernetesResourceId;
 import io.harness.k8s.releasehistory.IK8sRelease;
@@ -106,15 +105,51 @@ public class K8sBlueGreenStageScaleDownRequestHandlerTest extends CategoryTest {
                                                            .namespace(namespace)
                                                            .versioned(false)
                                                            .build();
-  private KubernetesResourceId statefulSetGreen = KubernetesResourceId.builder()
-                                                      .kind("StatefulSet")
-                                                      .name("release-ss-todolist-green")
-                                                      .namespace(namespace)
-                                                      .versioned(false)
-                                                      .build();
-  private KubernetesResourceId statefulSetBlue = KubernetesResourceId.builder()
-                                                     .kind("StatefulSet")
-                                                     .name("release-ss-todolist-blue")
+  private final KubernetesResourceId statefulSetGreen = KubernetesResourceId.builder()
+                                                            .kind("StatefulSet")
+                                                            .name("release-ss-todolist-green")
+                                                            .namespace(namespace)
+                                                            .versioned(false)
+                                                            .build();
+  private final KubernetesResourceId statefulSetBlue = KubernetesResourceId.builder()
+                                                           .kind("StatefulSet")
+                                                           .name("release-ss-todolist-blue")
+                                                           .namespace(namespace)
+                                                           .versioned(false)
+                                                           .build();
+  private final KubernetesResourceId hpaBlue = KubernetesResourceId.builder()
+                                                   .kind("HorizontalPodAutoscaler")
+                                                   .name("hpa-blue")
+                                                   .namespace(namespace)
+                                                   .versioned(false)
+                                                   .build();
+  private final KubernetesResourceId pdbBlue = KubernetesResourceId.builder()
+                                                   .kind("PodDisruptionBudget")
+                                                   .name("pdb-blue")
+                                                   .namespace(namespace)
+                                                   .versioned(false)
+                                                   .build();
+  private final KubernetesResourceId hpaGreen = KubernetesResourceId.builder()
+                                                    .kind("HorizontalPodAutoscaler")
+                                                    .name("hpa-green")
+                                                    .namespace(namespace)
+                                                    .versioned(false)
+                                                    .build();
+  private final KubernetesResourceId pdbGreen = KubernetesResourceId.builder()
+                                                    .kind("PodDisruptionBudget")
+                                                    .name("pdb-green")
+                                                    .namespace(namespace)
+                                                    .versioned(false)
+                                                    .build();
+  private final KubernetesResourceId customHpa = KubernetesResourceId.builder()
+                                                     .kind("HorizontalPodAutoscaler")
+                                                     .name("custom-hpa")
+                                                     .namespace(namespace)
+                                                     .versioned(false)
+                                                     .build();
+  private final KubernetesResourceId customPdb = KubernetesResourceId.builder()
+                                                     .kind("PodDisruptionBudget")
+                                                     .name("custom-pdb")
                                                      .namespace(namespace)
                                                      .versioned(false)
                                                      .build();
@@ -191,7 +226,6 @@ public class K8sBlueGreenStageScaleDownRequestHandlerTest extends CategoryTest {
     doReturn(true)
         .when(k8sTaskHelperBase)
         .checkIfResourceExists(any(Kubectl.class), eq(delegateTaskParams), eq(deploymentGreen), eq(logCallback));
-    doReturn(true).when(k8sClient).performSteadyStateCheck(any(K8sSteadyStateDTO.class));
     doReturn(k8sLegacyRelease).when(releaseHistory).getLatestSuccessfulBlueGreenRelease();
     when(k8sTaskHelperBase.scale(
              any(Kubectl.class), eq(delegateTaskParams), eq(deploymentGreen), eq(0), eq(logCallback), eq(true)))
@@ -213,7 +247,6 @@ public class K8sBlueGreenStageScaleDownRequestHandlerTest extends CategoryTest {
                            .build();
 
     doReturn(k8sClient).when(k8sTaskHelperBase).getKubernetesClient(anyBoolean());
-    doReturn(true).when(k8sClient).performSteadyStateCheck(any(K8sSteadyStateDTO.class));
     doReturn(k8sLegacyRelease).when(releaseHistory).getLatestSuccessfulBlueGreenRelease();
     doReturn(true)
         .when(k8sTaskHelperBase)
@@ -270,18 +303,6 @@ public class K8sBlueGreenStageScaleDownRequestHandlerTest extends CategoryTest {
   @Owner(developers = PRATYUSH)
   @Category(UnitTests.class)
   public void testDeleteHPAAndPDB() throws Exception {
-    KubernetesResourceId hpaBlue = KubernetesResourceId.builder()
-                                       .kind("HorizontalPodAutoscaler")
-                                       .name("hpa-blue")
-                                       .namespace(namespace)
-                                       .versioned(false)
-                                       .build();
-    KubernetesResourceId pdbBlue = KubernetesResourceId.builder()
-                                       .kind("PodDisruptionBudget")
-                                       .name("pdb-blue")
-                                       .namespace(namespace)
-                                       .versioned(false)
-                                       .build();
     List<KubernetesResourceId> allResources = Arrays.asList(deploymentBlue, hpaBlue, pdbBlue);
     K8sLegacyRelease k8sLegacyRelease = K8sLegacyRelease.builder()
                                             .managedWorkload(deploymentBlue)
@@ -290,20 +311,7 @@ public class K8sBlueGreenStageScaleDownRequestHandlerTest extends CategoryTest {
                                             .build();
     K8sClient k8sClient = mock(K8sClient.class);
     doReturn(k8sClient).when(k8sTaskHelperBase).getKubernetesClient(anyBoolean());
-    doReturn(true).when(k8sClient).performSteadyStateCheck(any(K8sSteadyStateDTO.class));
     doReturn(k8sLegacyRelease).when(releaseHistory).getLatestSuccessfulBlueGreenRelease();
-    KubernetesResourceId hpaGreen = KubernetesResourceId.builder()
-                                        .kind("HorizontalPodAutoscaler")
-                                        .name("hpa-green")
-                                        .namespace(namespace)
-                                        .versioned(false)
-                                        .build();
-    KubernetesResourceId pdbGreen = KubernetesResourceId.builder()
-                                        .kind("PodDisruptionBudget")
-                                        .name("pdb-green")
-                                        .namespace(namespace)
-                                        .versioned(false)
-                                        .build();
     List<KubernetesResourceId> deleteResources = Arrays.asList(hpaGreen, pdbGreen);
     doReturn(true)
         .when(k8sTaskHelperBase)
@@ -321,6 +329,47 @@ public class K8sBlueGreenStageScaleDownRequestHandlerTest extends CategoryTest {
              any(Kubectl.class), eq(delegateTaskParams), eq(deleteResources), eq(logCallback), eq(false)))
         .thenReturn(deleteResources);
 
+    K8sDeployResponse response = k8sBlueGreenStageScaleDownRequestHandler.executeTask(
+        k8sBlueGreenStageScaleDownRequest, delegateTaskParams, iLogStreamingTaskClient, commandUnitsProgress);
+    verify(k8sTaskHelperBase, times(1))
+        .scale(any(Kubectl.class), eq(delegateTaskParams), eq(deploymentGreen), eq(0), eq(logCallback), eq(true));
+    verify(k8sTaskHelperBase, times(1))
+        .executeDeleteHandlingPartialExecution(
+            any(Kubectl.class), eq(delegateTaskParams), eq(deleteResources), eq(logCallback), eq(false));
+    assertThat(response).isEqualTo(
+        K8sDeployResponse.builder().commandExecutionStatus(CommandExecutionStatus.SUCCESS).build());
+  }
+
+  @Test
+  @Owner(developers = PRATYUSH)
+  @Category(UnitTests.class)
+  public void testNotToDeleteCustomHPAAndPDB() throws Exception {
+    List<KubernetesResourceId> allResources =
+        Arrays.asList(deploymentBlue, deploymentBlue, hpaBlue, pdbBlue, customHpa, customPdb);
+    K8sLegacyRelease k8sLegacyRelease = K8sLegacyRelease.builder()
+                                            .managedWorkload(deploymentBlue)
+                                            .resources(allResources)
+                                            .status(IK8sRelease.Status.Succeeded)
+                                            .build();
+    K8sClient k8sClient = mock(K8sClient.class);
+    doReturn(k8sClient).when(k8sTaskHelperBase).getKubernetesClient(anyBoolean());
+    doReturn(k8sLegacyRelease).when(releaseHistory).getLatestSuccessfulBlueGreenRelease();
+    List<KubernetesResourceId> deleteResources = Arrays.asList(hpaGreen, pdbGreen);
+    doReturn(true)
+        .when(k8sTaskHelperBase)
+        .checkIfResourceExists(any(Kubectl.class), eq(delegateTaskParams), eq(deploymentGreen), eq(logCallback));
+    doReturn(true)
+        .when(k8sTaskHelperBase)
+        .checkIfResourceExists(any(Kubectl.class), eq(delegateTaskParams), eq(hpaGreen), eq(logCallback));
+    doReturn(true)
+        .when(k8sTaskHelperBase)
+        .checkIfResourceExists(any(Kubectl.class), eq(delegateTaskParams), eq(pdbGreen), eq(logCallback));
+    when(k8sTaskHelperBase.scale(
+             any(Kubectl.class), eq(delegateTaskParams), eq(deploymentGreen), eq(0), eq(logCallback), eq(true)))
+        .thenReturn(true);
+    when(k8sTaskHelperBase.executeDeleteHandlingPartialExecution(
+             any(Kubectl.class), eq(delegateTaskParams), eq(deleteResources), eq(logCallback), eq(false)))
+        .thenReturn(deleteResources);
     K8sDeployResponse response = k8sBlueGreenStageScaleDownRequestHandler.executeTask(
         k8sBlueGreenStageScaleDownRequest, delegateTaskParams, iLogStreamingTaskClient, commandUnitsProgress);
     verify(k8sTaskHelperBase, times(1))


### PR DESCRIPTION
## Describe your changes
Ignore workloads with no color suffix or duplicates. In the current feature we were scaling down the resources which did not had color suffix. These resources are not managed by harness so we should not scale them down. It use to show error message while trying to scale/ delete duplicates. To avoid the clutter in log messages we will remove the duplicated from the list.

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [x] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/48698)
<!-- Reviewable:end -->
