### PR TITLE
feat:[CDS-78286]: refactoring jira user flow to optimize jira calls

### DIFF
--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/jira/JiraTaskNGHandler.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/jira/JiraTaskNGHandler.java
@@ -7,10 +7,8 @@
 
 package io.harness.delegate.task.jira;
 import static io.harness.annotations.dev.HarnessTeam.CDC;
-import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.exception.WingsException.USER;
 
-import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -18,43 +16,29 @@ import io.harness.annotations.dev.CodePulse;
 import io.harness.annotations.dev.HarnessModuleComponent;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.annotations.dev.ProductModule;
-import io.harness.data.structure.EmptyPredicate;
 import io.harness.delegate.task.jira.mappers.JiraRequestResponseMapper;
 import io.harness.exception.InvalidArtifactServerException;
-import io.harness.exception.InvalidRequestException;
 import io.harness.exception.NestedExceptionUtils;
 import io.harness.jira.JiraClient;
-import io.harness.jira.JiraFieldTypeNG;
-import io.harness.jira.JiraInstanceData;
-import io.harness.jira.JiraInstanceData.JiraDeploymentType;
 import io.harness.jira.JiraIssueCreateMetadataNG;
 import io.harness.jira.JiraIssueNG;
 import io.harness.jira.JiraIssueTransitionNG;
 import io.harness.jira.JiraIssueTransitionsNG;
-import io.harness.jira.JiraIssueTypeNG;
 import io.harness.jira.JiraIssueUpdateMetadataNG;
 import io.harness.jira.JiraProjectBasicNG;
