### PR TITLE
fix:[CDS-79021]: Fix NPE when service selection is missing when saving a freeze window (target 804xx)

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/compliance/GovernanceConfigServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/compliance/GovernanceConfigServiceImpl.java
@@ -704,7 +704,9 @@ public class GovernanceConfigServiceImpl implements GovernanceConfigService {
 
   private void validateAppEnvFilterOneAppWhenServiceFilterTypeIsCustom(List<ApplicationFilter> appSelections) {
     if (appSelections.stream()
-            .filter(selection -> selection.getFilterType() == BlackoutWindowFilterType.CUSTOM)
+            .filter(selection
+                -> selection.getFilterType() == BlackoutWindowFilterType.CUSTOM
+                    && Objects.nonNull(selection.getServiceSelection()))
             .anyMatch(appSelection
                 -> appSelection.getServiceSelection().getFilterType() == ServiceFilterType.CUSTOM
                     && ((CustomAppFilter) appSelection).getApps().size() != 1)) {

--- a/400-rest/src/test/java/software/wings/service/GovernanceConfigServiceImplTest.java
+++ b/400-rest/src/test/java/software/wings/service/GovernanceConfigServiceImplTest.java
@@ -8,6 +8,7 @@
 package software.wings.service;
 
 import static io.harness.rule.OwnerRule.AGORODETKI;
+import static io.harness.rule.OwnerRule.FERNANDOD;
 import static io.harness.rule.OwnerRule.PRABU;
 import static io.harness.rule.OwnerRule.SHIVAM;
 import static io.harness.rule.OwnerRule.VINICIUS;
@@ -21,6 +22,7 @@ import static software.wings.utils.WingsTestConstants.SERVICE_ID;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -1466,5 +1468,15 @@ public class GovernanceConfigServiceImplTest extends WingsBaseTest {
     governanceConfig.getTimeRangeBasedFreezeConfigs().get(0).setApplicable(false);
     assertThatThrownBy(() -> governanceConfigService.upsert(governanceConfig.getAccountId(), governanceConfig))
         .isInstanceOf(InvalidRequestException.class);
+  }
+
+  @Test
+  @Owner(developers = FERNANDOD)
+  @Category(UnitTests.class)
+  public void shouldSaveWhenAppFilterHasFilterTypeCustomAndServiceSelectionIsNull() {
+    GovernanceConfig governanceConfig =
+        JsonUtils.readResourceFile("governance/governance_config22.json", GovernanceConfig.class);
+    assertThatCode(() -> governanceConfigService.upsert(governanceConfig.getAccountId(), governanceConfig))
+        .doesNotThrowAnyException();
   }
 }

--- a/400-rest/src/test/resources/governance/governance_config22.json
+++ b/400-rest/src/test/resources/governance/governance_config22.json
@@ -1,0 +1,214 @@
+{
+  "accountId": "kmpySmUISimoRrJL6NL73w",
+  "deploymentFreeze": false,
+  "timeRangeBasedFreezeConfigs": [
+    {
+      "freezeForAllApps": false,
+      "appIds": [],
+      "environmentTypes": [],
+      "timeRange": {
+        "from": 1615577100548,
+        "to": 1615580700548,
+        "timeZone": "America/Los_Angeles",
+        "durationBased": false,
+        "expires": false
+      },
+      "name": "devops-test-stage",
+      "description": null,
+      "applicable": false,
+      "appSelections": [
+        {
+          "filterType": "CUSTOM",
+          "envSelection": {
+            "filterType": "CUSTOM",
+            "environments": [
+              "D6IdnIwpTX28lFTZYtDW1A"
+            ]
+          },
+          "apps": [
+            "7oR5kwtrRN6Q7PUNn1oZRg"
+          ]
+        }
+      ],
+      "excludeAppSelections": [],
+      "userGroups": [
+        "cCMnEpGdSE658rF_BvTPXA",
+        "cn5HDV3BRryiqFaGNGNi4g"
+      ],
+      "uuid": "5LUDWZmeQ46PtbnLoTn4Vw",
+      "userGroupSelection": {
+        "filterType": "CUSTOM",
+        "userGroups": [
+          "cCMnEpGdSE658rF_BvTPXA",
+          "cn5HDV3BRryiqFaGNGNi4g"
+        ]
+      },
+      "freezeWindowState": "INACTIVE"
+    },
+    {
+      "freezeForAllApps": false,
+      "appIds": [],
+      "environmentTypes": [],
+      "timeRange": {
+        "from": 1627606800146,
+        "to": 1627610400146,
+        "timeZone": "America/Los_Angeles",
+        "durationBased": false,
+        "expires": false
+      },
+      "name": "CTUTemplates Prod",
+      "description": null,
+      "applicable": false,
+      "appSelections": [
+        {
+          "filterType": "CUSTOM",
+          "envSelection": {
+            "filterType": "CUSTOM",
+            "environments": [
+              "qetgGRnYShWAgQOrBdrMlw"
+            ]
+          },
+          "apps": [
+            "-p5dBRsUQ32HqtIVgNgoeg"
+          ]
+        }
+      ],
+      "excludeAppSelections": [],
+      "userGroups": [
+        "EEjzxNpKQqmuKQDfpeMGlg"
+      ],
+      "uuid": "enjopqegS8ym4br74TVNbg",
+      "userGroupSelection": {
+        "filterType": "CUSTOM",
+        "userGroups": [
+          "EEjzxNpKQqmuKQDfpeMGlg"
+        ]
+      },
+      "freezeWindowState": "INACTIVE"
+    },
+    {
+      "freezeForAllApps": false,
+      "appIds": [],
+      "environmentTypes": [],
+      "timeRange": {
+        "from": 1627423737014,
+        "to": 1627427337014,
+        "timeZone": "America/Los_Angeles",
+        "durationBased": false,
+        "expires": false
+      },
+      "name": "CTUTemplates stage",
+      "description": null,
+      "applicable": false,
+      "appSelections": [
+        {
+          "filterType": "CUSTOM",
+          "envSelection": {
+            "filterType": "CUSTOM",
+            "environments": [
+              "CbijFiomSRGdDx9C4iTUcg"
+            ]
+          },
+          "apps": [
+            "-p5dBRsUQ32HqtIVgNgoeg"
+          ]
+        }
+      ],
+      "excludeAppSelections": [],
+      "userGroups": [
+        "EEjzxNpKQqmuKQDfpeMGlg"
+      ],
+      "uuid": "vkf6Tx-dQWiXlGRwq9wh6w",
+      "userGroupSelection": {
+        "filterType": "CUSTOM",
+        "userGroups": [
+          "EEjzxNpKQqmuKQDfpeMGlg"
+        ]
+      },
+      "freezeWindowState": "INACTIVE"
+    },
+    {
+      "freezeForAllApps": false,
+      "appIds": [],
+      "environmentTypes": [],
+      "timeRange": {
+        "from": 1628097240138,
+        "to": 1628557200138,
+        "timeZone": "America/Los_Angeles",
+        "durationBased": false,
+        "expires": false
+      },
+      "name": "Funnels Prod",
+      "description": null,
+      "applicable": false,
+      "appSelections": [
+        {
+          "filterType": "CUSTOM",
+          "envSelection": {
+            "filterType": "CUSTOM",
+            "environments": [
+              "Pwh1AC85RbWLHQJ-m4utNw"
+            ]
+          },
+          "apps": [
+            "mWDSUdNSSJCUGFm4_1I2cQ"
+          ]
+        }
+      ],
+      "excludeAppSelections": [],
+      "userGroups": [
+        "cCMnEpGdSE658rF_BvTPXA",
+        "cn5HDV3BRryiqFaGNGNi4g",
+        "EEjzxNpKQqmuKQDfpeMGlg",
+        "ffRUwkUJTx2-Y83LKquwkA"
+      ],
+      "uuid": "wzyHmBVPTLukEhi7lTJgxA",
+      "userGroupSelection": {
+        "filterType": "CUSTOM",
+        "userGroups": [
+          "cCMnEpGdSE658rF_BvTPXA",
+          "cn5HDV3BRryiqFaGNGNi4g",
+          "EEjzxNpKQqmuKQDfpeMGlg",
+          "ffRUwkUJTx2-Y83LKquwkA"
+        ]
+      },
+      "freezeWindowState": "INACTIVE"
+    },
+    {
+      "name": "test for harness",
+      "description": "test for harness",
+      "userGroupSelection": {
+        "filterType": "CUSTOM",
+        "userGroups": [
+          "N0GRNOQMQVi9Pa05KrByPg"
+        ]
+      },
+      "applicable": false,
+      "appSelections": [
+        {
+          "filterType": "ALL",
+          "apps": [],
+          "envSelection": {
+            "filterType": "ALL",
+            "environments": []
+          },
+          "serviceSelection": {
+            "filterType": "ALL"
+          }
+        }
+      ],
+      "timeRange": {
+        "from": "1694209440519",
+        "to": "1694242860520",
+        "timeZone": "America/Los_Angeles",
+        "durationBased": false,
+        "endTime": "1852095571518",
+        "freezeOccurrence": "WEEKLY",
+        "expires": false
+      },
+      "uuid": "",
+      "excludeAppSelections": []
+    }
+  ],
+  "weeklyFreezeConfigs": []
+}

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=80407
+build.number=80408
 build.patch=000
 delegate.version=23.08.11
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/52733)
<!-- Reviewable:end -->
