### PR TITLE
fix: [PL-38786]: Reverting changes to avoid fetching all ACLs to find distinct resource selectors.

### DIFF
--- a/access-control/libs/core/src/main/java/io/harness/accesscontrol/acl/persistence/repositories/BaseACLRepositoryImpl.java
+++ b/access-control/libs/core/src/main/java/io/harness/accesscontrol/acl/persistence/repositories/BaseACLRepositoryImpl.java
@@ -10,16 +10,11 @@ package io.harness.accesscontrol.acl.persistence.repositories;
 import static io.harness.annotations.dev.HarnessTeam.PL;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.group;
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.match;
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.newAggregation;
-import static org.springframework.data.mongodb.core.aggregation.Aggregation.project;
 import static org.springframework.data.mongodb.util.MongoDbErrorCodes.isDuplicateKeyCode;
 
 import io.harness.accesscontrol.acl.persistence.ACL;
 import io.harness.accesscontrol.acl.persistence.ACL.ACLKeys;
 import io.harness.accesscontrol.resources.resourcegroups.ResourceSelector;
-import io.harness.accesscontrol.resources.resourcegroups.ResourceSelector.ResourceSelectorKeys;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.mongo.index.MongoIndex;
 
@@ -44,12 +39,6 @@ import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.data.mongodb.BulkOperationException;
 import org.springframework.data.mongodb.core.BulkOperations.BulkMode;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.aggregation.Aggregation;
-import org.springframework.data.mongodb.core.aggregation.AggregationOptions;
-import org.springframework.data.mongodb.core.aggregation.AggregationResults;
-import org.springframework.data.mongodb.core.aggregation.GroupOperation;
-import org.springframework.data.mongodb.core.aggregation.MatchOperation;
-import org.springframework.data.mongodb.core.aggregation.ProjectionOperation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
@@ -104,22 +93,15 @@ public abstract class BaseACLRepositoryImpl implements ACLRepository {
                             .ne(true);
     Query query = new Query();
     query.addCriteria(criteria);
-    MatchOperation matchStage = match(criteria);
-    GroupOperation groupOperation = group(ACLKeys.resourceSelector, ACLKeys.conditional, ACLKeys.condition);
-    ProjectionOperation projectionOperation = project()
-                                                  .andExpression("_id.resourceSelector")
-                                                  .as(ResourceSelectorKeys.selector)
-                                                  .andExpression("_id.conditional")
-                                                  .as(ResourceSelectorKeys.conditional)
-                                                  .andExpression("_id.condition")
-                                                  .as(ResourceSelectorKeys.condition);
-
-    AggregationOptions options = AggregationOptions.builder().allowDiskUse(true).build();
-    Aggregation aggregation = newAggregation(matchStage, groupOperation, projectionOperation).withOptions(options);
-
-    AggregationResults<ResourceSelector> aggregationResults =
-        mongoTemplate.aggregate(aggregation, getCollectionName(), ResourceSelector.class);
-    return aggregationResults.getMappedResults().stream().collect(Collectors.toSet());
+    List<ACL> acls = mongoTemplate.find(query, ACL.class, getCollectionName());
+    return acls.stream()
+        .map(acl
+            -> ResourceSelector.builder()
+                   .selector(acl.getResourceSelector())
+                   .conditional(acl.isConditional())
+                   .condition(acl.getCondition())
+                   .build())
+        .collect(Collectors.toSet());
   }
 
   @Override


### PR DESCRIPTION
fix: [PL-38786]: Reverting changes to Avoid fetching all ACLs to find distinct resource selectors.
Reverts harness/harness-core#47947

[PL-38786]: https://harness.atlassian.net/browse/PL-38786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/51915)
<!-- Reviewable:end -->