-import io.harness.jira.JiraProjectNG;
 import io.harness.jira.JiraStatusNG;
 import io.harness.jira.JiraUserData;
 
 import com.google.inject.Singleton;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 
 @CodePulse(module = ProductModule.CDS, unitCoverageRequired = true, components = {HarnessModuleComponent.CDS_APPROVALS})
 @OwnedBy(CDC)
 @Singleton
 @Slf4j
 public class JiraTaskNGHandler {
-  private static final String JIRA_USER_KEY = "JIRAUSER";
-
   public JiraTaskNGResponse validateCredentials(JiraTaskNGParameters params) {
     try {
       JiraClient jiraClient = getJiraClient(params);
@@ -118,61 +102,17 @@ public class JiraTaskNGHandler {
 
   public JiraTaskNGResponse createIssue(JiraTaskNGParameters params) {
     JiraClient jiraClient = getJiraClient(params);
-    Set<String> userTypeFields = new HashSet<>();
-    if (EmptyPredicate.isNotEmpty(params.getFields())) {
-      JiraIssueCreateMetadataNG createMetadata = null;
-      try {
-        createMetadata = jiraClient.getIssueCreateMetadata(
-            params.getProjectKey(), params.getIssueType(), null, false, false, params.isNewMetadata(), false);
-      } catch (Exception ex) {
-        // skipping setting user fields if error occurred while fetching createMetadata.
-        log.warn("Failed fetching createMetadata for setting user type fields during create issue", ex);
-      }
-      if (!isNull(createMetadata)) {
-        JiraProjectNG project = createMetadata.getProjects().get(params.getProjectKey());
-        if (project != null) {
-          JiraIssueTypeNG issueType = project.getIssueTypes().get(params.getIssueType());
-          if (issueType != null) {
-            issueType.getFields().entrySet().forEach(e -> {
-              if (e.getValue().getSchema().getType().equals(JiraFieldTypeNG.USER)) {
-                userTypeFields.add(e.getKey());
-              }
-            });
-            setUserTypeCustomFieldsIfPresent(jiraClient, userTypeFields, params);
-          }
-        }
-      }
-    }
+
     JiraIssueNG issue = jiraClient.createIssue(
-        params.getProjectKey(), params.getIssueType(), params.getFields(), true, params.isNewMetadata(), false);
+        params.getProjectKey(), params.getIssueType(), params.getFields(), true, params.isNewMetadata(), false, true);
     return JiraTaskNGResponse.builder().issue(issue).build();
   }
 
   public JiraTaskNGResponse updateIssue(JiraTaskNGParameters params) {
     JiraClient jiraClient = getJiraClient(params);
 
-    if (EmptyPredicate.isNotEmpty(params.getFields())) {
-      JiraIssueUpdateMetadataNG updateMetadata = null;
-
-      try {
-        updateMetadata = jiraClient.getIssueUpdateMetadata(params.getIssueKey());
-      } catch (Exception ex) {
-        // skipping setting user fields if error occurred while fetching updateMetadata.
-        log.warn("Failed fetching updateMetadata for setting user type fields during update issue", ex);
-      }
-
-      if (updateMetadata != null) {
-        Set<String> userTypeFields = updateMetadata.getFields()
-                                         .entrySet()
-                                         .stream()
-                                         .filter(e -> e.getValue().getSchema().getType().equals(JiraFieldTypeNG.USER))
-                                         .map(Map.Entry::getKey)
-                                         .collect(Collectors.toSet());
-        setUserTypeCustomFieldsIfPresent(jiraClient, userTypeFields, params);
-      }
-    }
     JiraIssueNG issue = jiraClient.updateIssue(
-        params.getIssueKey(), params.getTransitionToStatus(), params.getTransitionName(), params.getFields());
+        params.getIssueKey(), params.getTransitionToStatus(), params.getTransitionName(), params.getFields(), true);
     return JiraTaskNGResponse.builder().issue(issue).build();
   }
 
@@ -183,74 +123,6 @@ public class JiraTaskNGHandler {
     return JiraTaskNGResponse.builder()
         .jiraSearchUserData(JiraSearchUserData.builder().jiraUserDataList(jiraUserDataList).build())
         .build();
-  }
-
-  private void setUserTypeCustomFieldsIfPresent(
-      JiraClient jiraClient, Set<String> userTypeFields, JiraTaskNGParameters params) {
-    params.getFields().forEach((key, userQuery) -> {
-      if (userTypeFields.contains(key)) {
-        if (userQuery != null && !userQuery.equals("")) {
-          if (userQuery.startsWith(JIRA_USER_KEY)) {
-            JiraUserData userData = jiraClient.getUser(userQuery);
-            params.getFields().put(key, userData.getName());
-            return;
-          }
-
-          JiraInstanceData jiraInstanceData = jiraClient.getInstanceData();
-          final List<JiraUserData> userDataList = getJiraUserDataList(jiraClient, userQuery, jiraInstanceData);
-          params.getFields().put(key, extractUserValue(userDataList, userQuery));
-        }
-      }
-    });
-  }
-
-  private String extractUserValue(List<JiraUserData> userDataList, String userToMatch) {
-    if (isEmpty(userDataList)) {
-      throw new InvalidRequestException("Found no jira users with this query");
-    }
-
-    if (userDataList.size() == 1) {
-      JiraUserData jiraUserData = userDataList.get(0);
-      return getUserNameOrAccountId(jiraUserData);
-    }
-
-    Set<String> matchedUsers = userDataList.stream()
-                                   .map(this::getUserNameOrAccountId)
-                                   .filter(user -> StringUtils.compare(userToMatch, user) == 0)
-                                   .collect(Collectors.toSet());
-
-    if (matchedUsers.isEmpty()) {
-      throw new InvalidRequestException("Found no jira users with exact match for this query");
-    }
-
-    if (matchedUsers.size() == 1) {
-      return matchedUsers.iterator().next();
-    }
-
-    throw new InvalidRequestException("Found " + matchedUsers.size()
-        + " jira users exact match with this query. Should be exactly 1. Total matches = " + userDataList.size());
-  }
-
-  private String getUserNameOrAccountId(JiraUserData jiraUserData) {
-    if (jiraUserData.getAccountId().startsWith(JIRA_USER_KEY)) {
-      return jiraUserData.getName();
-    } else {
-      return jiraUserData.getAccountId();
-    }
-  }
-
-  private List<JiraUserData> getJiraUserDataList(
-      JiraClient jiraClient, String userQuery, JiraInstanceData jiraInstanceData) {
-    List<JiraUserData> userDataList;
-    if (jiraInstanceData.getDeploymentType() == JiraDeploymentType.CLOUD) {
-      userDataList = jiraClient.getUsers(null, userQuery, null);
-      if (userDataList.isEmpty()) {
-        userDataList = jiraClient.getUsers(userQuery, null, null);
-      }
-    } else {
-      userDataList = jiraClient.getUsers(userQuery, null, null);
-    }
-    return userDataList;
   }
 
   private JiraClient getJiraClient(JiraTaskNGParameters parameters) {

--- a/960-api-services/src/main/java/io/harness/jira/JiraClient.java
+++ b/960-api-services/src/main/java/io/harness/jira/JiraClient.java
@@ -664,7 +664,8 @@ public class JiraClient {
     return issueType;
   }
 
-  private void setUserTypeCustomFieldsIfPresent(
+  @VisibleForTesting
+  protected void setUserTypeCustomFieldsIfPresent(
       @NotNull Map<String, JiraFieldNG> metadataFields, @NotNull Map<String, String> fields) {
     // getting user type fields from metadata
     Set<String> userTypeFields = metadataFields.entrySet()
@@ -703,6 +704,9 @@ public class JiraClient {
 
   private List<JiraUserData> getJiraUserDataList(String userQuery, JiraInstanceData jiraInstanceData) {
     List<JiraUserData> userDataList;
+    if (isNull(jiraInstanceData) || isNull(jiraInstanceData.deploymentType)) {
+      return null;
+    }
     if (jiraInstanceData.getDeploymentType() == JiraDeploymentType.CLOUD) {
       userDataList = getUsers(null, userQuery, null, jiraInstanceData);
       if (userDataList.isEmpty()) {

--- a/960-api-services/src/main/java/io/harness/jira/JiraClient.java
+++ b/960-api-services/src/main/java/io/harness/jira/JiraClient.java
@@ -8,6 +8,8 @@
 package io.harness.jira;
 
 import static io.harness.annotations.dev.HarnessTeam.CDC;
+import static io.harness.data.structure.EmptyPredicate.isEmpty;
+import static io.harness.jira.JiraConstantsNG.JIRA_USER_KEY;
 import static io.harness.network.Http.getOkHttpClientBuilder;
 
 import static java.util.Objects.isNull;
@@ -21,6 +23,7 @@ import io.harness.exception.HttpResponseException;
 import io.harness.exception.InvalidRequestException;
 import io.harness.exception.JiraClientException;
 import io.harness.exception.NestedExceptionUtils;
+import io.harness.jira.JiraInstanceData.JiraDeploymentType;
 import io.harness.network.Http;
 import io.harness.network.SafeHttpCall;
 import io.harness.retry.RetryHelper;
@@ -35,11 +38,13 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import net.sf.json.JSONArray;
 import okhttp3.Credentials;
@@ -113,6 +118,20 @@ public class JiraClient {
       default:
         return executeCall(restClient.getUsers(userQuery, accountId, "10", startAt), "fetching users");
     }
+  }
+
+  public List<JiraUserData> getUsers(
+      String userQuery, String accountId, String startAt, @NotNull JiraInstanceData jiraInstanceData) {
+    if (isNull(jiraInstanceData) || isNull(jiraInstanceData.deploymentType)) {
+      return null;
+    }
+
+    if (jiraInstanceData.deploymentType == JiraDeploymentType.SERVER) {
+      return executeCall(
+          restClient.getUsersForJiraServer("".equals(userQuery) ? "\"\"" : userQuery, accountId, "10", startAt),
+          "fetching users from server");
+    }
+    return executeCall(restClient.getUsers(userQuery, accountId, "10", startAt), "fetching users from cloud");
   }
 
   /**
@@ -407,10 +426,13 @@ public class JiraClient {
    * @param issueTypeName the issue type
    * @param fields        the issue fields - list/array type are represented as comma separated strings - if an array
    *                      element has comma itself, it should be wrapped in quotes
+   * @param checkRequiredFields checks whether fields param contains required fields
+   * @param setUserTypeFields sets user type custom fields if true
    * @return the created issue
    */
   public JiraIssueNG createIssue(@NotBlank String projectKey, @NotBlank String issueTypeName,
-      Map<String, String> fields, boolean checkRequiredFields, boolean ffEnabled, boolean fromCG) {
+      Map<String, String> fields, boolean checkRequiredFields, boolean ffEnabled, boolean fromCG,
+      boolean setUserTypeFields) {
     JiraIssueCreateMetadataNG createMetadata;
 
     try {
@@ -436,6 +458,10 @@ public class JiraClient {
           String.format("Invalid issue type in project %s: %s", projectKey, issueTypeName));
     }
 
+    if (setUserTypeFields && EmptyPredicate.isNotEmpty(fields)) {
+      setUserTypeCustomFieldsIfPresent(issueType.getFields(), fields);
+    }
+
     ImmutablePair<Map<String, String>, String> pair = extractCommentField(fields);
     fields = pair.getLeft();
     String comment = pair.getRight();
@@ -452,6 +478,12 @@ public class JiraClient {
           "adding issue comment");
     }
     return getIssue(issue.getKey(), true);
+  }
+
+  public JiraIssueNG createIssue(@NotBlank String projectKey, @NotBlank String issueTypeName,
+      Map<String, String> fields, boolean checkRequiredFields, boolean ffEnabled, boolean fromCG) {
+    // don't set user type fields by default
+    return createIssue(projectKey, issueTypeName, fields, checkRequiredFields, ffEnabled, fromCG, false);
   }
 
   /**
@@ -473,10 +505,11 @@ public class JiraClient {
    * @param transitionName     the transition name to choose in case multiple transitions have same to status
    * @param fields             the issue fields - list/array type are represented as comma separated strings - if an
    *                           array element has comma itself, it should be wrapped in quotes
+   * @param setUserTypeFields sets user type custom fields if true
    * @return the updated issue
    */
-  public JiraIssueNG updateIssue(
-      @NotBlank String issueKey, String transitionToStatus, String transitionName, Map<String, String> fields) {
+  public JiraIssueNG updateIssue(@NotBlank String issueKey, String transitionToStatus, String transitionName,
+      Map<String, String> fields, boolean setUserTypeFields) {
     JiraIssueUpdateMetadataNG updateMetadata;
     try {
       updateMetadata = getIssueUpdateMetadata(issueKey);
@@ -485,6 +518,10 @@ public class JiraClient {
         throw new JiraClientException(String.format("Invalid jira issue key: %s", issueKey));
       }
       throw ex;
+    }
+
+    if (setUserTypeFields && EmptyPredicate.isNotEmpty(fields)) {
+      setUserTypeCustomFieldsIfPresent(updateMetadata.getFields(), fields);
     }
 
     String transitionId = findIssueTransition(issueKey, transitionToStatus, transitionName);
@@ -511,6 +548,11 @@ public class JiraClient {
       executeCall(restClient.transitionIssue(issueKey, updateIssueRequest), "updating issue status");
     }
     return getIssue(issueKey, true);
+  }
+
+  public JiraIssueNG updateIssue(
+      @NotBlank String issueKey, String transitionToStatus, String transitionName, Map<String, String> fields) {
+    return updateIssue(issueKey, transitionToStatus, transitionName, fields, false);
   }
 
   /**
@@ -620,5 +662,98 @@ public class JiraClient {
           String.format("Invalid issue type in project %s: %s", projectKey, issueTypeName));
     }
     return issueType;
+  }
+
+  private void setUserTypeCustomFieldsIfPresent(
+      @NotNull Map<String, JiraFieldNG> metadataFields, @NotNull Map<String, String> fields) {
+    // getting user type fields from metadata
+    Set<String> userTypeFields = metadataFields.entrySet()
+                                     .stream()
+                                     .filter(e -> e.getValue().getSchema().getType().equals(JiraFieldTypeNG.USER))
+                                     .map(Map.Entry::getKey)
+                                     .collect(Collectors.toSet());
+
+    // return if no user type fields in metadata; Added this condition in refactoring
+    if (EmptyPredicate.isEmpty(userTypeFields)) {
+      log.info("Found no user type fields in metadata, proceeding...");
+      return;
+    }
+
+    // getting instance data for deciding Server or Cloud
+    JiraInstanceData jiraInstanceData = getInstanceData();
+
+    fields.forEach((key, userQuery) -> {
+      if (userTypeFields.contains(key) && EmptyPredicate.isNotEmpty(userQuery)) {
+        // setting user type fields
+
+        if (userQuery.startsWith(JIRA_USER_KEY)) {
+          // directly get the user saved with Jira user key from Jira server
+          JiraUserData userData = getUser(userQuery);
+          fields.put(key, userData.getName());
+          return;
+        }
+
+        // else fetch jira users matching the user query
+        final List<JiraUserData> userDataList = getJiraUserDataList(userQuery, jiraInstanceData);
+        // extract one matching user
+        fields.put(key, extractUserValue(userDataList, userQuery));
+      }
+    });
+  }
+
+  private List<JiraUserData> getJiraUserDataList(String userQuery, JiraInstanceData jiraInstanceData) {
+    List<JiraUserData> userDataList;
+    if (jiraInstanceData.getDeploymentType() == JiraDeploymentType.CLOUD) {
+      userDataList = getUsers(null, userQuery, null, jiraInstanceData);
+      if (userDataList.isEmpty()) {
+        userDataList = getUsers(userQuery, null, null, jiraInstanceData);
+      }
+    } else {
+      userDataList = getUsers(userQuery, null, null, jiraInstanceData);
+    }
+    return userDataList;
+  }
+
+  private String extractUserValue(List<JiraUserData> userDataList, String userToMatch) {
+    if (isEmpty(userDataList)) {
+      throw new InvalidRequestException(String.format("Found no jira users with this query : [%s]", userToMatch));
+    }
+
+    if (userDataList.size() == 1) {
+      JiraUserData jiraUserData = userDataList.get(0);
+      return getUserNameOrAccountId(jiraUserData);
+    }
+
+    if (userDataList.size() > 1) {
+      log.info("Multiple users found in fuzzy search: {}", userDataList.size());
+    }
+
+    Set<String> matchedUsers = userDataList.stream()
+                                   .map(this::getUserNameOrAccountId)
+                                   .filter(user -> StringUtils.compare(userToMatch, user) == 0)
+                                   .collect(Collectors.toSet());
+
+    if (matchedUsers.isEmpty()) {
+      throw new InvalidRequestException(
+          String.format("Found no jira users with exact match for this query : [%s]", userToMatch));
+    }
+
+    if (matchedUsers.size() == 1) {
+      return matchedUsers.iterator().next();
+    }
+
+    throw new InvalidRequestException(String.format(
+        "Found %s jira users exactly matching with this query [%s]. Should be exactly 1. Total matches = %s",
+        matchedUsers.size(), userToMatch, userDataList.size()));
+  }
+
+  private String getUserNameOrAccountId(@NotNull JiraUserData jiraUserData) {
+    if (StringUtils.isNotBlank(jiraUserData.getAccountId()) && jiraUserData.getAccountId().startsWith(JIRA_USER_KEY)) {
+      // jira server
+      return jiraUserData.getName();
+    } else {
+      // jira cloud
+      return jiraUserData.getAccountId();
+    }
   }
 }

--- a/970-api-services-beans/src/main/java/io/harness/jira/JiraConstantsNG.java
+++ b/970-api-services-beans/src/main/java/io/harness/jira/JiraConstantsNG.java
@@ -47,4 +47,5 @@ public interface JiraConstantsNG {
   String REMAINING_ESTIMATE_NAME = "Remaining Estimate";
   String ORIGINAL_ESTIMATE_KEY = "originalEstimate";
   String REMAINING_ESTIMATE_KEY = "remainingEstimate";
+  String JIRA_USER_KEY = "JIRAUSER";
 }


### PR DESCRIPTION
## Describe your changes

- Refactors the Jira user flow in `JiraTaskNGHandler` and shifts the flow to `JiraClient`.
- Delegate Only Change. Backward compatibility of `JiraClient` create and update calls in CG and CCM are taken care of.
- Advantage 
   a. removes duplicate metadata calls in create and update flows in NG.
   b. reduces `getInstanceDetails` calls to 1 per create/update flow from 3 per jira user field per create/update flow
- While refactoring adding one fast return condition if no user type fields in metadata. Also added some null checks.   
- Changed error message to include the query used.
- Dev Testing Jira User flow in NG: [Test Plan](https://docs.google.com/spreadsheets/d/1PfTDKLqKibFRfyO1dmlTkrhri_-GI8JdISfwws9njLc/edit#gid=1495506352)
- Exhaustive UTs added for different cases of Jira user flow in `JiraClient
- [Tech Spec](https://harness.atlassian.net/wiki/spaces/CDNG/pages/21451080128/Jira+API+Performance+Improvements)


## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/52786)
<!-- Reviewable:end -->
