### PR TITLE
fix: [CDS-73469]: prod hotfix:  Passing env variables while calculating manifest hash

### DIFF
--- a/260-delegate/build.properties
+++ b/260-delegate/build.properties
@@ -1,1 +1,1 @@
-build.number=79708
+build.number=79709

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/k8s/K8sBGRequestHandler.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/k8s/K8sBGRequestHandler.java
@@ -343,8 +343,8 @@ public class K8sBGRequestHandler extends K8sRequestHandler {
         k8sDelegateTaskParams.getWorkingDirectory(), executionLogCallback);
 
     if (storeReleaseHash) {
-      currentManifestHash = k8sManifestHashGenerator.manifestHash(
-          resources, k8sDelegateTaskParams, executionLogCallback, timeoutInMillis, client);
+      currentManifestHash =
+          k8sManifestHashGenerator.manifestHash(resources, k8sDelegateTaskParams, executionLogCallback, client);
     }
 
     if (request.isSkipDryRun()) {

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/k8s/k8sbase/K8sTaskHelperBase.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/k8s/k8sbase/K8sTaskHelperBase.java
@@ -230,6 +230,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -368,14 +369,30 @@ public class K8sTaskHelperBase {
          ByteArrayOutputStream errorCaptureStream = new ByteArrayOutputStream(1024);
          LogOutputStream logErrorStream =
              getExecutionLogOutputStream(executionLogCallback, errorLogLevel, errorCaptureStream)) {
-      return ProcessResponse.builder()
-          .processResult(command.execute(k8sDelegateTaskParams.getWorkingDirectory(), logOutputStream, logErrorStream,
-              true, Collections.emptyMap()))
-          .errorMessage(ExceptionMessageSanitizer.sanitizeMessage(errorCaptureStream.toString()))
-          .kubectlPath(k8sDelegateTaskParams.getKubectlPath())
-          .printableCommand(getPrintableCommand(command.command()))
-          .build();
+      return getProcessResponse(command, logOutputStream, logErrorStream, errorCaptureStream,
+          k8sDelegateTaskParams.getWorkingDirectory(), k8sDelegateTaskParams.getKubectlPath(), true);
     }
+  }
+
+  public static ProcessResponse executeCommandSilentlyWithErrorCapture(AbstractExecutable command,
+      K8sDelegateTaskParams k8sDelegateTaskParams, LogCallback executionLogCallback, LogLevel errorLogLevel)
+      throws Exception {
+    try (ByteArrayOutputStream errorCaptureStream = new ByteArrayOutputStream(1024);
+         LogOutputStream logErrorStream =
+             getExecutionLogOutputStream(executionLogCallback, errorLogLevel, errorCaptureStream)) {
+      return getProcessResponse(command, null, logErrorStream, errorCaptureStream,
+          k8sDelegateTaskParams.getWorkingDirectory(), k8sDelegateTaskParams.getKubectlPath(), false);
+    }
+  }
+
+  private static ProcessResponse getProcessResponse(AbstractExecutable command, OutputStream output, OutputStream error,
+      OutputStream errorCaptureStream, String workingDir, String kubectlPath, boolean printCommand) throws Exception {
+    return ProcessResponse.builder()
+        .processResult(command.execute(workingDir, output, error, printCommand, Collections.emptyMap()))
+        .errorMessage(ExceptionMessageSanitizer.sanitizeMessage(errorCaptureStream.toString()))
+        .kubectlPath(kubectlPath)
+        .printableCommand(getPrintableCommand(command.command()))
+        .build();
   }
 
   public static String getOcCommandPrefix(String ocPath, String kubeConfigPath) {
@@ -3121,7 +3138,7 @@ public class K8sTaskHelperBase {
         .collect(toList());
   }
 
-  private void logExecutableFailed(ProcessResult result, LogCallback logCallback) {
+  public void logExecutableFailed(ProcessResult result, LogCallback logCallback) {
     String output = result.hasOutput() ? result.outputUTF8() : null;
     if (isNotEmpty(output)) {
       logCallback.saveExecutionLog(

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sBGRequestHandlerTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sBGRequestHandlerTest.java
@@ -184,7 +184,7 @@ public class K8sBGRequestHandlerTest extends CategoryTest {
     doReturn(true).when(k8sClient).performSteadyStateCheck(any(K8sSteadyStateDTO.class));
     doReturn("sampleManifest")
         .when(k8sManifestHashGenerator)
-        .manifestHash(anyList(), eq(k8sDelegateTaskParams), eq(logCallback), anyLong(), any(Kubectl.class));
+        .manifestHash(anyList(), eq(k8sDelegateTaskParams), eq(logCallback), any(Kubectl.class));
     doReturn(HarnessLabelValues.colorBlue)
         .when(k8sBGBaseHandler)
         .getPrimaryColor(any(KubernetesResource.class), eq(kubernetesConfig), eq(logCallback));
@@ -239,7 +239,7 @@ public class K8sBGRequestHandlerTest extends CategoryTest {
     doReturn(legacyRelease).when(releaseHandler).createRelease(any(), anyInt());
     doReturn("sampleManifest")
         .when(k8sManifestHashGenerator)
-        .manifestHash(anyList(), eq(k8sDelegateTaskParams), eq(logCallback), anyLong(), any(Kubectl.class));
+        .manifestHash(anyList(), eq(k8sDelegateTaskParams), eq(logCallback), any(Kubectl.class));
     K8sClient k8sClient = mock(K8sClient.class);
     doReturn(k8sClient).when(k8sTaskHelperBase).getKubernetesClient(anyBoolean());
     doReturn(true).when(k8sClient).performSteadyStateCheck(any(K8sSteadyStateDTO.class));
@@ -298,7 +298,7 @@ public class K8sBGRequestHandlerTest extends CategoryTest {
         .readManifests(anyList(), eq(logCallback), eq(true));
     doReturn("sampleManifest")
         .when(k8sManifestHashGenerator)
-        .manifestHash(anyList(), eq(k8sDelegateTaskParams), eq(logCallback), anyLong(), any(Kubectl.class));
+        .manifestHash(anyList(), eq(k8sDelegateTaskParams), eq(logCallback), any(Kubectl.class));
     doReturn(deployedPods)
         .when(k8sBGBaseHandler)
         .getAllPods(anyLong(), eq(kubernetesConfig), any(KubernetesResource.class), eq(HarnessLabelValues.colorBlue),
@@ -424,7 +424,7 @@ public class K8sBGRequestHandlerTest extends CategoryTest {
         .readManifests(anyList(), eq(logCallback), eq(true));
     doReturn("sampleManifest")
         .when(k8sManifestHashGenerator)
-        .manifestHash(anyList(), eq(k8sDelegateTaskParams), eq(logCallback), anyLong(), any(Kubectl.class));
+        .manifestHash(anyList(), eq(k8sDelegateTaskParams), eq(logCallback), any(Kubectl.class));
     doThrow(exception)
         .when(k8sTaskHelperBase)
         .applyManifests(
@@ -461,7 +461,7 @@ public class K8sBGRequestHandlerTest extends CategoryTest {
     K8sClient k8sClient = mock(K8sClient.class);
     doReturn("sampleManifest")
         .when(k8sManifestHashGenerator)
-        .manifestHash(anyList(), eq(k8sDelegateTaskParams), eq(logCallback), anyLong(), any(Kubectl.class));
+        .manifestHash(anyList(), eq(k8sDelegateTaskParams), eq(logCallback), any(Kubectl.class));
     doReturn(HarnessLabelValues.colorBlue)
         .when(k8sBGBaseHandler)
         .getPrimaryColor(any(KubernetesResource.class), eq(kubernetesConfig), eq(logCallback));
@@ -525,7 +525,7 @@ public class K8sBGRequestHandlerTest extends CategoryTest {
     final InvalidRequestException thrownException = new InvalidRequestException("failed");
     doReturn("sampleManifest")
         .when(k8sManifestHashGenerator)
-        .manifestHash(anyList(), eq(k8sDelegateTaskParams), eq(logCallback), anyLong(), any(Kubectl.class));
+        .manifestHash(anyList(), eq(k8sDelegateTaskParams), eq(logCallback), any(Kubectl.class));
     doReturn(kubernetesConfig)
         .when(containerDeploymentDelegateBaseHelper)
         .createKubernetesConfig(k8sInfraDelegateConfig, workingDirectory, logCallback);


### PR DESCRIPTION
## Describe your changes
Passing env variables while calculating manifest hash. We were not passing GCP environment variables in case GKE infra due to which it was failing specifically for this case

Parent PR: https://github.com/harness/harness-core/pull/50028
tested locally
## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/50058)
<!-- Reviewable:end -->
