### PR TITLE
[fix]: [CDS-72034]: adding handling for non recognized k8s resources

### DIFF
--- a/260-delegate/build.properties
+++ b/260-delegate/build.properties
@@ -1,1 +1,1 @@
-build.number=79505
+build.number=79506

--- a/970-api-services-beans/src/test/java/io/harness/k8s/model/KubernetesResourceEventHandlerTest.java
+++ b/970-api-services-beans/src/test/java/io/harness/k8s/model/KubernetesResourceEventHandlerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.k8s.model;
+
+import static io.harness.annotations.dev.HarnessTeam.CDP;
+import static io.harness.k8s.model.KubernetesResourceEventHandler.getHandler;
+import static io.harness.rule.OwnerRule.MLUKIC;
+
+import io.harness.CategoryTest;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.rule.Owner;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Slf4j
+@OwnedBy(CDP)
+public class KubernetesResourceEventHandlerTest extends CategoryTest {
+  @Test
+  @Owner(developers = MLUKIC)
+  @Category(UnitTests.class)
+  public void testGetHandler() {
+    getHandler("Deployment");
+    getHandler("HorizontalPodAutoscaler");
+    getHandler("PodDisruptionBudget");
+    getHandler("CustomCRD");
+    getHandler("ASDAPSIJDOAP");
+    getHandler("");
+    getHandler(null);
+  }
+}


### PR DESCRIPTION
## Describe your changes

In case of CRD resources we are handling the exception that happens in HPA and PDB handlers when trying to find the resources within our list of supported K8s Kinds. 

Once that case is recognised we are using default NOOP handler. 

## Checklist
- [X] I've documented the changes in the PR description.
- [X] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/49190)
<!-- Reviewable:end -->
