### PR TITLE
[fix]: [CDS-76795]: fix ECS BG Rollback for Stage Service

### DIFF
--- a/125-cd-nextgen/src/main/java/io/harness/cdng/ecs/EcsStepCommonHelper.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/ecs/EcsStepCommonHelper.java
@@ -6,6 +6,7 @@
  */
 
 package io.harness.cdng.ecs;
+
 import static io.harness.cdng.manifest.yaml.harness.HarnessStoreConstants.HARNESS_STORE_TYPE;
 import static io.harness.common.ParameterFieldHelper.getParameterFieldValue;
 import static io.harness.data.structure.CollectionUtils.emptyIfNull;
@@ -1910,6 +1911,14 @@ public class EcsStepCommonHelper extends EcsStepUtils {
               .stageListenerRuleArn(
                   ecsBlueGreenPrepareRollbackDataResult.getEcsLoadBalancerConfig().getStageListenerRuleArn())
               .stageTargetGroupArn(stageTargetGroupArn)
+              .isGreenServiceExist(ecsBlueGreenPrepareRollbackDataResult.isGreenServiceExist())
+              .greenServiceName(ecsBlueGreenPrepareRollbackDataResult.getGreenServiceName())
+              .greenServiceRequestBuilderString(
+                  ecsBlueGreenPrepareRollbackDataResult.getGreenServiceRequestBuilderString())
+              .greenServiceScalableTargetRequestBuilderStrings(
+                  ecsBlueGreenPrepareRollbackDataResult.getGreenServiceScalableTargetRequestBuilderStrings())
+              .greenServiceScalingPolicyRequestBuilderStrings(
+                  ecsBlueGreenPrepareRollbackDataResult.getGreenServiceScalingPolicyRequestBuilderStrings())
               .build();
 
       executionSweepingOutputService.consume(ambiance,

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/ecs/beans/EcsBlueGreenPrepareRollbackDataOutcome.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/ecs/beans/EcsBlueGreenPrepareRollbackDataOutcome.java
@@ -7,17 +7,17 @@
 
 package io.harness.cdng.ecs.beans;
 
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.pms.sdk.core.data.ExecutionSweepingOutput;
 import io.harness.pms.sdk.core.data.Outcome;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import java.util.List;
 import lombok.Builder;
 import lombok.Value;
 import org.springframework.data.annotation.TypeAlias;
-
-import java.util.List;
 
 @OwnedBy(HarnessTeam.CDP)
 @Value

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/ecs/beans/EcsBlueGreenPrepareRollbackDataOutcome.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/ecs/beans/EcsBlueGreenPrepareRollbackDataOutcome.java
@@ -7,17 +7,17 @@
 
 package io.harness.cdng.ecs.beans;
 
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.harness.annotation.RecasterAlias;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.pms.sdk.core.data.ExecutionSweepingOutput;
 import io.harness.pms.sdk.core.data.Outcome;
-
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import java.util.List;
 import lombok.Builder;
 import lombok.Value;
 import org.springframework.data.annotation.TypeAlias;
+
+import java.util.List;
 
 @OwnedBy(HarnessTeam.CDP)
 @Value
@@ -38,4 +38,9 @@ public class EcsBlueGreenPrepareRollbackDataOutcome implements Outcome, Executio
   String stageListenerArn;
   String stageListenerRuleArn;
   String stageTargetGroupArn;
+  String greenServiceName;
+  String greenServiceRequestBuilderString;
+  List<String> greenServiceScalableTargetRequestBuilderStrings;
+  List<String> greenServiceScalingPolicyRequestBuilderStrings;
+  boolean isGreenServiceExist;
 }

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/ecs/EcsBlueGreenRollbackStepTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/ecs/EcsBlueGreenRollbackStepTest.java
@@ -7,7 +7,7 @@
 
 package io.harness.cdng.ecs;
 
-import static io.harness.cdng.ecs.EcsBlueGreenSwapTargetGroupsStep.ECS_BLUE_GREEN_CREATE_SERVICE_STEP_MISSING;
+import static io.harness.cdng.ecs.EcsBlueGreenRollbackStep.ECS_BLUE_GREEN_CREATE_SERVICE_STEP_MISSING;
 import static io.harness.rule.OwnerRule.ALLU_VAMSI;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/ecs/EcsBlueGreenRollbackStepTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/ecs/EcsBlueGreenRollbackStepTest.java
@@ -191,7 +191,7 @@ public class EcsBlueGreenRollbackStepTest extends CategoryTest {
             .prodListenerRuleArn("lisRuleArn")
             .prodTargetGroupArn("grpArn")
             .isFirstDeployment(true)
-            .serviceName("service")
+            .serviceName("service__1")
             .build();
     OptionalSweepingOutput ecsBlueGreenPrepareRollbackDataOptionalOutput =
         OptionalSweepingOutput.builder().found(true).output(ecsBlueGreenPrepareRollbackDataOutcome).build();
@@ -203,7 +203,7 @@ public class EcsBlueGreenRollbackStepTest extends CategoryTest {
                 + OutcomeExpressionConstants.ECS_BLUE_GREEN_PREPARE_ROLLBACK_DATA_OUTCOME));
 
     EcsBlueGreenCreateServiceDataOutcome ecsBlueGreenCreateServiceDataOutcome =
-        EcsBlueGreenCreateServiceDataOutcome.builder().build();
+        EcsBlueGreenCreateServiceDataOutcome.builder().serviceName("service__2").build();
     OptionalSweepingOutput ecsBlueGreenSwapTargetGroupsDataOptionalOutput =
         OptionalSweepingOutput.builder().found(true).output(ecsBlueGreenCreateServiceDataOutcome).build();
     doReturn(ecsBlueGreenSwapTargetGroupsDataOptionalOutput)

--- a/260-delegate/build.properties
+++ b/260-delegate/build.properties
@@ -1,1 +1,1 @@
-build.number=80303
+build.number=80304

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/ecs/EcsBlueGreenRollbackCommandTaskHandler.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/ecs/EcsBlueGreenRollbackCommandTaskHandler.java
@@ -20,6 +20,7 @@ import io.harness.annotations.dev.ProductModule;
 import io.harness.aws.beans.AwsInternalConfig;
 import io.harness.delegate.beans.ecs.EcsBlueGreenRollbackResult;
 import io.harness.delegate.beans.ecs.EcsBlueGreenRollbackResult.EcsBlueGreenRollbackResultBuilder;
+import io.harness.delegate.beans.ecs.EcsMapper;
 import io.harness.delegate.beans.logstreaming.CommandUnitsProgress;
 import io.harness.delegate.beans.logstreaming.ILogStreamingTaskClient;
 import io.harness.delegate.exception.EcsNGException;
@@ -41,9 +42,14 @@ import software.wings.beans.LogColor;
 import software.wings.beans.LogWeight;
 
 import com.google.inject.Inject;
+import java.util.Optional;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
+import software.amazon.awssdk.services.ecs.model.CreateServiceRequest;
+import software.amazon.awssdk.services.ecs.model.Service;
+import software.amazon.awssdk.services.ecs.model.ServiceNotFoundException;
+import software.amazon.awssdk.services.ecs.model.UpdateServiceRequest;
 import software.amazon.awssdk.services.ecs.model.UpdateServiceResponse;
 
 @CodePulse(module = ProductModule.CDS, unitCoverageRequired = true, components = {HarnessModuleComponent.CDS_ECS})
@@ -85,6 +91,26 @@ public class EcsBlueGreenRollbackCommandTaskHandler extends EcsCommandTaskNGHand
             color(format("Old Service: %s is now stable %n%n", ecsBlueGreenRollbackRequest.getOldServiceName()),
                 LogColor.White, Bold),
             LogLevel.INFO);
