### PR TITLE
techdebt: [PL-39827]: Changes required for UTs to be able to run in java 17 runtime env

### DIFF
--- a/125-cd-nextgen/src/test/java/io/harness/cdng/elastigroup/ElastigroupStepCommonHelperTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/elastigroup/ElastigroupStepCommonHelperTest.java
@@ -684,7 +684,7 @@ public class ElastigroupStepCommonHelperTest extends CDNGTestBase {
 
     assertThat(((ElastigroupStepExceptionPassThroughData) taskChainResponse.getPassThroughData()).getErrorMessage())
         .isNotNull()
-        .isEqualTo("NullPointerException");
+        .contains("NullPointerException");
   }
 
   @Test

--- a/260-delegate/src/test/java/software/wings/delegatetasks/k8s/K8sTaskHelperTest.java
+++ b/260-delegate/src/test/java/software/wings/delegatetasks/k8s/K8sTaskHelperTest.java
@@ -986,6 +986,7 @@ public class K8sTaskHelperTest extends CategoryTest {
   @Category(UnitTests.class)
   public void testShouldGetEmptyResourcesFromRemoteManifests() throws Exception {
     K8sDelegateTaskParams params = K8sDelegateTaskParams.builder()
+                                       .workingDirectory("/some/dir/")
                                        .goTemplateClientPath(".")
                                        .kubeconfigPath("kubeconfig")
                                        .kubectlPath("kubectlPath")
@@ -1017,6 +1018,7 @@ public class K8sTaskHelperTest extends CategoryTest {
   @Category(UnitTests.class)
   public void testShouldGetResourcesFromRemoteManifests() throws Exception {
     K8sDelegateTaskParams params = K8sDelegateTaskParams.builder()
+                                       .workingDirectory("/some/dir/")
                                        .goTemplateClientPath(".")
                                        .kubeconfigPath("kubeconfig")
                                        .kubectlPath("kubectlPath")

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/TasValidationHandlerTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/TasValidationHandlerTest.java
@@ -97,6 +97,6 @@ public class TasValidationHandlerTest extends CategoryTest {
     ConnectorValidationParams connectorValidationParams =
         TasValidationParams.builder().tasConnectorDTO(tasConnectorDTO).build();
     assertThatThrownBy(() -> tasValidationHandler.validate(connectorValidationParams, accountIdentifier))
-        .hasMessageContaining("null");
+        .isInstanceOf(NullPointerException.class);
   }
 }

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/TasValidationHandlerTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/TasValidationHandlerTest.java
@@ -97,6 +97,6 @@ public class TasValidationHandlerTest extends CategoryTest {
     ConnectorValidationParams connectorValidationParams =
         TasValidationParams.builder().tasConnectorDTO(tasConnectorDTO).build();
     assertThatThrownBy(() -> tasValidationHandler.validate(connectorValidationParams, accountIdentifier))
-        .hasMessage(null);
+        .hasMessageContaining("null");
   }
 }

--- a/bazelrc.common
+++ b/bazelrc.common
@@ -14,25 +14,24 @@ build --java_runtime_version=local_jdk
 build --tool_java_language_version=11
 build --tool_java_runtime_version=local_jdk
 build --javacopt='--release 11'
-
-# Use JDK17 targeting JDK11 --config=jdk1711
-build:jdk1711 --jvmopt="--add-exports java.xml/com.sun.org.apache.xerces.internal.parsers=ALL-UNNAMED"
-build:jdk1711 --jvmopt="--add-opens java.base/java.lang=ALL-UNNAMED"
-build:jdk1711 --jvmopt="--add-opens java.base/java.math=ALL-UNNAMED"
-build:jdk1711 --jvmopt="--add-opens java.base/java.time=ALL-UNNAMED"
-build:jdk1711 --jvmopt="--add-opens java.base/java.util=ALL-UNNAMED"
-build:jdk1711 --jvmopt="--add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED"
+build --jvmopt="--illegal-access=debug"
+build --jvmopt="--add-exports java.xml/com.sun.org.apache.xerces.internal.parsers=ALL-UNNAMED"
+build --jvmopt="--add-opens java.base/java.io=ALL-UNNAMED"
+build --jvmopt="--add-opens java.base/java.lang=ALL-UNNAMED"
+build --jvmopt="--add-opens java.base/java.lang.invoke=ALL-UNNAMED"
+build --jvmopt="--add-opens java.base/java.math=ALL-UNNAMED"
+build --jvmopt="--add-opens java.base/java.nio=ALL-UNNAMED"
+build --jvmopt="--add-opens java.base/java.nio.file=ALL-UNNAMED"
+build --jvmopt="--add-opens java.base/java.time=ALL-UNNAMED"
+build --jvmopt="--add-opens java.base/java.util=ALL-UNNAMED"
+build --jvmopt="--add-opens java.base/java.util.concurrent=ALL-UNNAMED"
+build --jvmopt="--add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED"
+build --jvmopt="--add-opens java.xml/com.sun.org.apache.xpath.internal=ALL-UNNAMED"
 
 # Use JDK17 --config=jdk17
 build:jdk17 --java_language_version=17
 build:jdk17 --tool_java_language_version=17
 build:jdk17 --javacopt='--release 17'
-build:jdk17 --jvmopt="--add-exports java.xml/com.sun.org.apache.xerces.internal.parsers=ALL-UNNAMED"
-build:jdk17 --jvmopt="--add-opens java.base/java.lang=ALL-UNNAMED"
-build:jdk17 --jvmopt="--add-opens java.base/java.math=ALL-UNNAMED"
-build:jdk17 --jvmopt="--add-opens java.base/java.time=ALL-UNNAMED"
-build:jdk17 --jvmopt="--add-opens java.base/java.util=ALL-UNNAMED"
-build:jdk17 --jvmopt="--add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED"
 
 build --enable_platform_specific_config
 

--- a/pipeline-service/service/src/main/java/io/harness/pms/pipeline/service/PMSYamlSchemaServiceImpl.java
+++ b/pipeline-service/service/src/main/java/io/harness/pms/pipeline/service/PMSYamlSchemaServiceImpl.java
@@ -131,6 +131,9 @@ public class PMSYamlSchemaServiceImpl implements PMSYamlSchemaService {
       String accountIdentifier, String projectIdentifier, String orgIdentifier, Scope scope) {
     try {
       return getPipelineYamlSchemaInternal(accountIdentifier, projectIdentifier, orgIdentifier, scope);
+    } catch (NullPointerException npe) {
+      log.error("[PMS] Failed to get pipeline yaml schema due to NPE", npe);
+      throw npe;
     } catch (Exception e) {
       log.error("[PMS] Failed to get pipeline yaml schema");
       throw new JsonSchemaException(e.getMessage());

--- a/template-service/service/src/test/java/io/harness/template/services/NGTemplateServiceImplTest.java
+++ b/template-service/service/src/test/java/io/harness/template/services/NGTemplateServiceImplTest.java
@@ -702,7 +702,8 @@ public class NGTemplateServiceImplTest extends TemplateServiceTestBase {
                            -> templateService.delete(ACCOUNT_ID, ORG_IDENTIFIER, PROJ_IDENTIFIER, "templatex",
                                "versionxy", entity2.getVersion(), "", false))
         .isInstanceOf(UnexpectedException.class)
-        .hasMessage("Error while checking references for template templatex with version label: versionxy : null");
+        .hasMessageContainingAll(
+            "Error while checking references for template templatex with version label: versionxy :", "null");
 
     Call<ResponseDTO<Boolean>> request2 = mock(Call.class);
     String fqn2 = String.format("%s/orgId/projId/templateStable/versionxy/", ACCOUNT_ID);


### PR DESCRIPTION
## Describe your changes
As part of jdk 17 upgrade steps, UTs runtime env will be changed to java 17. This requires the UTs to be compatible with it. Additionally some packages need to be open up for allowing reflective access java internals. This has been added to `bazelrc.common` file. The changes doesn't affect jdk 11 env (apart from adding illegal access harmless log for any non opened package) because packages are not restricted by default in jdk 11.

Testing:
1. No effect on services/tests when execute with java 11 runtime env
2. All test passed with java 17 runtime env

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/50159)
<!-- Reviewable:end -->
