### PR TITLE
fix: [CDS-79142]: stop ListClusters request immediately after timeout

### DIFF
--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/aws/AwsEKSDelegateTaskHelper.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/aws/AwsEKSDelegateTaskHelper.java
@@ -28,6 +28,7 @@ import io.harness.logging.CommandExecutionStatus;
 import software.wings.service.impl.AwsUtils;
 import software.wings.service.impl.aws.client.CloseableAmazonWebServiceClient;
 
+import com.amazonaws.AbortedException;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.eks.AmazonEKSClient;
 import com.amazonaws.services.eks.model.ListClustersRequest;
@@ -112,6 +113,9 @@ public class AwsEKSDelegateTaskHelper {
         nextToken = extractClusterNamesFromResponse(region, clusterList, nextToken, listClustersResult);
       } while (nextToken != null);
       return AwsEksListClustersResponseDTO.builder().region(region).clusters(clusterList).status(SUCCESS).build();
+    } catch (AbortedException e) {
+      log.warn("AWS EKS list clusters request was aborted.", e);
+      throw e;
     } catch (Exception e) {
       Exception sanitizedException = ExceptionMessageSanitizer.sanitizeException(e);
       log.warn(

--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/aws/AwsEKSDelegateTaskHelper.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/aws/AwsEKSDelegateTaskHelper.java
@@ -12,6 +12,8 @@ import static io.harness.delegate.task.aws.AwsEksListClustersResponseDTO.ListClu
 
 import static software.wings.service.impl.aws.model.AwsConstants.AWS_DEFAULT_REGION;
 
+import static java.lang.String.format;
+
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.aws.beans.AwsInternalConfig;
@@ -47,6 +49,10 @@ import lombok.extern.slf4j.Slf4j;
 public class AwsEKSDelegateTaskHelper {
   private static final String LIST_CLUSTERS_FAILURE_MESSAGE_FORMAT = "Failed to list clusters for regions [%s].";
   private static final String LIST_CLUSTERS_REGION_FAILURE_MESSAGE_FORMAT = "%nErrors: %n%s";
+  private static final String LIST_CLUSTERS_INTERRUPTED_MESSAGE =
+      "AWS EKS list clusters request for region [%s] was aborted.";
+  private static final String LIST_CLUSTERS_GENERIC_ERROR_MESSAGE =
+      "Exception in listing AWS EKS clusters using AWS ListClustersRequest for region : %s";
   @Inject private AwsUtils awsUtils;
   public DelegateResponseData getEKSClustersList(AwsTaskParams awsTaskParams) throws AwsEKSException {
     awsUtils.decryptRequestDTOs(awsTaskParams.getAwsConnector(), awsTaskParams.getEncryptionDetails());
@@ -90,13 +96,13 @@ public class AwsEKSDelegateTaskHelper {
                 AwsEksListClustersResponseDTO::getRegion, AwsEksListClustersResponseDTO::getErrorMessage));
     String regionToErrorMessage = regionToErrorMessageMap.entrySet()
                                       .stream()
-                                      .map(e -> String.format("[%s]: %s", e.getKey(), e.getValue()))
+                                      .map(e -> format("[%s]: %s", e.getKey(), e.getValue()))
                                       .collect(Collectors.joining("\n"));
     String regionList =
         listClusterResponses.stream().map(AwsEksListClustersResponseDTO::getRegion).collect(Collectors.joining(", "));
 
-    return String.format(LIST_CLUSTERS_FAILURE_MESSAGE_FORMAT, regionList)
-        + String.format(LIST_CLUSTERS_REGION_FAILURE_MESSAGE_FORMAT, regionToErrorMessage);
+    return format(LIST_CLUSTERS_FAILURE_MESSAGE_FORMAT, regionList)
+        + format(LIST_CLUSTERS_REGION_FAILURE_MESSAGE_FORMAT, regionToErrorMessage);
   }
 
   private AwsEksListClustersResponseDTO listEKSClustersForGivenRegion(
@@ -114,13 +120,19 @@ public class AwsEKSDelegateTaskHelper {
       } while (nextToken != null);
       return AwsEksListClustersResponseDTO.builder().region(region).clusters(clusterList).status(SUCCESS).build();
     } catch (AbortedException e) {
-      log.warn("AWS EKS list clusters request was aborted.", e);
-      throw e;
+      String errorMessage = format(LIST_CLUSTERS_INTERRUPTED_MESSAGE, region);
+      log.warn(errorMessage, e);
+      throw new AwsEKSException(errorMessage, e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+
+      String errorMessage = format(LIST_CLUSTERS_INTERRUPTED_MESSAGE, region);
+      log.warn(errorMessage, e);
+      throw new AwsEKSException(errorMessage, e);
     } catch (Exception e) {
       Exception sanitizedException = ExceptionMessageSanitizer.sanitizeException(e);
-      log.warn(
-          String.format("Exception in listing AWS EKS clusters using AWS ListClustersRequest for region : %s", region),
-          sanitizedException);
+      String errorMessage = format(LIST_CLUSTERS_GENERIC_ERROR_MESSAGE, region);
+      log.warn(errorMessage, sanitizedException);
 
       return AwsEksListClustersResponseDTO.builder()
           .region(region)
@@ -135,7 +147,7 @@ public class AwsEKSDelegateTaskHelper {
     if (listClustersResult != null) {
       List<String> clusterNames = listClustersResult.getClusters();
       if (EmptyPredicate.isNotEmpty(clusterNames)) {
-        clusterNames.forEach(clusterName -> clusterList.add(String.format("%s/%s", region, clusterName)));
+        clusterNames.forEach(clusterName -> clusterList.add(format("%s/%s", region, clusterName)));
       }
       nextToken = listClustersResult.getNextToken();
     }

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/aws/AwsEKSDelegateTaskHelperTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/aws/AwsEKSDelegateTaskHelperTest.java
@@ -141,7 +141,6 @@ public class AwsEKSDelegateTaskHelperTest extends CategoryTest {
   @Test
   @Owner(developers = ABHINAV2)
   @Category(UnitTests.class)
-
   public void testEksListClustersTimeout() {
     List<String> regions = List.of("us-east-1", "ap-south-1", "us-east-2");
     doReturn(regions).when(awsUtils).listAwsRegionsForGivenAccount(any());
@@ -159,7 +158,7 @@ public class AwsEKSDelegateTaskHelperTest extends CategoryTest {
     try {
       awsEKSDelegateTaskHelper.getEKSClustersList(awsTaskParams);
     } catch (Exception e) {
-      assertThat(e).isInstanceOf(AbortedException.class);
+      assertThat(e).isInstanceOf(AwsEKSException.class);
       verify(awsUtils, times(1)).getAmazonEKSClient(eq(Regions.fromName("us-east-1")), any());
       verify(awsUtils, times(0)).getAmazonEKSClient(eq(Regions.fromName("us-east-2")), any());
       verify(awsUtils, times(0)).getAmazonEKSClient(eq(Regions.fromName("ap-south-1")), any());

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/aws/AwsEKSDelegateTaskHelperTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/aws/AwsEKSDelegateTaskHelperTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import io.harness.CategoryTest;
 import io.harness.annotations.dev.OwnedBy;
@@ -34,9 +36,11 @@ import io.harness.rule.Owner;
 
 import software.wings.service.impl.AwsUtils;
 
+import com.amazonaws.AbortedException;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.eks.AmazonEKSClient;
 import com.amazonaws.services.eks.model.AccessDeniedException;
+import com.amazonaws.services.eks.model.ListClustersRequest;
 import com.amazonaws.services.eks.model.ListClustersResult;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -132,5 +136,36 @@ public class AwsEKSDelegateTaskHelperTest extends CategoryTest {
         (AwsListClustersTaskResponse) awsEKSDelegateTaskHelper.getEKSClustersList(awsTaskParams);
     assertThat(response.getClusters().size()).isEqualTo(2);
     assertThat(response.getClusters()).contains("ap-south-1/c1", "ap-south-1/c2");
+  }
+
+  @Test
+  @Owner(developers = ABHINAV2)
+  @Category(UnitTests.class)
+
+  public void testEksListClustersTimeout() {
+    List<String> regions = List.of("us-east-1", "ap-south-1", "us-east-2");
+    doReturn(regions).when(awsUtils).listAwsRegionsForGivenAccount(any());
+
+    AmazonEKSClient useast1Client = mock(AmazonEKSClient.class);
+    AmazonEKSClient useast2Client = mock(AmazonEKSClient.class);
+    AmazonEKSClient apsouth1Client = mock(AmazonEKSClient.class);
+
+    doReturn(useast1Client).when(awsUtils).getAmazonEKSClient(eq(Regions.fromName("us-east-1")), any());
+    doReturn(useast2Client).when(awsUtils).getAmazonEKSClient(eq(Regions.fromName("us-east-2")), any());
+    doReturn(apsouth1Client).when(awsUtils).getAmazonEKSClient(eq(Regions.fromName("ap-south-1")), any());
+
+    doThrow(new AbortedException("first list op aborted")).when(useast1Client).listClusters(any());
+
+    try {
+      awsEKSDelegateTaskHelper.getEKSClustersList(awsTaskParams);
+    } catch (Exception e) {
+      assertThat(e).isInstanceOf(AbortedException.class);
+      verify(awsUtils, times(1)).getAmazonEKSClient(eq(Regions.fromName("us-east-1")), any());
+      verify(awsUtils, times(0)).getAmazonEKSClient(eq(Regions.fromName("us-east-2")), any());
+      verify(awsUtils, times(0)).getAmazonEKSClient(eq(Regions.fromName("ap-south-1")), any());
+      verify(useast1Client, times(1)).listClusters(any(ListClustersRequest.class));
+      verify(useast2Client, times(0)).listClusters(any(ListClustersRequest.class));
+      verify(apsouth1Client, times(0)).listClusters(any(ListClustersRequest.class));
+    }
   }
 }


### PR DESCRIPTION
## Describe your changes
Currently, ListClusters request continues to list clusters for all remaining regions, in case of delegate task timeout. We're now catching AWS's AbortedException and re-throwing it.

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/53293)
<!-- Reviewable:end -->
