### PR TITLE
fix: [CDS-72920]: Ignore freeze override access check if execution is through trigger

### DIFF
--- a/125-freeze/src/main/java/io/harness/freeze/helpers/FreezeRBACHelper.java
+++ b/125-freeze/src/main/java/io/harness/freeze/helpers/FreezeRBACHelper.java
@@ -90,7 +90,8 @@ public class FreezeRBACHelper {
   public boolean checkIfUserHasFreezeOverrideAccess(NGFeatureFlagHelperService featureFlagHelperService,
       String accountId, String orgId, String projectId, AccessControlClient accessControlClient,
       io.harness.accesscontrol.acl.api.Principal principal) {
-    if (principal == null) {
+    if (principal == null
+        || io.harness.accesscontrol.principals.PrincipalType.SERVICE.equals(principal.getPrincipalType())) {
       return false;
     }
     Resource resource = Resource.of(DEPLOYMENTFREEZE, null);


### PR DESCRIPTION
## Describe your changes
Ignore freeze override access check if execution is through trigger, previously when a pipeline was executed through a trigger, the principal of Service was being set, which allowed anyone to override the freeze(as Service principal acts as Admin). So now ignored the override check if the principal type is service.

Tested locally with CDS_NG_TRIGGER_EXECUTION_REFACTOR FF enabled and disabled:
1. Manual execution using both Admin and another user(which doesn't have override access) - freezes for other user
2. Cron trigger, created by both Admin and another user(which doesn't have override access) - freezes for both case
3. Custom Webhook Trigger, using API key of both Admin and another user(which doesn't have override access) - freezes for both case
4. Custom Webhook Trigger(without API authentication) - freezes for both case

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/49791)
<!-- Reviewable:end -->
