### PR TITLE
fix: [CDS-72111]: do not retry when ssh session is aborted/expired

### DIFF
--- a/960-api-services/src/main/java/io/harness/shell/SshHelperUtils.java
+++ b/960-api-services/src/main/java/io/harness/shell/SshHelperUtils.java
@@ -83,6 +83,8 @@ public class SshHelperUtils {
         errorConst = SOCKET_CONNECTION_TIMEOUT;
       } else if (message.equals("session is down")) {
         errorConst = SSH_SESSION_TIMEOUT;
+      } else if (message.equals("socket is not established")) {
+        errorConst = SOCKET_CONNECTION_ERROR;
       }
     }
     return errorConst;

--- a/960-api-services/src/main/java/io/harness/shell/SshSessionFactory.java
+++ b/960-api-services/src/main/java/io/harness/shell/SshSessionFactory.java
@@ -41,6 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SshSessionFactory {
   private static final String SSH_NETWORK_PROXY = "SSH_NETWORK_PROXY";
   private static final int NR_OF_RETRIES_FOR_SSH_SESSION_CONNECTION = 6;
+  private static final String SOCKET_INTERRUPT_MESSAGE = "socket is not established";
 
   /**
    * Gets the SSH session with jumpbox.
@@ -91,7 +92,11 @@ public class SshSessionFactory {
       } catch (InterruptedException ie) {
         log.error("Interrupted exception while fetching ssh session", ie);
       } catch (JSchException jse) {
-        if (retryCount == NR_OF_RETRIES_FOR_SSH_SESSION_CONNECTION) {
+        if (SOCKET_INTERRUPT_MESSAGE.equals(jse.getMessage())) {
+          log.error("Interrupted while waiting for SSH connection with retry count {}, cause {}", retryCount,
+              jse.getMessage());
+          throw jse;
+        } else if (retryCount == NR_OF_RETRIES_FOR_SSH_SESSION_CONNECTION) {
           log.error("Jschexception while SSH connection with retry count {}, cause {}", retryCount, jse.getMessage());
           throw jse;
         }


### PR DESCRIPTION
## Describe your changes
Checked the jsch library. Only when thread.join is interrupted. We get the message exactly `socket is not established` otherwise its either `timeout: socket is not established` or from the exception thrown like (connect exception)

We are asserting on the message and not retrying when we see it. Added UT for the same. 

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/49004)
<!-- Reviewable:end -->
