### PR TITLE
fix: [CDS-79578]: Return null if expression is null, in CD Expression Resolver::Render

### DIFF
--- a/125-cd-nextgen/src/test/java/io/harness/cdng/expressions/CDExpressionResolverTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/expressions/CDExpressionResolverTest.java
@@ -32,9 +32,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.opensaml.xmlsec.signature.P;
 
 public class CDExpressionResolverTest extends CategoryTest {
   @InjectMocks private CDExpressionResolver cdExpressionResolver;

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/expressions/CDExpressionResolverTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/expressions/CDExpressionResolverTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.cdng.expressions;
+
+import static io.harness.rule.OwnerRule.YOGESH;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.harness.CategoryTest;
+import io.harness.category.element.UnitTests;
+import io.harness.pms.contracts.ambiance.Ambiance;
+import io.harness.pms.expression.EngineExpressionService;
+import io.harness.pms.plan.execution.SetupAbstractionKeys;
+import io.harness.rule.Owner;
+import io.harness.utils.NGFeatureFlagHelperService;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.opensaml.xmlsec.signature.P;
+
+public class CDExpressionResolverTest extends CategoryTest {
+  @InjectMocks private CDExpressionResolver cdExpressionResolver;
+  @Mock private EngineExpressionService engineExpressionService;
+  @Mock private NGFeatureFlagHelperService ngFeatureFlagHelperService;
+  private final Ambiance ambiance = Ambiance.newBuilder()
+                                        .putSetupAbstractions(SetupAbstractionKeys.accountId, "accId")
+                                        .putSetupAbstractions(SetupAbstractionKeys.orgIdentifier, "orgId")
+                                        .putSetupAbstractions(SetupAbstractionKeys.projectIdentifier, "projId")
+                                        .build();
+
+  private AutoCloseable mocks;
+  @Before
+  public void setUp() throws Exception {
+    mocks = MockitoAnnotations.openMocks(this);
+    doReturn(true).when(ngFeatureFlagHelperService).isEnabled(any(), any());
+    // behaviour of EngineGrpcExpressionService since proto cannot have null fields
+    when(engineExpressionService.renderExpression(any(Ambiance.class), eq(null)))
+        .thenThrow(new NullPointerException("cannot set expression as null"));
+  }
+
+  @Test
+  @Owner(developers = YOGESH)
+  @Category(UnitTests.class)
+  public void renderExpressionTest() {
+    String expression = "<+some_expression>";
+    when(engineExpressionService.renderExpression(ambiance, expression)).thenReturn("result");
+
+    String result = cdExpressionResolver.renderExpression(ambiance, expression);
+
+    verify(engineExpressionService, times(1)).renderExpression(any(), any());
+    assertThat(result).isEqualTo("result");
+  }
+
+  @Test
+  @Owner(developers = YOGESH)
+  @Category(UnitTests.class)
+  public void renderExpressionTest_Null() {
+    assertThat(cdExpressionResolver.renderExpression(ambiance, null)).isNull();
+    verify(engineExpressionService, never()).renderExpression(any(), any());
+  }
+
+  @Test
+  @Owner(developers = YOGESH)
+  @Category(UnitTests.class)
+  public void renderExpressionWithSkipCheckTest_Null() {
+    assertThat(cdExpressionResolver.renderExpression(ambiance, null, true)).isNull();
+    assertThat(cdExpressionResolver.renderExpression(ambiance, null, false)).isNull();
+    verify(engineExpressionService, never()).renderExpression(any(), any());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (mocks != null) {
+      mocks.close();
+    }
+  }
+}

--- a/127-cd-nextgen-entities/src/main/java/io/harness/cdng/expressions/CDExpressionResolver.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/cdng/expressions/CDExpressionResolver.java
@@ -9,7 +9,10 @@ package io.harness.cdng.expressions;
 
 import static io.harness.annotations.dev.HarnessTeam.CDP;
 
+import io.harness.annotations.dev.CodePulse;
+import io.harness.annotations.dev.HarnessModuleComponent;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.annotations.dev.ProductModule;
 import io.harness.beans.FeatureName;
 import io.harness.cdng.manifest.yaml.storeConfig.StoreConfig;
 import io.harness.cdng.manifest.yaml.storeConfig.StoreConfigWrapper;
@@ -28,6 +31,8 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
+@CodePulse(module = ProductModule.CDS, unitCoverageRequired = true,
+    components = {HarnessModuleComponent.CDS_EXPRESSION_ENGINE})
 @OwnedBy(CDP)
 @Singleton
 @Slf4j

--- a/127-cd-nextgen-entities/src/main/java/io/harness/cdng/expressions/CDExpressionResolver.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/cdng/expressions/CDExpressionResolver.java
@@ -74,15 +74,24 @@ public class CDExpressionResolver {
   }
 
   public <T> T evaluateExpression(Ambiance ambiance, String expression, Class<T> type) {
+    if (expression == null) {
+      return null;
+    }
     Object result = engineExpressionService.evaluateExpression(ambiance, expression);
     return type.cast(result);
   }
 
   public String renderExpression(Ambiance ambiance, String expression) {
+    if (expression == null) {
+      return null;
+    }
     return engineExpressionService.renderExpression(ambiance, expression);
   }
 
   public String renderExpression(Ambiance ambiance, String expression, boolean skipUnresolvedExpressionCheck) {
+    if (expression == null) {
+      return null;
+    }
     return engineExpressionService.renderExpression(ambiance, expression, skipUnresolvedExpressionCheck);
   }
 }


