### PR TITLE
[feat]: [CDS-79705] : fix mongo query for serviceResourceV2 list services call

### DIFF
--- a/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/service/mappers/ServiceFilterHelper.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/service/mappers/ServiceFilterHelper.java
@@ -61,24 +61,15 @@ public class ServiceFilterHelper {
   public Criteria createCriteriaForGetList(String accountId, String orgIdentifier, String projectIdentifier,
       List<String> scopedServiceRefs, boolean deleted, String searchTerm, ServiceDefinitionType type,
       Boolean gitOpsEnabled, boolean includeAllServicesAccessibleAtScope, String repoName) {
-    Criteria criteria = createCriteriaForGetList(
-        accountId, orgIdentifier, projectIdentifier, scopedServiceRefs, deleted, includeAllServicesAccessibleAtScope);
-    final List<Criteria> andCriterias = new ArrayList<>();
+    Criteria criteria = createCriteriaForGetList(accountId, orgIdentifier, projectIdentifier, scopedServiceRefs,
+        deleted, includeAllServicesAccessibleAtScope, searchTerm);
 
     if (isNotEmpty(repoName)) {
       criteria.and(ServiceEntityKeys.repo).is(repoName);
     }
-    if (isNotEmpty(searchTerm)) {
-      Criteria searchCriteria = createSearchTermCriteria(searchTerm);
-      andCriterias.add(searchCriteria);
-    }
 
     if (type != null) {
       criteria.and(ServiceEntityKeys.type).is(type.name());
-    }
-
-    if (isNotEmpty(andCriterias)) {
-      criteria = criteria.andOperator(andCriterias.toArray(Criteria[] ::new));
     }
 
     return applyBooleanFilter(criteria, gitOpsEnabled, ServiceEntityKeys.gitOpsEnabled);
@@ -153,7 +144,7 @@ public class ServiceFilterHelper {
   }
 
   public Criteria createCriteriaForGetList(String accountId, String orgIdentifier, String projectIdentifier,
-      List<String> scopedServiceRefs, boolean deleted, boolean includeAllServicesAccessibleAtScope) {
+      List<String> scopedServiceRefs, boolean deleted, boolean includeAllServicesAccessibleAtScope, String searchTerm) {
     Criteria criteria = new Criteria();
     if (isNotEmpty(accountId)) {
       // accountId
@@ -181,6 +172,12 @@ public class ServiceFilterHelper {
       if (scopedServicesCriteria != null) {
         criteriaList.add(scopedServicesCriteria);
       }
+
+      if (isNotEmpty(searchTerm)) {
+        Criteria searchCriteria = createSearchTermCriteria(searchTerm);
+        criteriaList.add(searchCriteria);
+      }
+
       if (criteriaList.size() != 0) {
         criteria.andOperator(criteriaList.toArray(new Criteria[0]));
       }

--- a/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/service/services/impl/ServiceEntityServiceImpl.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/ng/core/service/services/impl/ServiceEntityServiceImpl.java
@@ -1144,7 +1144,7 @@ public class ServiceEntityServiceImpl implements ServiceEntityService {
   public RepoListResponseDTO getListOfRepos(String accountIdentifier, String orgIdentifier, String projectIdentifier,
       boolean includeAllServicesAccessibleAtScope) {
     Criteria criteria = ServiceFilterHelper.createCriteriaForGetList(
-        accountIdentifier, orgIdentifier, projectIdentifier, null, false, includeAllServicesAccessibleAtScope);
+        accountIdentifier, orgIdentifier, projectIdentifier, null, false, includeAllServicesAccessibleAtScope, null);
 
     List<String> uniqueRepos = serviceRepository.getListOfDistinctRepos(criteria);
     CollectionUtils.filter(uniqueRepos, PredicateUtils.notNullPredicate());

--- a/127-cd-nextgen-entities/src/test/java/io/harness/ng/core/service/mappers/ServiceFilterHelperTest.java
+++ b/127-cd-nextgen-entities/src/test/java/io/harness/ng/core/service/mappers/ServiceFilterHelperTest.java
@@ -107,7 +107,7 @@ public class ServiceFilterHelperTest extends CategoryTest {
 
     assertThat(criteria.getCriteriaObject().toJson())
         .isEqualTo(
-            "{\"accountId\": \"accId\", \"orgIdentifier\": \"orgId\", \"projectIdentifier\": \"projId\", \"deleted\": false, \"$and\": [{\"$or\": [{\"name\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"identifier\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.key\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.value\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}]}]}");
+            "{\"accountId\": \"accId\", \"orgIdentifier\": \"orgId\", \"projectIdentifier\": \"projId\", \"$and\": [{\"$or\": [{\"name\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"identifier\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.key\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.value\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}]}], \"deleted\": false}");
   }
 
   @Test
@@ -119,7 +119,7 @@ public class ServiceFilterHelperTest extends CategoryTest {
 
     assertThat(criteria.getCriteriaObject().toJson())
         .isEqualTo(
-            "{\"accountId\": \"accId\", \"orgIdentifier\": \"orgId\", \"projectIdentifier\": \"projId\", \"deleted\": false, \"type\": \"KUBERNETES\", \"$and\": [{\"$or\": [{\"name\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"identifier\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.key\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.value\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}]}], \"gitOpsEnabled\": true}");
+            "{\"accountId\": \"accId\", \"orgIdentifier\": \"orgId\", \"projectIdentifier\": \"projId\", \"$and\": [{\"$or\": [{\"name\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"identifier\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.key\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.value\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}]}], \"deleted\": false, \"type\": \"KUBERNETES\", \"gitOpsEnabled\": true}");
   }
 
   @Test
