### PR TITLE
fix: [PL-41469]: Remove NotifyEventConsumerCg thread

### DIFF
--- a/360-cg-manager/src/main/java/software/wings/app/WingsApplication.java
+++ b/360-cg-manager/src/main/java/software/wings/app/WingsApplication.java
@@ -150,8 +150,6 @@ import io.harness.queue.QueueListenerController;
 import io.harness.queue.QueuePublisher;
 import io.harness.queue.RedisConsumerControllerCg;
 import io.harness.queue.TimerScheduledExecutorService;
-import io.harness.queue.consumers.GeneralEventConsumerCg;
-import io.harness.queue.consumers.NotifyEventConsumerCg;
 import io.harness.queue.publishers.CgGeneralEventPublisher;
 import io.harness.queue.publishers.CgNotifyEventPublisher;
 import io.harness.redis.DelegateHeartBeatSyncFromRedis;
@@ -1293,8 +1291,6 @@ public class WingsApplication extends Application<MainConfiguration> {
         listenerConfig.getOrchestrationNotifyEventListenerCount());
 
     RedisConsumerControllerCg controller = injector.getInstance(RedisConsumerControllerCg.class);
-    controller.register(injector.getInstance(NotifyEventConsumerCg.class), listenerConfig.getNotifyConsumerCount());
-    controller.register(injector.getInstance(GeneralEventConsumerCg.class), listenerConfig.getGeneralConsumerCount());
     controller.register(injector.getInstance(ApplicationTimeScaleRedisChangeEventConsumer.class),
         configuration.getDebeziumConsumerConfigs().getApplicationTimescaleStreaming().getThreads());
   }

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 build.majorVersion=1
 build.minorVersion=0
-build.number=80801
+build.number=80802
 build.patch=000
 delegate.version=23.09.10
 delegate.patch=000


### PR DESCRIPTION
## Describe your changes
No microservice is using the NotifyEventConsumer and this is causing high retained memory in heapDump in manager. Removing that thread altogether.

In manager heapDump, we are seeing a lot of HKryo objects, reflect objects because of NotifyEventCgConsumer. After taking to prashanth, we got to know that no one is using the NotifyEventCgConsumer and we are going to remove it.
<img width="1398" alt="Screenshot 2023-09-25 at 12 49 51 PM" src="https://github.com/harness/harness-core/assets/86037848/4b60f9c9-4255-49d5-bdfe-73580cd30890">
<img width="1330" alt="Screenshot 2023-09-25 at 12 49 24 PM" src="https://github.com/harness/harness-core/assets/86037848/4d6c8ee1-45d5-4e1f-b03c-35886318e91c">


develop pr - https://github.com/harness/harness-core/pull/53273
Note: This is not a hotfix. We want to get this to prod faster to verify the memory reduction in manager after this change.
## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/53275)
<!-- Reviewable:end -->
