### PR TITLE
feat:[CDS-74514]: Null pointer exception in prepare rollback when stack does not exist

### DIFF
--- a/125-cd-nextgen/src/main/java/io/harness/cdng/serverless/container/steps/ServerlessAwsLambdaDeployV2Step.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/serverless/container/steps/ServerlessAwsLambdaDeployV2Step.java
@@ -14,6 +14,7 @@ import io.harness.cdng.aws.sam.AwsSamStepHelper;
 import io.harness.cdng.infra.beans.ServerlessAwsLambdaInfrastructureOutcome;
 import io.harness.cdng.instance.info.InstanceInfoService;
 import io.harness.cdng.serverless.ServerlessStepCommonHelper;
+import io.harness.data.structure.EmptyPredicate;
 import io.harness.delegate.beans.instancesync.ServerInstanceInfo;
 import io.harness.delegate.beans.serverless.ServerlessAwsLambdaFunction;
 import io.harness.delegate.beans.serverless.ServerlessAwsLambdaFunctionsWithServiceName;
@@ -122,6 +123,10 @@ public class ServerlessAwsLambdaDeployV2Step extends AbstractContainerStepV2<Ste
       if (stepOutput instanceof StepMapOutput) {
         StepMapOutput stepMapOutput = (StepMapOutput) stepOutput;
         String instancesByte64 = stepMapOutput.getMap().get("serverlessInstances");
+        if (EmptyPredicate.isEmpty(instancesByte64)) {
+          log.info("No instances were received in Serverless Aws Lambda Deploy V2 Response");
+          return stepOutcome;
+        }
         log.info(String.format("Serverless Aws Lambda Deploy V2 instances byte64 %s", instancesByte64));
         instances = serverlessStepCommonHelper.convertByte64ToString(instancesByte64);
         log.info(String.format("Serverless Aws Lambda Deploy V2 instances %s", instances));

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/serverless/container/steps/ServerlessAwsLambdaPrepareRollbackV2Step.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/serverless/container/steps/ServerlessAwsLambdaPrepareRollbackV2Step.java
@@ -130,11 +130,18 @@ public class ServerlessAwsLambdaPrepareRollbackV2Step extends AbstractContainerS
         && stepStatusTaskResponseData.getStepStatus().getStepExecutionStatus() == StepExecutionStatus.SUCCESS) {
       StepOutput stepOutput = stepStatusTaskResponseData.getStepStatus().getOutput();
 
+      ServerlessAwsLambdaPrepareRollbackDataOutcome serverlessAwsLambdaPrepareRollbackDataOutcome = null;
+
       if (stepOutput instanceof StepMapOutput) {
         StepMapOutput stepMapOutput = (StepMapOutput) stepOutput;
         String stackDetailsByte64 = stepMapOutput.getMap().get("stackDetails");
         if (EmptyPredicate.isEmpty(stackDetailsByte64)) {
           log.info("No stack details was received in Serverless Aws Lambda Prepare Rollback V2 Response");
+          serverlessAwsLambdaPrepareRollbackDataOutcome =
+              ServerlessAwsLambdaPrepareRollbackDataOutcome.builder().firstDeployment(true).stackDetails(null).build();
+          executionSweepingOutputService.consume(ambiance,
+              OutcomeExpressionConstants.SERVERLESS_AWS_LAMBDA_PREPARE_ROLLBACK_DATA_OUTCOME_V2,
+              serverlessAwsLambdaPrepareRollbackDataOutcome, StepOutcomeGroup.STEP.name());
           return stepOutcome;
         }
         stackDetailsString = serverlessStepCommonHelper.convertByte64ToString(stackDetailsByte64);
@@ -147,7 +154,6 @@ public class ServerlessAwsLambdaPrepareRollbackV2Step extends AbstractContainerS
         log.error("Error while parsing Stack Details", e);
       }
 
-      ServerlessAwsLambdaPrepareRollbackDataOutcome serverlessAwsLambdaPrepareRollbackDataOutcome = null;
       if (stackDetails != null) {
         serverlessAwsLambdaPrepareRollbackDataOutcome =
             ServerlessAwsLambdaPrepareRollbackDataOutcome.builder().stackDetails(stackDetails).build();

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/serverless/container/steps/ServerlessAwsLambdaPrepareRollbackV2Step.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/serverless/container/steps/ServerlessAwsLambdaPrepareRollbackV2Step.java
@@ -14,6 +14,7 @@ import io.harness.callback.DelegateCallbackToken;
 import io.harness.cdng.instance.info.InstanceInfoService;
 import io.harness.cdng.serverless.ServerlessStepCommonHelper;
 import io.harness.cdng.stepsdependency.constants.OutcomeExpressionConstants;
+import io.harness.data.structure.EmptyPredicate;
 import io.harness.delegate.beans.serverless.StackDetails;
 import io.harness.delegate.task.stepstatus.StepExecutionStatus;
 import io.harness.delegate.task.stepstatus.StepMapOutput;
@@ -132,6 +133,10 @@ public class ServerlessAwsLambdaPrepareRollbackV2Step extends AbstractContainerS
       if (stepOutput instanceof StepMapOutput) {
         StepMapOutput stepMapOutput = (StepMapOutput) stepOutput;
         String stackDetailsByte64 = stepMapOutput.getMap().get("stackDetails");
+        if (EmptyPredicate.isEmpty(stackDetailsByte64)) {
+          log.info("No stack details was received in Serverless Aws Lambda Prepare Rollback V2 Response");
+          return stepOutcome;
+        }
         stackDetailsString = serverlessStepCommonHelper.convertByte64ToString(stackDetailsByte64);
       }
 

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/serverless/container/steps/ServerlessAwsLambdaDeployStepV2Test.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/serverless/container/steps/ServerlessAwsLambdaDeployStepV2Test.java
@@ -133,6 +133,61 @@ public class ServerlessAwsLambdaDeployStepV2Test extends CategoryTest {
   @Test
   @Owner(developers = PIYUSH_BHUWALKA)
   @Category(UnitTests.class)
+  public void testGetAnyOutComeForStepWhenNoInstancesReceived() {
+    String accountId = "accountId";
+    Ambiance ambiance = Ambiance.newBuilder().putSetupAbstractions("accountId", accountId).build();
+    ServerlessAwsLambdaDeployV2StepParameters stepParameters =
+        ServerlessAwsLambdaDeployV2StepParameters.infoBuilder()
+            .image(ParameterField.<String>builder().value("sdaf").build())
+            .build();
+    StepElementParameters stepElementParameters = StepElementParameters.builder().spec(stepParameters).build();
+
+    Map<String, ResponseData> responseDataMap = new HashMap<>();
+    Map<String, String> resultMap = new HashMap<>();
+    String instancesContentBase64 = "content64";
+    String instanceContent = "content";
+
+    List<ServerlessAwsLambdaFunction> serverlessAwsLambdaFunctions = Collections.emptyList();
+    ServerlessAwsLambdaFunctionsWithServiceName serverlessAwsLambdaFunctionsWithServiceName =
+        ServerlessAwsLambdaFunctionsWithServiceName.builder()
+            .serviceName("service")
+            .serverlessAwsLambdaFunctions(serverlessAwsLambdaFunctions)
+            .build();
+    resultMap.put("serverlessInstances", null);
+    StepMapOutput stepMapOutput = StepMapOutput.builder().map(resultMap).build();
+    StepStatusTaskResponseData stepStatusTaskResponseData =
+        StepStatusTaskResponseData.builder()
+            .stepStatus(
+                StepStatus.builder().stepExecutionStatus(StepExecutionStatus.SUCCESS).output(stepMapOutput).build())
+            .build();
+    doReturn(stepStatusTaskResponseData).when(containerStepExecutionResponseHelper).filterK8StepResponse(any());
+    responseDataMap.put("key", stepStatusTaskResponseData);
+    when(serverlessStepCommonHelper.convertByte64ToString(instancesContentBase64)).thenReturn(instanceContent);
+    when(serverlessStepCommonHelper.getServerlessAwsLambdaFunctionsWithServiceName(instanceContent))
+        .thenReturn(serverlessAwsLambdaFunctionsWithServiceName);
+
+    ServerlessAwsLambdaInfrastructureOutcome serverlessAwsLambdaInfrastructureOutcome =
+        ServerlessAwsLambdaInfrastructureOutcome.builder()
+            .stage("stage")
+            .region("regjion")
+            .infrastructureKey("infraKey")
+            .build();
+    when(serverlessStepCommonHelper.getInfrastructureOutcome(ambiance))
+        .thenReturn(serverlessAwsLambdaInfrastructureOutcome);
+
+    List<ServerInstanceInfo> serverInstanceInfoList = Collections.emptyList();
+    when(serverlessStepCommonHelper.getServerlessDeployFunctionInstanceInfo(any(), any(), any(), any(), any()))
+        .thenReturn(serverInstanceInfoList);
+    StepOutcome stepOutcome = mock(StepOutcome.class);
+    when(instanceInfoService.saveServerInstancesIntoSweepingOutput(any(), any())).thenReturn(stepOutcome);
+    assertThat(serverlessAwsLambdaDeployV2Step.getAnyOutComeForStep(ambiance, stepElementParameters, responseDataMap))
+        .isNull();
+  }
+
+  @SneakyThrows
+  @Test
+  @Owner(developers = PIYUSH_BHUWALKA)
+  @Category(UnitTests.class)
   public void testGetSerialisedStep() {
     String accountId = "accountId";
     int port = 1;

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/serverless/container/steps/ServerlessAwsLambdaPrepareRollbackV2StepTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/serverless/container/steps/ServerlessAwsLambdaPrepareRollbackV2StepTest.java
@@ -102,6 +102,41 @@ public class ServerlessAwsLambdaPrepareRollbackV2StepTest extends CategoryTest {
   @Test
   @Owner(developers = PIYUSH_BHUWALKA)
   @Category(UnitTests.class)
+  public void testGetAnyOutComeForStepWhenStackDetailsAreEmpty() {
+    String accountId = "accountId";
+    Ambiance ambiance = Ambiance.newBuilder().putSetupAbstractions("accountId", accountId).build();
+    ServerlessAwsLambdaPrepareRollbackV2StepParameters stepParameters =
+        ServerlessAwsLambdaPrepareRollbackV2StepParameters.infoBuilder()
+            .image(ParameterField.<String>builder().value("sdaf").build())
+            .build();
+    StepElementParameters stepElementParameters = StepElementParameters.builder().spec(stepParameters).build();
+
+    Map<String, ResponseData> responseDataMap = new HashMap<>();
+    Map<String, String> resultMap = new HashMap<>();
+    String contentBase64 = "content64";
+    String content = "content";
+    resultMap.put("stackDetails", null);
+    StepMapOutput stepMapOutput = StepMapOutput.builder().map(resultMap).build();
+    StepStatusTaskResponseData stepStatusTaskResponseData =
+        StepStatusTaskResponseData.builder()
+            .stepStatus(
+                StepStatus.builder().stepExecutionStatus(StepExecutionStatus.SUCCESS).output(stepMapOutput).build())
+            .build();
+    doReturn(stepStatusTaskResponseData).when(containerStepExecutionResponseHelper).filterK8StepResponse(any());
+    responseDataMap.put("key", stepStatusTaskResponseData);
+
+    StackDetails stackDetails = StackDetails.builder().build();
+    when(serverlessStepCommonHelper.convertByte64ToString(contentBase64)).thenReturn(content);
+    when(serverlessStepCommonHelper.getStackDetails(content)).thenReturn(stackDetails);
+
+    serverlessAwsLambdaPrepareRollbackV2Step.getAnyOutComeForStep(ambiance, stepElementParameters, responseDataMap);
+    verify(executionSweepingOutputService, times(1)).consume(any(), any(), any(), any());
+  }
+
+  @SneakyThrows
+  @Test
+  @Owner(developers = PIYUSH_BHUWALKA)
+  @Category(UnitTests.class)
   public void testGetSerialisedStep() {
     String accountId = "accountId";
     int port = 1;

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=80000
+build.number=80001
 build.patch=000
 delegate.version=23.07.10
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes

Null pointer exception is occuring in prepare rollback when stack does not exist. So added a check for the same

Tests done:

- First time failure without prepare rollback, and checking rollback is skipped
- First time failure with prepare rollback and checking rollback says that its first time rollback when stack does not exist

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/50687)
<!-- Reviewable:end -->