@@ -131,7 +131,19 @@ public class ServiceFilterHelperTest extends CategoryTest {
 
     assertThat(criteria.getCriteriaObject().toJson())
         .isEqualTo(
-            "{\"accountId\": \"accId\", \"orgIdentifier\": \"orgId\", \"projectIdentifier\": \"projId\", \"deleted\": false, \"type\": \"NATIVE_HELM\", \"$and\": [{\"$or\": [{\"name\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"identifier\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.key\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.value\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}]}]}");
+            "{\"accountId\": \"accId\", \"orgIdentifier\": \"orgId\", \"projectIdentifier\": \"projId\", \"$and\": [{\"$or\": [{\"name\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"identifier\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.key\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.value\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}]}], \"deleted\": false, \"type\": \"NATIVE_HELM\"}");
+  }
+
+  @Test
+  @Owner(developers = YOGESH)
+  @Category(UnitTests.class)
+  public void testCreateCriteriaForGetList4() {
+    Criteria criteria = ServiceFilterHelper.createCriteriaForGetList(
+        "accId", "orgId", "projId", false, "foo", ServiceDefinitionType.NATIVE_HELM, null, true, null);
+
+    assertThat(criteria.getCriteriaObject().toJson())
+        .isEqualTo(
+            "{\"accountId\": \"accId\", \"$and\": [{\"$or\": [{\"orgIdentifier\": \"orgId\", \"projectIdentifier\": \"projId\"}, {\"orgIdentifier\": \"orgId\", \"projectIdentifier\": null}, {\"orgIdentifier\": null, \"projectIdentifier\": null}]}, {\"$or\": [{\"name\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"identifier\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.key\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}, {\"tags.value\": {\"$regularExpression\": {\"pattern\": \"foo\", \"options\": \"i\"}}}]}], \"deleted\": false, \"type\": \"NATIVE_HELM\"}");
   }
 
   @Test

--- a/127-cd-nextgen-entities/src/test/java/io/harness/ng/core/service/services/impl/ServiceEntityServiceImplTest.java
+++ b/127-cd-nextgen-entities/src/test/java/io/harness/ng/core/service/services/impl/ServiceEntityServiceImplTest.java
@@ -836,7 +836,7 @@ public class ServiceEntityServiceImplTest extends CDNGEntitiesTestBase {
     // List down all services accessible from that scope
     // project level
     Criteria criteriaFromServiceFilter =
-        ServiceFilterHelper.createCriteriaForGetList("ACCOUNT_ID", "ORG_ID", "PROJECT_ID", null, false, true);
+        ServiceFilterHelper.createCriteriaForGetList("ACCOUNT_ID", "ORG_ID", "PROJECT_ID", null, false, true, null);
     Pageable pageRequest = PageUtils.getPageRequest(0, 10, null);
     Page<ServiceEntity> list = serviceEntityService.list(criteriaFromServiceFilter, pageRequest);
     assertThat(list.getContent()).isNotNull();
@@ -845,7 +845,7 @@ public class ServiceEntityServiceImplTest extends CDNGEntitiesTestBase {
 
     // org level
     criteriaFromServiceFilter =
-        ServiceFilterHelper.createCriteriaForGetList("ACCOUNT_ID", "ORG_ID", null, null, false, true);
+        ServiceFilterHelper.createCriteriaForGetList("ACCOUNT_ID", "ORG_ID", null, null, false, true, null);
     list = serviceEntityService.list(criteriaFromServiceFilter, pageRequest);
     assertThat(list.getContent()).isNotNull();
     // services from org,account scopes
@@ -853,7 +853,7 @@ public class ServiceEntityServiceImplTest extends CDNGEntitiesTestBase {
 
     // account level
     criteriaFromServiceFilter =
-        ServiceFilterHelper.createCriteriaForGetList("ACCOUNT_ID", null, null, null, false, true);
+        ServiceFilterHelper.createCriteriaForGetList("ACCOUNT_ID", null, null, null, false, true, null);
     list = serviceEntityService.list(criteriaFromServiceFilter, pageRequest);
     assertThat(list.getContent()).isNotNull();
     // services from acc scope
@@ -865,7 +865,7 @@ public class ServiceEntityServiceImplTest extends CDNGEntitiesTestBase {
   @Category(UnitTests.class)
   public void testCreateCriteriaForGetListWithOptionalOrgAndProject() {
     Criteria criteriaFromServiceFilter =
-        ServiceFilterHelper.createCriteriaForGetList("ACCOUNT_ID", null, null, null, false, false);
+        ServiceFilterHelper.createCriteriaForGetList("ACCOUNT_ID", null, null, null, false, false, null);
 
     assertThat(criteriaFromServiceFilter.getCriteriaObject()).containsKey("accountId");
     assertThat(criteriaFromServiceFilter.getCriteriaObject()).containsKey("orgIdentifier");


### PR DESCRIPTION

## Describe your changes

Issue was when includeAllAccessibleAtScope and search term both were present in service list api call, 
We adding these in query criteria through andOperator, and two andOperator are not supported in mongo.

For the fix i have made a single array of criteria including includeAllAccessibleAtScope and searchTerm both.

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/53097)
<!-- Reviewable:end -->
