### PR TITLE
[fix]: [PL-00000]: update CG LDAP group sync logic if FF enabled or not

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/UserGroupServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/UserGroupServiceImpl.java
@@ -1063,7 +1063,8 @@ public class UserGroupServiceImpl implements UserGroupService {
 
     auditServiceHelper.reportForAuditingUsingAccountId(accountId, group, updatedGroup, Type.LINK_SSO);
 
-    if (ssoType == SSOType.LDAP) {
+    if (ssoType == SSOType.LDAP
+        && !featureFlagService.isEnabled(FeatureName.PL_RESTRICT_CG_LDAP_SYNC_ON_GROUP_LINK, accountId)) {
       LdapSettings ldapSettings = (LdapSettings) ssoSettings;
       ldapGroupScheduledHandler.handle(ldapSettings);
     }

--- a/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
+++ b/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
@@ -568,6 +568,7 @@ public enum FeatureName {
   PL_LDAP_PARALLEL_GROUP_SYNC(
       "Enables User Group sync operation to fetch data from Ldap Server in Parallel. Enable only if Ldap Server can take the load",
       HarnessTeam.PL),
+  PL_RESTRICT_CG_LDAP_SYNC_ON_GROUP_LINK("Restrict LDAP sync when user group is linked in CG", HarnessTeam.PL),
   PL_NEW_PAGE_SIZE(
       "Enables new default page size for several listing pages like pipelines, access control, executions, connectors, etc.",
       HarnessTeam.PL),


### PR DESCRIPTION
## Describe your changes
Restrict CG LDAP sync to not trigger when FF `PL_RESTRICT_CG_LDAP_SYNC_ON_GROUP_LINK` is turned ON. The downside of this change is for customer's whose FF is turned ON, they will only see the users being populated in User group in the next regular sync cycle (and not immediately). So this do involve an intimation to customer of this behaviour.

Testing Done:
- Tested in Local. When FF is ON (true), the LDAP sync doesn't get triggered.



## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/53089)
<!-- Reviewable:end -->
