### PR TITLE
fix: [CDS-79153]: Using V2 feature flag enum instead of existing one

### DIFF
--- a/100-migrator/src/main/java/io/harness/ngmigration/api/EntityDetailsResource.java
+++ b/100-migrator/src/main/java/io/harness/ngmigration/api/EntityDetailsResource.java
@@ -305,7 +305,7 @@ public class EntityDetailsResource {
   }
 
   private FindOptions createFindOptionsToHitSecondaryNode(String accountId) {
-    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION, accountId)) {
+    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION_V2, accountId)) {
       return new FindOptions().readPreference(ReadPreference.secondaryPreferred());
     }
     return new FindOptions();

--- a/400-rest/src/main/java/io/harness/event/handler/impl/account/AccountChangeHandler.java
+++ b/400-rest/src/main/java/io/harness/event/handler/impl/account/AccountChangeHandler.java
@@ -240,7 +240,7 @@ public class AccountChangeHandler implements EventHandler {
   }
 
   private CountOptions createCountOptionsToHitSecondaryNode(String accountId) {
-    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION, accountId)) {
+    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION_V2, accountId)) {
       return new CountOptions().readPreference(ReadPreference.secondaryPreferred());
     }
     return new CountOptions();

--- a/400-rest/src/main/java/software/wings/delegatetasks/buildsource/BuildSourceCleanupHelper.java
+++ b/400-rest/src/main/java/software/wings/delegatetasks/buildsource/BuildSourceCleanupHelper.java
@@ -7,7 +7,7 @@
 
 package software.wings.delegatetasks.buildsource;
 import static io.harness.annotations.dev.HarnessTeam.CDC;
-import static io.harness.beans.FeatureName.CDS_QUERY_OPTIMIZATION;
+import static io.harness.beans.FeatureName.CDS_QUERY_OPTIMIZATION_V2;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.exception.WingsException.ExecutionContext.MANAGER;
 import static io.harness.mongo.MongoConfig.NO_LIMIT;
