### PR TITLE
[PL-39219]: Fix to shuffle delegates for uniform distribution of tasks

### DIFF
--- a/400-rest/src/test/java/software/wings/service/impl/DelegateTaskServiceClassicImplTest.java
+++ b/400-rest/src/test/java/software/wings/service/impl/DelegateTaskServiceClassicImplTest.java
@@ -8,6 +8,7 @@
 package software.wings.service.impl;
 
 import static io.harness.data.structure.UUIDGenerator.generateUuid;
+import static io.harness.rule.OwnerRule.GAURAV_NANDA;
 import static io.harness.rule.OwnerRule.JENNY;
 
 import static java.util.stream.Collectors.toList;
@@ -77,7 +78,7 @@ public class DelegateTaskServiceClassicImplTest extends WingsBaseTest {
   }
 
   @Test
-  @Owner(developers = JENNY)
+  @Owner(developers = GAURAV_NANDA)
   @Category(UnitTests.class)
   public void getEligibleDelegateListOrderedNumberByTaskAssigned_allDelegateWithZeroTasks_shuffledListReturned()
       throws ExecutionException {


### PR DESCRIPTION
## Describe your changes

Earlier we relied on a custom comparator to sort, which had a bug - fixed the bug, but even then shuffling was not great using comparators. Ended up writing a custom shuffler which only shuffles delegates with equal number of tasks assigned. Another minor optimization, is to ensure the first position between the same values is always shuffled.

I ran an experiment, with 10 delegates and simulated creation of 10 tasks together. Here is the distribution with each approach, delegate name and count.

1. **As is - with broken comparator** - as you can see that one delegate got 5 tasks, another got 3 and 1 for two of them. This is very close to what we observe on the customer side

[2ut4qobaR268meWuxcq (5), aZBtL13DTMey7jBoiHdP4w (3), UxPjCAj6TIuBrMCLjflZMw (1), eQTWPHSuTkWWvyWkD2Za7A (1)] 

2. **With fixed comparator** - still pretty bad results

[tRGPuJqhSb2B_4-2fQ_ikQ (4), 2fy2LPjsT--_wwoK8SGiOw (2), xRv3oIwwTeiEfvSsmj5SmQ (2), pwhhI0V9RzSVtIerfwHRmQ (2)]

3. **With shuffling without micro-optimization**

[BpmprAlPR6CzrB_I-e5IOQ (2), _b6f8VchQJ-2yRB4gJ5bZg(2), SRdi9AUiRp-ZDykT34GxWg(2), BH7_KVuxRp2wvHoUFKfaBg (1), ve94dZGdT7eoZBfDV4JNaQ(1), XeCuYeCsQGWy7PDTeOsI1g(1), rbfXpd3wTLqZfeLyBF6U(1)]

4. **Shuffling with the minor optimization of swapping the first index**

[ Gyqh2OcOQ6mxl7ITOwslEg (2), SKBU8FUrQx-hUsY1hur3hw (1), Gclsc33fT2q1j_S9pWqEPA (1),, icI8FRlmQeW4mnZdilPlHQ (1), OEJ_hb0NR1iQQmRl0jglgA (1), 0Anwi4YMSe68tS0ZCjovgQ (1), 4NhigH_bSceyPDqdFBYJXw (1), icI8FRlmQeW4mnZdilPlHQ (1), NYBkhbClQnCM7dXGu5ne2g (1)]


## Checklist
- [X] I've documented the changes in the PR description.
- [X] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/48833)
<!-- Reviewable:end -->