+      }
+
+      if (!ecsBlueGreenRollbackRequest.isFirstDeployment()) {
+        rollbackCallback.saveExecutionLog(
+            format("Updating tag of old service: %s", ecsBlueGreenRollbackRequest.getOldServiceName()));
+        // update service tag of old service with blue version
+        ecsCommandTaskHelper.updateTag(ecsBlueGreenRollbackRequest.getOldServiceName(), ecsInfraConfig,
+            EcsCommandTaskNGHelper.BG_BLUE, awsInternalConfig, rollbackCallback);
+
+        rollbackCallback.saveExecutionLog(
+            color(format("Successfully updated tag %n%n"), LogColor.White, LogWeight.Bold), LogLevel.INFO);
+
+        rollbackCallback.saveExecutionLog(
+            format("Updating tag of new service: %s", ecsBlueGreenRollbackRequest.getNewServiceName()));
+        // update service tag of new service with green version
+        ecsCommandTaskHelper.updateTag(ecsBlueGreenRollbackRequest.getNewServiceName(), ecsInfraConfig,
+            EcsCommandTaskNGHelper.BG_GREEN, awsInternalConfig, rollbackCallback);
+
+        rollbackCallback.saveExecutionLog(
+            color(format("Successfully updated tag %n%n"), LogColor.White, LogWeight.Bold), LogLevel.INFO);
       }
 
       // Get current prod targetGroup Arn