@@ -207,7 +207,7 @@ public class BuildSourceCleanupHelper {
     if (isEmpty(accountId)) {
       log.info("accountId provided for mongoQery is null");
     }
-    if (accountId != null && featureFlagService.isEnabled(CDS_QUERY_OPTIMIZATION, accountId)) {
+    if (accountId != null && featureFlagService.isEnabled(CDS_QUERY_OPTIMIZATION_V2, accountId)) {
       return new FindOptions().readPreference(ReadPreference.secondaryPreferred());
     }
     return new FindOptions();

--- a/400-rest/src/main/java/software/wings/helpers/ext/account/DeleteAccountHelper.java
+++ b/400-rest/src/main/java/software/wings/helpers/ext/account/DeleteAccountHelper.java
@@ -7,6 +7,7 @@
 
 package software.wings.helpers.ext.account;
 import static io.harness.annotations.dev.HarnessTeam.PL;
+import static io.harness.beans.FeatureName.CDS_QUERY_OPTIMIZATION;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.persistence.HQuery.excludeAuthority;
 
@@ -181,7 +182,7 @@ public class DeleteAccountHelper {
 
   private boolean deleteAppLevelDocuments(String accountId, Class<? extends PersistentEntity> entry) {
     FindOptions findOptions = new FindOptions();
-    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION_V2, accountId)) {
+    if (accountId != null && featureFlagService.isEnabled(CDS_QUERY_OPTIMIZATION, accountId)) {
       findOptions.readPreference(ReadPreference.secondaryPreferred());
     }
     try (

--- a/400-rest/src/main/java/software/wings/helpers/ext/account/DeleteAccountHelper.java
+++ b/400-rest/src/main/java/software/wings/helpers/ext/account/DeleteAccountHelper.java
@@ -181,7 +181,7 @@ public class DeleteAccountHelper {
 
   private boolean deleteAppLevelDocuments(String accountId, Class<? extends PersistentEntity> entry) {
     FindOptions findOptions = new FindOptions();
-    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION, accountId)) {
+    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION_V2, accountId)) {
       findOptions.readPreference(ReadPreference.secondaryPreferred());
     }
     try (

--- a/400-rest/src/main/java/software/wings/service/impl/AppServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/AppServiceImpl.java
@@ -8,6 +8,7 @@
 package software.wings.service.impl;
 import static io.harness.annotations.dev.HarnessModule._870_CG_ORCHESTRATION;
 import static io.harness.annotations.dev.HarnessTeam.CDC;
+import static io.harness.beans.FeatureName.CDS_QUERY_OPTIMIZATION;
 import static io.harness.beans.FeatureName.GITHUB_WEBHOOK_AUTHENTICATION;
 import static io.harness.beans.FeatureName.PURGE_DANGLING_APP_ENV_REFS;
 import static io.harness.beans.FeatureName.SPG_ALLOW_DISABLE_TRIGGERS;
@@ -504,7 +505,9 @@ public class AppServiceImpl implements AppService {
   @Override
   public List<Application> getAppsByAccountId(String accountId) {
     FindOptions findOptions = new FindOptions();
-    findOptions.readPreference(ReadPreference.secondaryPreferred());
+    if (featureFlagService.isEnabled(CDS_QUERY_OPTIMIZATION, accountId)) {
+      findOptions.readPreference(ReadPreference.secondaryPreferred());
+    }
     return wingsPersistence.createQuery(Application.class)
         .filter(ApplicationKeys.accountId, accountId)
         .asList(findOptions);
@@ -513,7 +516,9 @@ public class AppServiceImpl implements AppService {
   @Override
   public List<String> getAppIdsByAccountId(String accountId) {
     FindOptions findOptions = new FindOptions();
-    findOptions.readPreference(ReadPreference.secondaryPreferred());
+    if (featureFlagService.isEnabled(CDS_QUERY_OPTIMIZATION, accountId)) {
+      findOptions.readPreference(ReadPreference.secondaryPreferred());
+    }
     return wingsPersistence.createQuery(Application.class)
         .filter(ApplicationKeys.accountId, accountId)
         .asKeyList(findOptions)
@@ -525,7 +530,9 @@ public class AppServiceImpl implements AppService {
   @Override
   public Set<String> getAppIdsAsSetByAccountId(String accountId) {
     FindOptions findOptions = new FindOptions();
-    findOptions.readPreference(ReadPreference.secondaryPreferred());
+    if (featureFlagService.isEnabled(CDS_QUERY_OPTIMIZATION, accountId)) {
+      findOptions.readPreference(ReadPreference.secondaryPreferred());
+    }
     return wingsPersistence.createQuery(Application.class)
         .filter(ApplicationKeys.accountId, accountId)
         .asKeyList(findOptions)
@@ -537,7 +544,9 @@ public class AppServiceImpl implements AppService {
   @Override
   public List<String> getAppNamesByAccountId(String accountId) {
     FindOptions findOptions = new FindOptions();
-    findOptions.readPreference(ReadPreference.secondaryPreferred());
+    if (featureFlagService.isEnabled(CDS_QUERY_OPTIMIZATION, accountId)) {
+      findOptions.readPreference(ReadPreference.secondaryPreferred());
+    }
     return wingsPersistence.createQuery(Application.class)
         .project(ApplicationKeys.name, true)
         .filter(ApplicationKeys.accountId, accountId)
@@ -550,7 +559,9 @@ public class AppServiceImpl implements AppService {
   @Override
   public void deleteByAccountId(String accountId) {
     FindOptions findOptions = new FindOptions();
-    findOptions.readPreference(ReadPreference.secondaryPreferred());
+    if (featureFlagService.isEnabled(CDS_QUERY_OPTIMIZATION, accountId)) {
+      findOptions.readPreference(ReadPreference.secondaryPreferred());
+    }
     wingsPersistence.createQuery(Application.class)
         .filter(Application.ACCOUNT_ID_KEY2, accountId)
         .asKeyList(findOptions)

--- a/400-rest/src/main/java/software/wings/service/impl/EnvironmentServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/EnvironmentServiceImpl.java
@@ -694,7 +694,7 @@ public class EnvironmentServiceImpl implements EnvironmentService {
     } else {
       PageRequest<Environment> pageRequest = aPageRequest()
                                                  .addFilter(EnvironmentKeys.accountId, EQ, accountId)
-                                                 .addFilter(EnvironmentKeys.appId, Operator.IN, appIds.toArray())
+                                                 .addFilter(EnvironmentKeys.appId, IN, appIds.toArray())
                                                  .addFieldsIncluded("_id", "appId", "environmentType")
                                                  .build();
 

--- a/400-rest/src/main/java/software/wings/service/impl/EnvironmentServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/EnvironmentServiceImpl.java
@@ -9,6 +9,7 @@ package software.wings.service.impl;
 import static io.harness.annotations.dev.HarnessTeam.CDC;
 import static io.harness.beans.EnvironmentType.NON_PROD;
 import static io.harness.beans.EnvironmentType.PROD;
+import static io.harness.beans.FeatureName.CDS_QUERY_OPTIMIZATION;
 import static io.harness.beans.FeatureName.CDS_QUERY_OPTIMIZATION_GLOBAL;
 import static io.harness.beans.FeatureName.HARNESS_TAGS;
 import static io.harness.beans.FeatureName.PURGE_DANGLING_APP_ENV_REFS;
@@ -53,6 +54,7 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.annotations.dev.ProductModule;
 import io.harness.annotations.dev.TargetModule;
 import io.harness.beans.EnvironmentType;
+import io.harness.beans.FeatureName;
 import io.harness.beans.PageRequest;
 import io.harness.beans.PageResponse;
 import io.harness.event.handler.impl.EventPublishHelper;
@@ -657,7 +659,7 @@ public class EnvironmentServiceImpl implements EnvironmentService {
   public List<Environment> getEnvByAccountId(String accountId, boolean hitSecondary) {
     PageRequest<Environment> pageRequest =
         aPageRequest().addFilter(EnvironmentKeys.accountId, EQ, accountId).withLimit(UNLIMITED).build();
-    if (hitSecondary) {
+    if (featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION, accountId) && hitSecondary) {
       return wingsPersistence.querySecondary(Environment.class, pageRequest).getResponse();
     } else {
       return wingsPersistence.query(Environment.class, pageRequest).getResponse();
@@ -677,15 +679,27 @@ public class EnvironmentServiceImpl implements EnvironmentService {
     if (isEmpty(appIds)) {
       return new HashMap<>();
     }
-    FindOptions findOptions = new FindOptions();
-    findOptions.readPreference(ReadPreference.secondaryPreferred());
-    List<Environment> list = wingsPersistence.createQuery(Environment.class)
-                                 .filter(EnvironmentKeys.accountId, accountId)
-                                 .field(EnvironmentKeys.appId)
-                                 .in(appIds)
-                                 .project(EnvironmentKeys.appId, true)
-                                 .project(EnvironmentKeys.environmentType, true)
-                                 .asList(findOptions);
+    List<Environment> list;
+
+    if (featureFlagService.isEnabled(CDS_QUERY_OPTIMIZATION, accountId)) {
+      FindOptions findOptions = new FindOptions();
+      findOptions.readPreference(ReadPreference.secondaryPreferred());
+      list = wingsPersistence.createQuery(Environment.class)
+                 .filter(EnvironmentKeys.accountId, accountId)
+                 .field(EnvironmentKeys.appId)
+                 .in(appIds)
+                 .project(EnvironmentKeys.appId, true)
+                 .project(EnvironmentKeys.environmentType, true)
+                 .asList(findOptions);
+    } else {
+      PageRequest<Environment> pageRequest = aPageRequest()
+                                                 .addFilter(EnvironmentKeys.accountId, EQ, accountId)
+                                                 .addFilter(EnvironmentKeys.appId, Operator.IN, appIds.toArray())
+                                                 .addFieldsIncluded("_id", "appId", "environmentType")
+                                                 .build();
+
+      list = wingsPersistence.getAllEntities(pageRequest, () -> list(pageRequest, false, null, true));
+    }
 
     List<Base> emptyList = new ArrayList<>();
 

--- a/400-rest/src/main/java/software/wings/service/impl/HarnessTagServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/HarnessTagServiceImpl.java
@@ -713,7 +713,7 @@ public class HarnessTagServiceImpl implements HarnessTagService {
   public List<HarnessTagLink> getTagLinksWithEntityId(String accountId, String entityId, boolean hitSecondary) {
     FindOptions findOptions = new FindOptions();
     if (hitSecondary && accountId != null
-        && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION, accountId)) {
+        && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION_V2, accountId)) {
       findOptions.readPreference(ReadPreference.secondaryPreferred());
     }
     return wingsPersistence.createQuery(HarnessTagLink.class)

--- a/400-rest/src/main/java/software/wings/service/impl/PipelineServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/PipelineServiceImpl.java
@@ -198,7 +198,7 @@ public class PipelineServiceImpl implements PipelineService {
   public PageResponse<Pipeline> listPipelines(
       PageRequest<Pipeline> pageRequest, boolean hitSecondary, String accountId) {
     if (hitSecondary && accountId != null
-        && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION, accountId)) {
+        && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION_V2, accountId)) {
       return wingsPersistence.querySecondary(Pipeline.class, pageRequest);
     }
     return wingsPersistence.query(Pipeline.class, pageRequest);

--- a/400-rest/src/main/java/software/wings/service/impl/ResourceLookupServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/ResourceLookupServiceImpl.java
@@ -360,7 +360,7 @@ public class ResourceLookupServiceImpl implements ResourceLookupService {
     pageRequest.addOrder(ResourceLookupKeys.resourceName, ASC);
     resourceLookupFilterHelper.addResourceLookupFiltersToPageRequest(pageRequest, filter);
     PageResponse<ResourceLookup> pageResponse;
-    if (hitSecondary) {
+    if (featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION, accountId) && hitSecondary) {
       pageResponse = wingsPersistence.querySecondary(ResourceLookup.class, pageRequest);
     } else {
       pageResponse = wingsPersistence.query(ResourceLookup.class, pageRequest);

--- a/400-rest/src/main/java/software/wings/service/impl/ResourceLookupServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/ResourceLookupServiceImpl.java
@@ -441,7 +441,7 @@ public class ResourceLookupServiceImpl implements ResourceLookupService {
       }
     }
 
-    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION, accountId)
+    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION_V2, accountId)
         && hitSecondary) {
       if (addAccountFilterAutomatically && !accountIdPresentInPageRequest(request)) {
         request.addFilter("accountId", EQ, accountId);

--- a/400-rest/src/main/java/software/wings/service/impl/ServiceResourceServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/ServiceResourceServiceImpl.java
@@ -3359,7 +3359,7 @@ public class ServiceResourceServiceImpl implements ServiceResourceService, DataP
   }
 
   private FindOptions createFindOptionsToHitSecondaryNode(String accountId) {
-    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION, accountId)) {
+    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION_V2, accountId)) {
       return new FindOptions().readPreference(ReadPreference.secondaryPreferred());
     }
     return new FindOptions();

--- a/400-rest/src/main/java/software/wings/service/impl/UserGroupServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/UserGroupServiceImpl.java
@@ -272,7 +272,7 @@ public class UserGroupServiceImpl implements UserGroupService {
       populateAppIdFilter(req, applicationIdsMatchingSearchTerm);
     }
     PageResponse<UserGroup> res;
-    if (hitSecondary && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION, accountId)) {
+    if (hitSecondary && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION_V2, accountId)) {
       res = wingsPersistence.querySecondary(UserGroup.class, req);
     } else {
       res = wingsPersistence.query(UserGroup.class, req);
@@ -1439,7 +1439,7 @@ public class UserGroupServiceImpl implements UserGroupService {
   }
 
   private FindOptions createFindOptionsToHitSecondaryNode(String accountId) {
-    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION, accountId)) {
+    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION_V2, accountId)) {
       return new FindOptions().readPreference(ReadPreference.secondaryPreferred());
     }
     return new FindOptions();

--- a/400-rest/src/main/java/software/wings/service/impl/instance/CloudToHarnessMappingServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/instance/CloudToHarnessMappingServiceImpl.java
@@ -545,7 +545,7 @@ public class CloudToHarnessMappingServiceImpl implements CloudToHarnessMappingSe
   }
 
   private FindOptions createFindOptionsToHitSecondaryNode(String accountId) {
-    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION, accountId)) {
+    if (accountId != null && featureFlagService.isEnabled(FeatureName.CDS_QUERY_OPTIMIZATION_V2, accountId)) {
       return new FindOptions().readPreference(ReadPreference.secondaryPreferred());
     }
     return new FindOptions();

--- a/400-rest/src/main/java/software/wings/service/impl/workflow/WorkflowServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/workflow/WorkflowServiceImpl.java
@@ -8,6 +8,7 @@
 package software.wings.service.impl.workflow;
 import static io.harness.annotations.dev.HarnessTeam.CDC;
 import static io.harness.beans.ExecutionStatus.SUCCESS;
+import static io.harness.beans.FeatureName.CDS_QUERY_OPTIMIZATION;
 import static io.harness.beans.FeatureName.HELM_CHART_AS_ARTIFACT;
 import static io.harness.beans.FeatureName.SPG_CG_TIMEOUT_FAILURE_AT_WORKFLOW;
 import static io.harness.beans.FeatureName.TIMEOUT_FAILURE_SUPPORT;
@@ -470,7 +471,9 @@ public class WorkflowServiceImpl implements WorkflowService {
   @Override
   public List<Workflow> list(String accountId, List<String> projectFields, String queryHint) {
     FindOptions findOptions = new FindOptions();
-    findOptions.readPreference(ReadPreference.secondaryPreferred());
+    if (featureFlagService.isEnabled(CDS_QUERY_OPTIMIZATION, accountId)) {
+      findOptions.readPreference(ReadPreference.secondaryPreferred());
+    }
     Query<Workflow> workflowQuery =
         wingsPersistence.createQuery(Workflow.class).filter(WorkflowKeys.accountId, accountId);
     emptyIfNull(projectFields).forEach(field -> { workflowQuery.project(field, true); });

--- a/400-rest/src/main/java/software/wings/service/impl/yaml/YamlGitServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/yaml/YamlGitServiceImpl.java
@@ -6,6 +6,7 @@
  */
 
 package software.wings.service.impl.yaml;
+import static io.harness.beans.FeatureName.CDS_QUERY_OPTIMIZATION;
 import static io.harness.beans.FeatureName.NOTIFY_GIT_SYNC_ERRORS_PER_APP;
 import static io.harness.beans.PageRequest.PageRequestBuilder.aPageRequest;
 import static io.harness.beans.PageRequest.UNLIMITED;
@@ -1393,7 +1394,9 @@ public class YamlGitServiceImpl implements YamlGitService {
       fullSync(accountId, accountId, EntityType.ACCOUNT, false);
 
       FindOptions findOptions = new FindOptions();
-      findOptions.readPreference(ReadPreference.secondaryPreferred());
+      if (featureFlagService.isEnabled(CDS_QUERY_OPTIMIZATION, accountId)) {
+        findOptions.readPreference(ReadPreference.secondaryPreferred());
+      }
 
       try (HIterator<Application> apps = new HIterator<>(wingsPersistence.createQuery(Application.class)
                                                              .filter(ApplicationKeys.accountId, accountId)

--- a/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
+++ b/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
@@ -155,6 +155,7 @@ public enum FeatureName {
       "With enabling this FF with serviceV2 setup, pipeline in different projects but having the same infra key can be executed parallely",
       HarnessTeam.CDC),
   CDS_QUERY_OPTIMIZATION("Feature flag to optimize CG Queries", HarnessTeam.CDC),
+  CDS_QUERY_OPTIMIZATION_V2("Feature flag to optimize CG Queries V2", HarnessTeam.CDC),
   CDS_QUERY_OPTIMIZATION_GLOBAL(
       "Feature flag to optimize CG Queries when accountId is not present", HarnessTeam.CDC, Scope.GLOBAL),
   CDS_RANCHER_SUPPORT_NG("Enable Rancher support in NG.", HarnessTeam.CDP),


### PR DESCRIPTION
## Describe your changes

This pr does two things:

- As part of previous pr we had removed usages of CDS_QUERY_OPTIMIZATIONS as those were done quite a few months back. But I noticed these were enabled only on prod 2 globally. So I am reverting removal of those flags.
- All new changes I have created a new flag CDS_QUERY_OPTIMIZATIONS_V2 and put them behind this. This is so the changes are by default not enabled when the changes reach prod.

In future once some flag is enabled for a long time in prods we will move them to CDS_QUERY_OPTIMIZATIONS and new ones will go to V2

Hot fix pr for qa https://github.com/harness/harness-core/pull/53606

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/53483)
<!-- Reviewable:end -->
