### PR TITLE
feat: [IDP-687]: Handle gzip/octet-stream content type. Send response in bytes

### DIFF
--- a/260-delegate/build.properties
+++ b/260-delegate/build.properties
@@ -1,1 +1,1 @@
-build.number=79710
+build.number=79711

--- a/910-delegate-task-grpc-service/src/main/proto/io/harness/task/service/task_service.proto
+++ b/910-delegate-task-grpc-service/src/main/proto/io/harness/task/service/task_service.proto
@@ -60,6 +60,7 @@ message FetchParkedTaskStatusResponse {
 message HTTPTaskResponse {
   string httpResponseBody = 1;
   int32 httpResponseCode = 2;
+  bytes httpResponseBodyInBytes = 3;
 }
 
 // Jira Task Response data

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/http/HttpTaskNG.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/http/HttpTaskNG.java
@@ -74,6 +74,7 @@ public class HttpTaskNG extends AbstractDelegateRunnableTask {
                                    .encryptedDataDetails(httpTaskParametersNg.getEncryptedDataDetails())
                                    .isCertValidationRequired(httpTaskParametersNg.isCertValidationRequired())
                                    .throwErrorIfNoProxySetWithDelegateProxy(false)
+                                   .supportNonTextResponse(httpTaskParametersNg.isSupportNonTextResponse())
                                    .build(),
             executionLogCallback);
     return HttpStepResponse.builder()
@@ -84,6 +85,7 @@ public class HttpTaskNG extends AbstractDelegateRunnableTask {
         .httpUrl(httpInternalResponse.getHttpUrl())
         .httpResponseCode(httpInternalResponse.getHttpResponseCode())
         .httpResponseBody(httpInternalResponse.getHttpResponseBody())
+        .httpResponseBodyInBytes(httpInternalResponse.getHttpResponseBodyInBytes())
         .build();
   }
 

--- a/930-delegate-tasks/src/main/java/io/harness/http/BUILD.bazel
+++ b/930-delegate-tasks/src/main/java/io/harness/http/BUILD.bazel
@@ -16,6 +16,7 @@ java_library(
         "//970-api-services-beans/src/main/java/io/harness/beans:module",
         "//970-api-services-beans/src/main/java/io/harness/globalcontex:module",
         "//970-api-services-beans/src/main/java/io/harness/logging:module",
+        "//970-ng-commons/src/main/java/io/harness/constants:module",
         "//980-commons/src/main/java/io/harness/beans:module",
         "//980-commons/src/main/java/io/harness/data/structure:module",
         "//980-commons/src/main/java/io/harness/exception:module",

--- a/930-delegate-tasks/src/main/java/io/harness/http/beans/HttpInternalConfig.java
+++ b/930-delegate-tasks/src/main/java/io/harness/http/beans/HttpInternalConfig.java
@@ -29,6 +29,7 @@ public class HttpInternalConfig {
   boolean useProxy;
   boolean isCertValidationRequired;
   boolean throwErrorIfNoProxySetWithDelegateProxy; // We need to throw this error in cg but not in ng
+  boolean supportNonTextResponse;
   HttpCertificate certificate;
   List<EncryptedDataDetail> encryptedDataDetails;
 }

--- a/930-delegate-tasks/src/main/java/io/harness/http/beans/HttpInternalResponse.java
+++ b/930-delegate-tasks/src/main/java/io/harness/http/beans/HttpInternalResponse.java
@@ -26,6 +26,7 @@ public class HttpInternalResponse {
   private CommandExecutionStatus commandExecutionStatus;
   private String errorMessage;
   private String httpResponseBody;
+  private byte[] httpResponseBodyInBytes;
   private int httpResponseCode;
   private String httpMethod;
   private String httpUrl;

--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/http/HttpStepResponse.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/http/HttpStepResponse.java
@@ -21,6 +21,7 @@ public class HttpStepResponse implements DelegateTaskNotifyResponseData {
   private CommandExecutionStatus commandExecutionStatus;
   private String errorMessage;
   private String httpResponseBody;
+  private byte[] httpResponseBodyInBytes;
   private int httpResponseCode;
   private String httpMethod;
   private String httpUrl;

--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/http/HttpTaskParametersNg.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/http/HttpTaskParametersNg.java
@@ -40,6 +40,7 @@ public class HttpTaskParametersNg implements TaskParameters, ExecutionCapability
   boolean isCertValidationRequired;
   boolean shouldAvoidHeadersInCapability;
   boolean isIgnoreResponseCode;
+  boolean supportNonTextResponse;
 
   // New type for supporting NG secret resolution
   @Expression(ALLOW_SECRETS) HttpCertificateNG certificateNG;

--- a/970-ng-commons/src/main/java/io/harness/constants/NGCommonEntityConstants.java
+++ b/970-ng-commons/src/main/java/io/harness/constants/NGCommonEntityConstants.java
@@ -145,6 +145,9 @@ public class NGCommonEntityConstants {
   public static final String INTERNAL_SERVER_ERROR_CODE = "500";
   public static final String APPLICATION_JSON_MEDIA_TYPE = "application/json";
   public static final String APPLICATION_YAML_MEDIA_TYPE = "application/yaml";
+  public static final String CONTENT_TYPE_HEADER = "Content-Type";
+  public static final String APPLICATION_GZIP_MEDIA_TYPE = "application/x-gzip";
+  public static final String APPLICATION_OCTET_STREAM_MEDIA_TYPE = "application/octet-stream";
   public static final String OPERATOR_PARAM_MESSAGE = "Operator Criteria for Criterias ";
   public static final String RESOURCE = "Resource it targets (For icons)";
   public static final String POLICY = "Get YAML of the policy";

--- a/idp-service/src/main/java/io/harness/idp/proxy/delegate/BUILD.bazel
+++ b/idp-service/src/main/java/io/harness/idp/proxy/delegate/BUILD.bazel
@@ -12,6 +12,7 @@ java_library(
     visibility = ["//idp-service:__subpackages__"],
     deps = [
         "//:lombok",
+        "//970-ng-commons/src/main/java/io/harness/constants:module",
         "//idp-service/contracts/openapi/v1:idp-service-server-spec-module",
         "//idp-service/contracts/src/main/java/io/harness/idp/annotations:module",
         "//idp-service/modules/clients:module",

--- a/idp-service/src/main/java/io/harness/idp/proxy/delegate/DelegateProxyApiImpl.java
+++ b/idp-service/src/main/java/io/harness/idp/proxy/delegate/DelegateProxyApiImpl.java
@@ -7,6 +7,9 @@
 
 package io.harness.idp.proxy.delegate;
 
+import static io.harness.NGCommonEntityConstants.APPLICATION_GZIP_MEDIA_TYPE;
+import static io.harness.NGCommonEntityConstants.APPLICATION_OCTET_STREAM_MEDIA_TYPE;
+import static io.harness.NGCommonEntityConstants.CONTENT_TYPE_HEADER;
 import static io.harness.annotations.dev.HarnessTeam.IDP;
 import static io.harness.idp.proxy.ngmanager.IdpAuthInterceptor.AUTHORIZATION;
 
@@ -42,6 +45,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DelegateProxyApiImpl implements DelegateProxyApi {
   private static final String HEADER_STRING_PATTERN = "%s:%s; ";
+  private static final String HEADER_SEPARATOR = ";";
+  private static final String KEY_VALUE_SEPARATOR = ":";
+
   private final DelegateProxyRequestForwarder delegateProxyRequestForwarder;
   private final DelegateSelectorsCache delegateSelectorsCache;
 
@@ -88,7 +94,30 @@ public class DelegateProxyApiImpl implements DelegateProxyApi {
           .build();
     }
 
-    return Response.status(httpResponse.getHttpResponseCode()).entity(httpResponse.getHttpResponseBody()).build();
+    Response.ResponseBuilder responseBuilder = Response.status(httpResponse.getHttpResponseCode());
+
+    String responseHeaders = httpResponse.getHeader();
+    boolean isByteResponse = false;
+    if (responseHeaders != null) {
+      for (String header : responseHeaders.split(HEADER_SEPARATOR)) {
+        String[] nameValue = header.split(KEY_VALUE_SEPARATOR);
+        String name = nameValue[0].trim();
+        String value = nameValue[1].trim();
+        if (name.equals(CONTENT_TYPE_HEADER)
+            && (value.equals(APPLICATION_GZIP_MEDIA_TYPE) || value.equals(APPLICATION_OCTET_STREAM_MEDIA_TYPE))) {
+          isByteResponse = true;
+        }
+        responseBuilder.header(name, value);
+      }
+    }
+
+    if (isByteResponse) {
+      responseBuilder.entity(httpResponse.getHttpResponseBodyInBytes());
+    } else {
+      responseBuilder.entity(httpResponse.getHttpResponseBody());
+    }
+
+    return responseBuilder.build();
   }
 
   private Set<String> getDelegateSelectors(String urlString, String accountIdentifier) throws ExecutionException {

--- a/idp-service/src/main/java/io/harness/idp/proxy/delegate/DelegateProxyRequestForwarder.java
+++ b/idp-service/src/main/java/io/harness/idp/proxy/delegate/DelegateProxyRequestForwarder.java
@@ -97,6 +97,7 @@ public class DelegateProxyRequestForwarder {
         .requestHeader(headers)
         .body(body)
         .socketTimeoutMillis(SOCKET_TIMEOUT_IN_MILLISECONDS)
+        .supportNonTextResponse(true)
         .build();
   }
 }


### PR DESCRIPTION
## Describe your changes
We are using HTTP_TASK_NG in IDP Service wherein one of the use cases we use it to download a gzip file.
In the current implementation of this delegate task, we return the response body as a string. But for gzip case, we would have to return it as a byte array. Hence we have introduced this responseBodyInBytes field and handled it specifically for gzip and octet-stream content types.

## Testing
- Tested with URL which returns gzip (https://api.github.com/repos/vigneswara-propelo/python-pipeline-samples/tarball/efce50fec2c942ea7ede7ebbb7474c3febc94138)
- Tested with URL which returns octet-stream (https://gitlab.com/api/v4/projects/45092595/repository/archive.tar.gz?private_token=glpat-kcmyF5AZJJPT6KC6LN9m)
- Tested with regular flow with json/yaml output (https://api.github.com/repos/SarvJ1/catalogtest/contents/PREQA_NG.yaml?ref=main)

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [x] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/50446)
<!-- Reviewable:end -->