@@ -153,52 +179,76 @@ public class EcsBlueGreenRollbackCommandTaskHandler extends EcsCommandTaskNGHand
             LogLevel.INFO);
       }
 
-      if (!ecsBlueGreenRollbackRequest.isFirstDeployment()) {
-        rollbackCallback.saveExecutionLog(
-            format("Updating tag of old service: %s", ecsBlueGreenRollbackRequest.getOldServiceName()));
-        // update service tag of old service with blue version
-        ecsCommandTaskHelper.updateTag(ecsBlueGreenRollbackRequest.getOldServiceName(), ecsInfraConfig,
-            EcsCommandTaskNGHelper.BG_BLUE, awsInternalConfig, rollbackCallback);
+      if (ecsBlueGreenRollbackRequest.isGreenServiceExisted()) {
+        // if green service existed before deployment, do rollback
+        CreateServiceRequest.Builder createServiceRequestBuilder =
+            ecsCommandTaskHelper.parseYamlAsObject(ecsBlueGreenRollbackRequest.getNewServiceRequestBuilderString(),
+                CreateServiceRequest.serializableBuilderClass());
+        Integer desiredCount = ecsCommandTaskHelper.getDesiredCountOfServiceForRollback(ecsInfraConfig,
+            createServiceRequestBuilder.build().desiredCount(), createServiceRequestBuilder.build().serviceName());
+        // replace cluster and desired count
+        CreateServiceRequest createServiceRequest =
+            createServiceRequestBuilder.cluster(ecsInfraConfig.getCluster()).desiredCount(desiredCount).build();
 
-        rollbackCallback.saveExecutionLog(
-            color(format("Successfully updated tag %n%n"), LogColor.White, LogWeight.Bold), LogLevel.INFO);
+        rollbackCallback.saveExecutionLog(format("Rolling back green service: %s with desired count: %s",
+            ecsBlueGreenRollbackRequest.getNewServiceName(), desiredCount));
+
+        // if service exists create service, otherwise update service
+        Optional<Service> optionalService = ecsCommandTaskHelper.describeService(createServiceRequest.cluster(),
+            createServiceRequest.serviceName(), ecsInfraConfig.getRegion(), ecsInfraConfig.getAwsConnectorDTO());
+
+        if (optionalService.isPresent() && ecsCommandTaskHelper.isServiceActive(optionalService.get())) {
+          Service service = optionalService.get();
+          ecsCommandTaskHelper.deleteScalingPolicies(ecsInfraConfig.getAwsConnectorDTO(), service.serviceName(),
+              ecsInfraConfig.getCluster(), ecsInfraConfig.getRegion(), rollbackCallback);
+          ecsCommandTaskHelper.deregisterScalableTargets(ecsInfraConfig.getAwsConnectorDTO(), service.serviceName(),
+              ecsInfraConfig.getCluster(), ecsInfraConfig.getRegion(), rollbackCallback);
+
+          UpdateServiceRequest updateServiceRequest =
+              EcsMapper.createServiceRequestToUpdateServiceRequest(createServiceRequest, false);
+
+          rollbackCallback.saveExecutionLog(
+              format("Updating Green Service %s with task definition %s and desired count %s %n",
+                  updateServiceRequest.service(), updateServiceRequest.taskDefinition(),
+                  updateServiceRequest.desiredCount()),
+              LogLevel.INFO);
+          UpdateServiceResponse updateServiceResponse = ecsCommandTaskHelper.updateService(
+              updateServiceRequest, ecsInfraConfig.getRegion(), ecsInfraConfig.getAwsConnectorDTO());
+
+          rollbackCallback.saveExecutionLog(format("Updated Service %s with Arn %s %n", updateServiceRequest.service(),
+                                                updateServiceResponse.service().serviceArn()),
+              LogLevel.INFO);
+
+          ecsCommandTaskHelper.registerScalableTargets(
+              ecsBlueGreenRollbackRequest.getNewServiceScalableTargetRequestBuilderStrings(),
+              ecsInfraConfig.getAwsConnectorDTO(), service.serviceName(), ecsInfraConfig.getCluster(),
+              ecsInfraConfig.getRegion(), rollbackCallback);
+
+          ecsCommandTaskHelper.attachScalingPolicies(
+              ecsBlueGreenRollbackRequest.getNewServiceScalingPolicyRequestBuilderStrings(),
+              ecsInfraConfig.getAwsConnectorDTO(), service.serviceName(), ecsInfraConfig.getCluster(),
+              ecsInfraConfig.getRegion(), rollbackCallback);
+        }
+      } else {
+        // if green service doesn't exist before deployment, delete it
+        String serviceName = ecsBlueGreenRollbackRequest.getNewServiceName();
+
+        rollbackCallback.saveExecutionLog(format("Deleting green service %s..", serviceName), LogLevel.INFO);
+
+        try {
+          ecsCommandTaskHelper.deleteService(serviceName, ecsInfraConfig.getCluster(), ecsInfraConfig.getRegion(),
+              ecsInfraConfig.getAwsConnectorDTO());
+        } catch (Exception e) {
+          if (e.getCause() instanceof ServiceNotFoundException) {
+            rollbackCallback.saveExecutionLog(format("service %s doesn't exist, so "
+                                                      + "skipping deletion of service",
+                                                  serviceName),
+                LogLevel.INFO);
+          } else {
+            throw e;
+          }
+        }
       }
-
-      rollbackCallback.saveExecutionLog(
-          format("Updating tag of new service: %s", ecsBlueGreenRollbackRequest.getNewServiceName()));
-      // update service tag of new service with green version
-      ecsCommandTaskHelper.updateTag(ecsBlueGreenRollbackRequest.getNewServiceName(), ecsInfraConfig,
-          EcsCommandTaskNGHelper.BG_GREEN, awsInternalConfig, rollbackCallback);
-
-      rollbackCallback.saveExecutionLog(
-          color(format("Successfully updated tag %n%n"), LogColor.White, LogWeight.Bold), LogLevel.INFO);
-
-      rollbackCallback.saveExecutionLog(
-          format("Removing green service:  %s scaling policies", ecsBlueGreenRollbackRequest.getNewServiceName()));
-      // deleting scaling policies for new service
-      ecsCommandTaskHelper.deleteScalingPolicies(ecsInfraConfig.getAwsConnectorDTO(),
-          ecsBlueGreenRollbackRequest.getNewServiceName(), ecsInfraConfig.getCluster(), ecsInfraConfig.getRegion(),
-          rollbackCallback);
-
-      rollbackCallback.saveExecutionLog(
-          format("Removing green service:  %s scalable targets", ecsBlueGreenRollbackRequest.getNewServiceName()));
-      // de-registering scalable target for new service
-      ecsCommandTaskHelper.deregisterScalableTargets(ecsInfraConfig.getAwsConnectorDTO(),
-          ecsBlueGreenRollbackRequest.getNewServiceName(), ecsInfraConfig.getCluster(), ecsInfraConfig.getRegion(),
-          rollbackCallback);
-
-      rollbackCallback.saveExecutionLog(format(
-          "Downsizing green service:  %s with zero desired count", ecsBlueGreenRollbackRequest.getNewServiceName()));
-      // downsize new service desired count to zero
-      UpdateServiceResponse updateServiceResponse = ecsCommandTaskHelper.updateDesiredCount(
-          ecsBlueGreenRollbackRequest.getNewServiceName(), ecsInfraConfig, awsInternalConfig, 0);
-
-      if (updateServiceResponse.service() != null) {
-        rollbackCallback.saveExecutionLog(format("Current desired count for green service:  %s is %s",
-            ecsBlueGreenRollbackRequest.getNewServiceName(), updateServiceResponse.service().desiredCount()));
-      }
-      rollbackCallback.saveExecutionLog("Waiting 30s for downsize to complete green service to synchronize");
-
       EcsBlueGreenRollbackResultBuilder ecsBlueGreenRollbackResultBuilder =
           EcsBlueGreenRollbackResult.builder()
               .region(ecsBlueGreenRollbackRequest.getEcsInfraConfig().getRegion())

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/ecs/EcsCommandTaskNGHelper.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/ecs/EcsCommandTaskNGHelper.java
@@ -1273,6 +1273,20 @@ public class EcsCommandTaskNGHelper {
     return service != null && service.status().equals("ACTIVE");
   }
 
+  public Integer getDesiredCountOfServiceForRollback(
+      EcsInfraConfig ecsInfraConfig, Integer currentCount, String serviceName) {
+    Integer maxDesiredCount = currentCount;
+
+    Optional<Service> optionalService = ecsCommandTaskHelper.describeService(
+        ecsInfraConfig.getCluster(), serviceName, ecsInfraConfig.getRegion(), ecsInfraConfig.getAwsConnectorDTO());
+
+    // compare max desired count with live desired count
+    if (optionalService.isPresent() && ecsCommandTaskHelper.isServiceActive(optionalService.get())) {
+      maxDesiredCount = Math.max(maxDesiredCount, optionalService.get().desiredCount());
+    }
+    return maxDesiredCount;
+  }
+
   public boolean isServiceDraining(Service service) {
     return service != null && service.status().equals("DRAINING");
   }

--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/beans/ecs/EcsBlueGreenPrepareRollbackDataResult.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/beans/ecs/EcsBlueGreenPrepareRollbackDataResult.java
@@ -25,4 +25,9 @@ public class EcsBlueGreenPrepareRollbackDataResult {
   List<String> registerScalingPolicyRequestBuilderStrings;
   boolean isFirstDeployment;
   EcsLoadBalancerConfig ecsLoadBalancerConfig;
+  String greenServiceName;
+  String greenServiceRequestBuilderString;
+  List<String> greenServiceScalableTargetRequestBuilderStrings;
+  List<String> greenServiceScalingPolicyRequestBuilderStrings;
+  boolean isGreenServiceExist;
 }

--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/ecs/request/EcsBlueGreenRollbackRequest.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/ecs/request/EcsBlueGreenRollbackRequest.java
@@ -35,12 +35,16 @@ public class EcsBlueGreenRollbackRequest
   @NonFinal @Expression(ALLOW_SECRETS) EcsInfraConfig ecsInfraConfig;
   @NonFinal @Expression(ALLOW_SECRETS) Integer timeoutIntervalInMin;
   @NonFinal @Expression(ALLOW_SECRETS) EcsLoadBalancerConfig ecsLoadBalancerConfig;
-  String oldServiceName;
-  String newServiceName;
+  String oldServiceName; // Note: Here, old service refers to blue service before deployment
+  String newServiceName; // Note: Here, new service refers to green service before deployment
   boolean isFirstDeployment;
   boolean isNewServiceCreated;
   boolean isTargetShiftStarted;
   String oldServiceCreateRequestBuilderString;
   List<String> oldServiceScalableTargetManifestContentList;
   List<String> oldServiceScalingPolicyManifestContentList;
+  boolean isGreenServiceExisted;
+  String newServiceRequestBuilderString;
+  List<String> newServiceScalableTargetRequestBuilderStrings;
+  List<String> newServiceScalingPolicyRequestBuilderStrings;
 }


### PR DESCRIPTION
## Describe your changes
We're adding a fix in rollback logic of Green Service in ECS BG Deployments. We will fetch Green Service details in prepare rollback task. Incase of rollback, we will move back green service to same state as it was before deployment. We will first do rollback of blue service, then update tag and rollback of green service.
There can be two case in green service rollback: 
1. Suppose Green service exists with v1 version, during deployment it moved to v2 version and rollback happens due to some failure. So now green service will move back to v1 version. Earlier it was not happening
2. Green service doesn't exist before deployment, in this case we will delete it during rollback.

Note: we have decided to not add steady state check for green service in rollback because it will increase rollback time unnecessarily.
Test Plan: https://docs.google.com/spreadsheets/d/1uO_8RSo-u_hAr88_aoYyPeF-4ubK_jwdplPsF_7uaBE/edit#gid=0
## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/51670)
<!-- Reviewable:end -->
