### PR TITLE
fix:[CDS-77767]: [StockX] Error showing in the UI when opening a template or issuing reconcile

### DIFF
--- a/953-yaml-commons/src/main/java/io/harness/pms/yaml/validation/RuntimeInputValuesValidator.java
+++ b/953-yaml-commons/src/main/java/io/harness/pms/yaml/validation/RuntimeInputValuesValidator.java
@@ -18,12 +18,14 @@ import io.harness.annotations.dev.ProductModule;
 import io.harness.common.NGExpressionUtils;
 import io.harness.data.structure.EmptyPredicate;
 import io.harness.exception.InvalidRequestException;
+import io.harness.exception.InvalidYamlException;
 import io.harness.expression.EngineExpressionEvaluator;
 import io.harness.pms.yaml.ParameterField;
 import io.harness.pms.yaml.YamlUtils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -213,12 +215,16 @@ public class RuntimeInputValuesValidator {
     if (EmptyPredicate.isEmpty(inputSetValue)) {
       return null;
     }
-    ParameterField<String> inputSetField;
+    ParameterField<String> inputSetField = null;
     try {
       inputSetField = YamlUtils.read(inputSetValue, new TypeReference<ParameterField<String>>() {});
     } catch (IOException e) {
       log.error(String.format("Error mapping input set value %s to ParameterField class", inputSetValue), e);
       return null;
+    } catch (Exception e) {
+      if (e.getCause() instanceof MismatchedInputException) {
+        throw new InvalidYamlException("Please check the input value provided, Input value: " + inputSetValue);
+      }
     }
     return inputSetField;
   }

--- a/953-yaml-commons/src/test/java/io/harness/pms/yaml/validation/RuntimeInputValuesValidatorTest.java
+++ b/953-yaml-commons/src/test/java/io/harness/pms/yaml/validation/RuntimeInputValuesValidatorTest.java
@@ -7,15 +7,20 @@
 
 package io.harness.pms.yaml.validation;
 
+import static io.harness.rule.OwnerRule.SRIDHAR;
 import static io.harness.rule.OwnerRule.VINICIUS;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import io.harness.CategoryTest;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.category.element.UnitTests;
 import io.harness.exception.InvalidRequestException;
+import io.harness.exception.InvalidYamlException;
+import io.harness.pms.yaml.ParameterField;
 import io.harness.rule.Owner;
 
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -51,5 +56,24 @@ public class RuntimeInputValuesValidatorTest extends CategoryTest {
         .isInstanceOf(InvalidRequestException.class)
         .hasMessage(
             "Invalid pattern eaapps-${helmChart.version.substring(helmChart.version.indexOf('-'))} provided for validation of value someValue");
+  }
+
+  @Test
+  @Owner(developers = SRIDHAR)
+  @Category(UnitTests.class)
+  public void testGetInputSetParameterFieldWithInvalidDefaultField() {
+    assertThatThrownBy(() -> RuntimeInputValuesValidator.getInputSetParameterField("<+input>.default(#test)"))
+        .isInstanceOf(InvalidYamlException.class)
+        .hasMessageContaining("Please check the input value provided");
+  }
+
+  @Test
+  @Owner(developers = SRIDHAR)
+  @Category(UnitTests.class)
+  public void testGetInputSetParameterFieldWithValidDefaultField() {
+    ParameterField<String> inputField = RuntimeInputValuesValidator.getInputSetParameterField("<+input>.default(test)");
+
+    assertNotNull(inputField);
+    assertEquals("test", inputField.getDefaultValue());
   }
 }


### PR DESCRIPTION
## Describe your changes
Currently when a runtime exception containing a MismatchedInputException is thrown while resolving the <+input> field the error is not handled and a http 500 error is thrown with the following message
![image](https://github.com/harness/harness-core/assets/106265061/c43c7086-ec12-4079-9d82-0e8f6aef223a)

With this change, we are handling exclusively MismatchedInputException showing an invalid yaml exception with.


![image](https://github.com/harness/harness-core/assets/106265061/131b4ac5-67bd-488b-a625-411cc51fac60)

The reason we have to add it insde the Exception bucket is because MismatchedInputException is wrapped inside a runtime exception and hence we are handling it via `e.getCause() instanceof MismatchedInputException`

Added Junits and verified on the UI.

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/52669)
<!-- Reviewable:end -->
