### PR TITLE
[fix]: [CDS-73765]: Removing PIE expression concat FF

### DIFF
--- a/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
+++ b/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
@@ -521,8 +521,6 @@ public enum FeatureName {
       "Enables saving of monitored service created during template verify step", HarnessTeam.CV),
   PIE_ASYNC_VALIDATION("Validate Pipelines asynchronously on Get calls in Pipeline Studio", HarnessTeam.PIPELINE),
   PIE_DEPRECATE_PAUSE_INTERRUPT_NG("Deprecate Pause and Resume interrupts in NG", HarnessTeam.PIPELINE),
-  PIE_EXPRESSION_CONCATENATION(
-      "Support for new string concatenation support in expression engine", HarnessTeam.PIPELINE),
   PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT(
       "Support for disabling returning complex objects as json", HarnessTeam.PIPELINE),
   PIE_GET_FILE_CONTENT_ONLY(

--- a/980-commons/src/test/java/io/harness/expression/EngineExpressionEvaluatorTest.java
+++ b/980-commons/src/test/java/io/harness/expression/EngineExpressionEvaluatorTest.java
@@ -391,7 +391,6 @@ public class EngineExpressionEvaluatorTest extends CategoryTest {
             .put("var6", "[{\"lmn\":\"pqr\"},{\"stu\":\"<+f>\"}]")
             .put("var7", "[{\"stu\":\"<+f>\"},{\"u\":{\"vw\":\"xyz\"}}]")
             .put("var8", "[{\"lmn\":\"pqr\"},{\"stu\":\"<+f>\"},{\"u\":{\"vw\":\"<+g>\"}}]")
-            .put(EngineExpressionEvaluator.ENABLED_FEATURE_FLAGS_KEY, Arrays.asList("PIE_EXPRESSION_CONCATENATION"))
             .build());
     // concat expressions
     assertThat(evaluator.resolve("archit-<+company>", true)).isEqualTo("archit-harness");
@@ -572,8 +571,7 @@ public class EngineExpressionEvaluatorTest extends CategoryTest {
             .put("var6", "[{\"lmn\":\"pqr\"},{\"stu\":\"<+f>\"}]")
             .put("var7", "[{\"stu\":\"<+f>\"},{\"u\":{\"vw\":\"xyz\"}}]")
             .put("var8", "[{\"lmn\":\"pqr\"},{\"stu\":\"<+f>\"},{\"u\":{\"vw\":\"<+g>\"}}]")
-            .put(EngineExpressionEvaluator.ENABLED_FEATURE_FLAGS_KEY,
-                Arrays.asList("PIE_EXPRESSION_CONCATENATION", "PIE_EXECUTION_JSON_SUPPORT"))
+            .put(EngineExpressionEvaluator.ENABLED_FEATURE_FLAGS_KEY, Arrays.asList("PIE_EXECUTION_JSON_SUPPORT"))
             .build());
     // concat expressions
     assertThat(evaluator.resolve("archit-<+company>", true)).isEqualTo("archit-harness");

--- a/pipeline-service/modules/orchestration/src/test/java/io/harness/engine/pms/execution/strategy/plannode/PlanNodeExecutionStrategyTest.java
+++ b/pipeline-service/modules/orchestration/src/test/java/io/harness/engine/pms/execution/strategy/plannode/PlanNodeExecutionStrategyTest.java
@@ -7,7 +7,6 @@
 
 package io.harness.engine.pms.execution.strategy.plannode;
 
-import static io.harness.beans.FeatureName.PIE_EXPRESSION_CONCATENATION;
 import static io.harness.beans.FeatureName.PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT;
 import static io.harness.data.structure.UUIDGenerator.generateUuid;
 import static io.harness.logging.LoggingInitializer.initializeLogging;
@@ -165,8 +164,8 @@ public class PlanNodeExecutionStrategyTest extends OrchestrationTestBase {
                             .putAllSetupAbstractions(prepareInputArgs())
                             .addLevels(Level.newBuilder().setRuntimeId(generateUuid()).build())
                             .setMetadata(ExecutionMetadata.newBuilder()
-                                             .putAllFeatureFlagToValueMap(Map.of(PIE_EXPRESSION_CONCATENATION.name(),
-                                                 false, PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT.name(), false))
+                                             .putAllFeatureFlagToValueMap(
+                                                 Map.of(PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT.name(), false))
                                              .build())
                             .build();
     PlanNode planNode =
@@ -191,8 +190,7 @@ public class PlanNodeExecutionStrategyTest extends OrchestrationTestBase {
     verify(waitForExecutionInputHelper, never()).waitForExecutionInput(any(), any(), any());
     ambiance.toBuilder()
         .setMetadata(ExecutionMetadata.newBuilder()
-                         .putAllFeatureFlagToValueMap(Map.of(PIE_EXPRESSION_CONCATENATION.name(), true,
-                             PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT.name(), true))
+                         .putAllFeatureFlagToValueMap(Map.of(PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT.name(), true))
                          .build())
         .build();
     executionStrategy.runNode(ambiance, planNode, null);
@@ -244,8 +242,8 @@ public class PlanNodeExecutionStrategyTest extends OrchestrationTestBase {
                             .putAllSetupAbstractions(prepareInputArgs())
                             .addLevels(PmsLevelUtils.buildLevelFromNode(nodeExecutionId, planNode))
                             .setMetadata(ExecutionMetadata.newBuilder()
-                                             .putAllFeatureFlagToValueMap(Map.of(PIE_EXPRESSION_CONCATENATION.name(),
-                                                 false, PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT.name(), false))
+                                             .putAllFeatureFlagToValueMap(
+                                                 Map.of(PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT.name(), false))
                                              .build())
                             .build();
 
@@ -288,8 +286,8 @@ public class PlanNodeExecutionStrategyTest extends OrchestrationTestBase {
                             .putAllSetupAbstractions(prepareInputArgs())
                             .addLevels(PmsLevelUtils.buildLevelFromNode(nodeExecutionId, planNode))
                             .setMetadata(ExecutionMetadata.newBuilder()
-                                             .putAllFeatureFlagToValueMap(Map.of(PIE_EXPRESSION_CONCATENATION.name(),
-                                                 false, PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT.name(), false))
+                                             .putAllFeatureFlagToValueMap(
+                                                 Map.of(PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT.name(), false))
                                              .build())
                             .build();
     NodeExecution nodeExecution = NodeExecution.builder().uuid(nodeExecutionId).ambiance(ambiance).build();
@@ -940,10 +938,10 @@ public class PlanNodeExecutionStrategyTest extends OrchestrationTestBase {
         Ambiance.newBuilder()
             .setPlanId(planId)
             .addLevels(Level.newBuilder().setRuntimeId(runtimeId).setSetupId(setupId).setRetryIndex(1).build())
-            .setMetadata(ExecutionMetadata.newBuilder()
-                             .putAllFeatureFlagToValueMap(Map.of(PIE_EXPRESSION_CONCATENATION.name(), false,
-                                 PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT.name(), false))
-                             .build())
+            .setMetadata(
+                ExecutionMetadata.newBuilder()
+                    .putAllFeatureFlagToValueMap(Map.of(PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT.name(), false))
+                    .build())
             .build();
     PlanNode planNode = PlanNode.builder()
                             .expressionMode(ExpressionMode.RETURN_NULL_IF_UNRESOLVED)

--- a/pipeline-service/service/src/main/java/io/harness/pms/plan/execution/ExecutionHelper.java
+++ b/pipeline-service/service/src/main/java/io/harness/pms/plan/execution/ExecutionHelper.java
@@ -7,7 +7,6 @@
 
 package io.harness.pms.plan.execution;
 import static io.harness.annotations.dev.HarnessTeam.PIPELINE;
-import static io.harness.beans.FeatureName.PIE_EXPRESSION_CONCATENATION;
 import static io.harness.beans.FeatureName.PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
@@ -163,8 +162,7 @@ public class ExecutionHelper {
   RollbackGraphGenerator rollbackGraphGenerator;
 
   // Add all FFs to this list that we want to use during pipeline execution
-  public final List<FeatureName> featureNames =
-      List.of(PIE_EXPRESSION_CONCATENATION, PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT);
+  public final List<FeatureName> featureNames = List.of(PIE_EXPRESSION_DISABLE_COMPLEX_JSON_SUPPORT);
   public static final String PMS_EXECUTION_SETTINGS_GROUP_IDENTIFIER = "pms_execution_settings";
 
   public PipelineEntity fetchPipelineEntity(@NotNull String accountId, @NotNull String orgIdentifier,


### PR DESCRIPTION
## Describe your changes

Changes - Making the FF globally GA
Reverted fallback engine expression changes as well which we did as part of - https://github.com/harness/harness-core/commit/017826bf00ee95960e85edbc29675aaa72a39a40

for concat flows

Impact - As all cluster have this code enabled by default there should be no impact 

Testing -
UTs are passing which contains nested concate expressions, thus its working

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/52903)
<!-- Reviewable:end -->
