### PR TITLE
fix: [CDS-79519]: Exception summary for spotElastic Group

### DIFF
--- a/930-delegate-tasks/src/main/java/io/harness/delegate/elastigroup/ElastigroupSetupCommandTaskHandler.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/elastigroup/ElastigroupSetupCommandTaskHandler.java
@@ -101,8 +101,8 @@ public class ElastigroupSetupCommandTaskHandler extends ElastigroupCommandTaskHa
 
       deployLogCallback.saveExecutionLog(
           format("Sending request to create Elastigroup with name: [%s]", newElastiGroupName));
-      ElastiGroup elastigroup =
-          spotInstHelperServiceDelegate.createElastiGroup(spotInstApiToken, spotInstAccountId, finalJson);
+      ElastiGroup elastigroup = spotInstHelperServiceDelegate.createElastiGroup(
+          spotInstApiToken, spotInstAccountId, finalJson, deployLogCallback);
       deployLogCallback.saveExecutionLog(format("Created Elastigroup %s", getElastigroupString(elastigroup)));
 
       /**
@@ -175,7 +175,6 @@ public class ElastigroupSetupCommandTaskHandler extends ElastigroupCommandTaskHa
 
     } catch (Exception ex) {
       Exception sanitizedException = ExceptionMessageSanitizer.sanitizeException(ex);
-      deployLogCallback.saveExecutionLog(sanitizedException.getMessage());
       deployLogCallback.saveExecutionLog(
           color("Deployment Failed.", LogColor.Red, LogWeight.Bold), LogLevel.ERROR, CommandExecutionStatus.FAILURE);
       throw new ElastigroupNGException(sanitizedException);

--- a/960-api-services/src/main/java/io/harness/spotinst/SpotInstErrorHandler.java
+++ b/960-api-services/src/main/java/io/harness/spotinst/SpotInstErrorHandler.java
@@ -35,10 +35,7 @@ public class SpotInstErrorHandler {
     }
   }
 
-  public WingsException generateException(String error, LogCallback deployLogCallback) {
-    if (deployLogCallback != null) {
-      deployLogCallback.saveExecutionLog(error);
-    }
+  public WingsException generateException(String error) {
     JsonNode jsonNode = parseToJson(error);
     if (jsonNode == null) {
       return getDefaultException(error);

--- a/960-api-services/src/main/java/io/harness/spotinst/SpotInstHelperServiceDelegate.java
+++ b/960-api-services/src/main/java/io/harness/spotinst/SpotInstHelperServiceDelegate.java
@@ -7,6 +7,7 @@
 
 package io.harness.spotinst;
 
+import io.harness.logging.LogCallback;
 import io.harness.spotinst.model.ElastiGroup;
 import io.harness.spotinst.model.ElastiGroupInstanceHealth;
 
@@ -23,6 +24,8 @@ public interface SpotInstHelperServiceDelegate {
   Optional<ElastiGroup> getElastiGroupById(String spotInstToken, String spotInstAccountId, String elastiGroupId)
       throws Exception;
   ElastiGroup createElastiGroup(String spotInstToken, String spotInstAccountId, String jsonPayload) throws Exception;
+  ElastiGroup createElastiGroup(String spotInstToken, String spotInstAccountId, String jsonPayload,
+      LogCallback deployLogCallback) throws Exception;
   void updateElastiGroup(String spotInstToken, String spotInstAccountId, String elastiGroupId, String jsonPayload)
       throws Exception;
   void updateElastiGroup(String spotInstToken, String spotInstAccountId, String elastiGroupId, Object group)

--- a/960-api-services/src/main/java/io/harness/spotinst/SpotInstHelperServiceDelegateImpl.java
+++ b/960-api-services/src/main/java/io/harness/spotinst/SpotInstHelperServiceDelegateImpl.java
@@ -85,9 +85,12 @@ public class SpotInstHelperServiceDelegateImpl implements SpotInstHelperServiceD
         try (ResponseBody responseBody = response.errorBody()) {
           if (null != responseBody) {
             error = responseBody.string();
+            if(deployLogCallback != null) {
+              deployLogCallback.saveExecutionLog(error);
+            }
           }
         }
-        throw SpotInstErrorHandler.generateException(error, deployLogCallback);
+        throw SpotInstErrorHandler.generateException(error);
       }
       return response.body();
     } catch (FailsafeException | IOException ex) {

--- a/960-api-services/src/test/java/io/harness/spotinst/SpotInstErrorHandlerTest.java
+++ b/960-api-services/src/test/java/io/harness/spotinst/SpotInstErrorHandlerTest.java
@@ -40,7 +40,7 @@ public class SpotInstErrorHandlerTest extends CategoryTest {
   @Category(UnitTests.class)
   public void testGenerateException_instancehealthiness() throws IOException {
     String error = loadContent(instancehealthiness_error_file_path);
-    WingsException exception = SpotInstErrorHandler.generateException(error);
+    WingsException exception = SpotInstErrorHandler.generateException(error, null);
     assertThat(exception.getMessage()).contains("An error occurred when calling InstanceHealthiness API");
   }
 
@@ -48,7 +48,7 @@ public class SpotInstErrorHandlerTest extends CategoryTest {
   @Owner(developers = VITALIE)
   @Category(UnitTests.class)
   public void testGenerateException_not_json() {
-    WingsException exception = SpotInstErrorHandler.generateException(random_error);
+    WingsException exception = SpotInstErrorHandler.generateException(random_error, null);
     assertThat(exception.getMessage()).isEqualTo(random_error);
   }
 
@@ -57,7 +57,7 @@ public class SpotInstErrorHandlerTest extends CategoryTest {
   @Category(UnitTests.class)
   public void testGenerateException_instancehealthiness_invalid_req() throws IOException {
     String error = loadContent(instanceHealthiness_error_invalid_req_file_path);
-    WingsException exception = SpotInstErrorHandler.generateException(error);
+    WingsException exception = SpotInstErrorHandler.generateException(error, null);
     assertThat(exception.getMessage()).isEqualTo(error);
   }
 
@@ -66,7 +66,7 @@ public class SpotInstErrorHandlerTest extends CategoryTest {
   @Category(UnitTests.class)
   public void testGenerateException_instancehealthiness_invalid_res() throws IOException {
     String error = loadContent(instanceHealthiness_error_invalid_res_file_path);
-    WingsException exception = SpotInstErrorHandler.generateException(error);
+    WingsException exception = SpotInstErrorHandler.generateException(error, null);
     assertThat(exception.getMessage()).isEqualTo(error);
   }
 

--- a/960-api-services/src/test/java/io/harness/spotinst/SpotInstErrorHandlerTest.java
+++ b/960-api-services/src/test/java/io/harness/spotinst/SpotInstErrorHandlerTest.java
@@ -40,7 +40,7 @@ public class SpotInstErrorHandlerTest extends CategoryTest {
   @Category(UnitTests.class)
   public void testGenerateException_instancehealthiness() throws IOException {
     String error = loadContent(instancehealthiness_error_file_path);
-    WingsException exception = SpotInstErrorHandler.generateException(error, null);
+    WingsException exception = SpotInstErrorHandler.generateException(error);
     assertThat(exception.getMessage()).contains("An error occurred when calling InstanceHealthiness API");
   }
 
@@ -48,7 +48,7 @@ public class SpotInstErrorHandlerTest extends CategoryTest {
   @Owner(developers = VITALIE)
   @Category(UnitTests.class)
   public void testGenerateException_not_json() {
-    WingsException exception = SpotInstErrorHandler.generateException(random_error, null);
+    WingsException exception = SpotInstErrorHandler.generateException(random_error);
     assertThat(exception.getMessage()).isEqualTo(random_error);
   }
 
@@ -57,7 +57,7 @@ public class SpotInstErrorHandlerTest extends CategoryTest {
   @Category(UnitTests.class)
   public void testGenerateException_instancehealthiness_invalid_req() throws IOException {
     String error = loadContent(instanceHealthiness_error_invalid_req_file_path);
-    WingsException exception = SpotInstErrorHandler.generateException(error, null);
+    WingsException exception = SpotInstErrorHandler.generateException(error);
     assertThat(exception.getMessage()).isEqualTo(error);
   }
 
@@ -66,7 +66,7 @@ public class SpotInstErrorHandlerTest extends CategoryTest {
   @Category(UnitTests.class)
   public void testGenerateException_instancehealthiness_invalid_res() throws IOException {
     String error = loadContent(instanceHealthiness_error_invalid_res_file_path);
-    WingsException exception = SpotInstErrorHandler.generateException(error, null);
+    WingsException exception = SpotInstErrorHandler.generateException(error);
     assertThat(exception.getMessage()).isEqualTo(error);
   }
 


### PR DESCRIPTION
## Describe your changes
Report target previously was universal hence the error summary was hidden from user, with this change updated the target to USER and also in the error summary we are printing the error messages from the response body.

Before Fix(Error summary is empty):
<img width="1728" alt="Screenshot 2023-09-21 at 12 49 49 PM" src="https://github.com/harness/harness-core/assets/109350689/54bcf463-b65c-41a4-b190-b33acf791fef">

After Fix:
<img width="1728" alt="Screenshot 2023-09-21 at 12 48 55 PM" src="https://github.com/harness/harness-core/assets/109350689/1ca11743-1ba9-4768-aae0-9c5b3b4dd02b">

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/53134)
<!-- Reviewable:end -->
