### PR TITLE
fix: [CDS-75478]: Throwing error in case string other than true or false

### DIFF
--- a/953-yaml-commons/src/main/java/io/harness/pms/yaml/ParameterDocumentFieldMapper.java
+++ b/953-yaml-commons/src/main/java/io/harness/pms/yaml/ParameterDocumentFieldMapper.java
@@ -14,6 +14,7 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.annotations.dev.ProductModule;
 import io.harness.beans.CastedField;
 import io.harness.exception.InvalidRequestException;
+import io.harness.exception.ParameterFieldCastException;
 import io.harness.pms.serializer.recaster.RecastOrchestrationUtils;
 import io.harness.pms.yaml.ParameterDocumentField.ParameterDocumentFieldKeys;
 import io.harness.utils.RecastReflectionUtils;
@@ -105,6 +106,13 @@ public class ParameterDocumentFieldMapper {
             return;
           }
         }
+      }
+
+      if (cls.getSimpleName().equals("Boolean")
+          && parameterFieldValueWrapper.getValue().getClass().getSimpleName().equals("String")) {
+        throw new ParameterFieldCastException(String.format(
+            "The field should be of type [%s] but got: [%s] with value [%s]", cls.getSimpleName(),
+            parameterFieldValueWrapper.getValue().getClass().getSimpleName(), parameterFieldValueWrapper.getValue()));
       }
       // TODO(Shalini): throw error instead of just logging after handling the case of parameterField<Timeout>
       log.error(String.format("The field should be of type [%s] but got: [%s] with value [%s]", cls.getSimpleName(),

--- a/953-yaml-commons/src/main/java/io/harness/pms/yaml/ParameterDocumentFieldMapper.java
+++ b/953-yaml-commons/src/main/java/io/harness/pms/yaml/ParameterDocumentFieldMapper.java
@@ -108,8 +108,8 @@ public class ParameterDocumentFieldMapper {
         }
       }
 
-      if (cls.getSimpleName().equals("Boolean")
-          && parameterFieldValueWrapper.getValue().getClass().getSimpleName().equals("String")) {
+      if ("Boolean".equals(cls.getSimpleName())
+          && "String".equals(parameterFieldValueWrapper.getValue().getClass().getSimpleName())) {
         throw new ParameterFieldCastException(String.format(
             "The field should be of type [%s] but got: [%s] with value [%s]", cls.getSimpleName(),
             parameterFieldValueWrapper.getValue().getClass().getSimpleName(), parameterFieldValueWrapper.getValue()));

--- a/953-yaml-commons/src/main/java/io/harness/pms/yaml/ParameterDocumentFieldProcessor.java
+++ b/953-yaml-commons/src/main/java/io/harness/pms/yaml/ParameterDocumentFieldProcessor.java
@@ -136,9 +136,8 @@ public class ParameterDocumentFieldProcessor {
           }
         } else if (fieldClass.equals(Boolean.class)) {
           if (finalValue.getClass().equals(String.class)) {
-            finalValue = BooleanUtils.toBooleanObject((String) finalValue) == null
-                ? finalValue
-                : BooleanUtils.toBooleanObject((String) finalValue);
+            Object booleanValue = BooleanUtils.toBooleanObject((String) finalValue);
+            finalValue = booleanValue == null ? finalValue : booleanValue;
           }
         }
       }

--- a/953-yaml-commons/src/main/java/io/harness/pms/yaml/ParameterDocumentFieldProcessor.java
+++ b/953-yaml-commons/src/main/java/io/harness/pms/yaml/ParameterDocumentFieldProcessor.java
@@ -6,6 +6,7 @@
  */
 
 package io.harness.pms.yaml;
+
 import io.harness.annotations.dev.CodePulse;
 import io.harness.annotations.dev.HarnessModuleComponent;
 import io.harness.annotations.dev.HarnessTeam;
@@ -22,6 +23,7 @@ import io.harness.pms.yaml.validation.RuntimeValidatorResponse;
 
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ClassUtils;
 
 @CodePulse(module = ProductModule.CDS, unitCoverageRequired = true, components = {HarnessModuleComponent.CDS_PIPELINE})
@@ -134,7 +136,7 @@ public class ParameterDocumentFieldProcessor {
           }
         } else if (fieldClass.equals(Boolean.class)) {
           if (finalValue.getClass().equals(String.class)) {
-            finalValue = Boolean.valueOf((String) finalValue);
+            finalValue = BooleanUtils.toBoolean((String) finalValue, "true", "false");
           }
         }
       }

--- a/953-yaml-commons/src/main/java/io/harness/pms/yaml/ParameterDocumentFieldProcessor.java
+++ b/953-yaml-commons/src/main/java/io/harness/pms/yaml/ParameterDocumentFieldProcessor.java
@@ -136,7 +136,9 @@ public class ParameterDocumentFieldProcessor {
           }
         } else if (fieldClass.equals(Boolean.class)) {
           if (finalValue.getClass().equals(String.class)) {
-            finalValue = BooleanUtils.toBoolean((String) finalValue, "true", "false");
+            finalValue = BooleanUtils.toBooleanObject((String) finalValue) == null
+                ? finalValue
+                : BooleanUtils.toBooleanObject((String) finalValue);
           }
         }
       }


### PR DESCRIPTION
Currently in parameterDocumentFieldProcessor in case we have passed any string other than true or false in the yaml . We have changed that to work only in case correct values i.e true or false. In case some value is given in boolean parameter field we will throw an error.

Tested this with correct true and false values. 
Also tested with wrong value we are displaying proper error on UI

<img width="1717" alt="Screenshot 2023-08-02 at 5 44 09 PM" src="https://github.com/harness/harness-core/assets/106136394/4365c190-88a9-469c-8ed1-b8193c8bc7ec">

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/51290)
<!-- Reviewable:end -->