### PR DESCRIPTION
## Describe your changes
engineExpressionService.evaluateExpression throws NPE if the expression is null. This leads to exceptions which are not handled currently in CD. Example is this [pipeline](https://app.harness.io/ng/account/XzgUIuZXRMWymCzLKYZpCg/home/orgs/GetPaid/projects/GetPaidPerf/pipelines/develop_Perf_Appserver/deployments/0J1yXqI-RnmndF0tR9D4iQ/pipeline?stage=WrdkQFRoTKq9IwMs2kp1-Q&stageExecId=q28C4seGRfC2o6hP1Dgugg)
### 1. Why we made the change ? 
`Null` value from the expression might be called from multiple places. Hence, returning back null instead of NPE will prevent failures arising from this 
Stack trace
```java
java.lang.NullPointerException: null
at io.harness.pms.contracts.service.ExpressionRenderBlobRequest$Builder.setExpression(ExpressionRenderBlobRequest.java:736)
at io.harness.pms.sdk.core.resolver.expressions.EngineGrpcExpressionService.renderExpression(EngineGrpcExpressionService.java:44)
``` 
### 2. What is the change ?
If the expression to render is null, we return the same expression back i.e `null`
This is also done for `updateExpressions` method, where we return `null` if the object to resolve is null
### 3. What will be the impact ?
This should not cause any failures since any flow going through this method and sending a null would be failing. With this change, the returned value ( null ) would be consumed by the caller. It still might fail due to the caller not handling null but that would be a separate fix specific to that particular method.

### 4. Is there a Design Doc / Tech Spec for feature attached in the PR Description?
Its a small bug fix, no design or tech spec is needed here
## Testing

- [x]  Have you added Unit Tests for the Changes

- [ ]  Have you added Automation for the Changes

- [x]  Have you run Sanity for existing features

- [x]  Single PR may contain changes in multiple msvc, have you tested for inter-operability and backward compatibility?


###  Share critical test scenarios.

### Optional: Screenshots if applicable.


## Feature Flags

- [ ]  Have you added / removed a feature flag in the code base **No**

- [ ]  Have you ensured functionality is not breaking with or without Enabling FF

- [ ]  Have you created ticket for removing FF once GA’d.

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [x] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
-
Specific builds
    - `trigger manager`
    - `trigger dms`
    - `trigger ng_manager`
    - `trigger cvng `
    - `trigger cmdlib`
    - `trigger template_svc`
    - `trigger events_fmwrk_monitor`
    - `trigger event_server`
    - `trigger change_data_capture`
    -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
    - CodeFormat: `trigger codeformat`
    - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/53021)
<!-- Reviewable:end -->
