### PR TITLE
[fix]: [PL-41943]: Fixes decryption issue for secret value with curl braces

### DIFF
--- a/260-delegate/build.properties
+++ b/260-delegate/build.properties
@@ -1,1 +1,1 @@
-build.number=80808
+build.number=80809

--- a/931-encryption-service/src/java/io/harness/encryptors/clients/AwsSecretsManagerEncryptor.java
+++ b/931-encryption-service/src/java/io/harness/encryptors/clients/AwsSecretsManagerEncryptor.java
@@ -15,7 +15,6 @@ import static io.harness.eraro.ErrorCode.VAULT_OPERATION_ERROR;
 import static io.harness.exception.WingsException.USER;
 import static io.harness.exception.WingsException.USER_SRE;
 import static io.harness.helpers.GlobalSecretManagerUtils.getValueByJsonPath;
-import static io.harness.helpers.GlobalSecretManagerUtils.parse;
 import static io.harness.threading.Morpheus.sleep;
 
 import static software.wings.helpers.ext.vault.VaultRestClientFactory.getFullPath;
@@ -332,7 +331,7 @@ public class AwsSecretsManagerEncryptor implements VaultEncryptor {
     String secretValue = result.getSecretString();
 
     log.info("Done decrypting AWS secret {} in {}ms", secretName, System.currentTimeMillis() - startTime);
-    return getValueByJsonPath(parse(secretValue), refKeyName).toCharArray();
+    return getValueByJsonPath(secretValue, refKeyName).toCharArray();
   }
 
   @VisibleForTesting

--- a/931-encryption-service/src/java/io/harness/encryptors/clients/AzureVaultEncryptor.java
+++ b/931-encryption-service/src/java/io/harness/encryptors/clients/AzureVaultEncryptor.java
@@ -389,7 +389,7 @@ public class AzureVaultEncryptor implements VaultEncryptor {
         throw new AzureKeyVaultOperationException("Received null value for " + parsedSecretReference.getSecretName(),
             AZURE_KEY_VAULT_OPERATION_ERROR, USER_SRE);
       }
-      return getValueByJsonPath(parse(response.getValue().getValue()), parsedSecretReference.getKey()).toCharArray();
+      return getValueByJsonPath(response.getValue().getValue(), parsedSecretReference.getKey()).toCharArray();
     } catch (KeyVaultErrorException | MsalException ex) {
       throw ex;
     } catch (Exception ex) {

--- a/931-encryption-service/src/java/io/harness/encryptors/clients/GcpSecretsManagerEncryptor.java
+++ b/931-encryption-service/src/java/io/harness/encryptors/clients/GcpSecretsManagerEncryptor.java
@@ -16,7 +16,6 @@ import static io.harness.eraro.ErrorCode.GCP_SECRET_OPERATION_ERROR;
 import static io.harness.exception.WingsException.USER;
 import static io.harness.exception.WingsException.USER_SRE;
 import static io.harness.helpers.GlobalSecretManagerUtils.getValueByJsonPath;
-import static io.harness.helpers.GlobalSecretManagerUtils.parse;
 
 import static com.google.datastore.v1.client.DatastoreHelper.getProjectIdFromComputeEngine;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
@@ -189,7 +188,7 @@ public class GcpSecretsManagerEncryptor implements VaultEncryptor {
       if (secretVersionName != null) {
         AccessSecretVersionResponse response = gcpSecretsManagerClient.accessSecretVersion(secretVersionName);
         String payload = response.getPayload().getData().toStringUtf8();
-        return getValueByJsonPath(parse(payload), key).toCharArray();
+        return getValueByJsonPath(payload, key).toCharArray();
       }
     } catch (IOException e) {
       throw new SecretManagementClientException(

--- a/931-encryption-service/src/test/io/harness/encryptors/clients/AwsSecretsManagerEncryptorTest.java
+++ b/931-encryption-service/src/test/io/harness/encryptors/clients/AwsSecretsManagerEncryptorTest.java
@@ -731,6 +731,26 @@ public class AwsSecretsManagerEncryptorTest extends CategoryTest {
     char[] returnedValue = awsSecretsManagerEncryptor.fetchSecretValue(
         awsSecretsManagerConfig.getAccountId(), encryptedRecord, awsSecretsManagerConfig);
     assertThat(returnedValue).isEqualTo(value.toCharArray());
+
+    value = "{01dkd7}op910";
+    result = "{\"" + key + "\":\"" + value + "\"}";
+    getSecretRequest = new GetSecretValueRequest().withSecretId(fullSecretName);
+    getSecretValueResult = new GetSecretValueResult().withSecretString(result);
+    when(awsSecretsManager.getSecretValue(getSecretRequest)).thenReturn(getSecretValueResult);
+    encryptedRecord = builder().path(fullSecretNameAndKey).build();
+    returnedValue = awsSecretsManagerEncryptor.fetchSecretValue(
+        awsSecretsManagerConfig.getAccountId(), encryptedRecord, awsSecretsManagerConfig);
+    assertThat(returnedValue).isEqualTo(value.toCharArray());
+
+    value = "";
+    result = "{\"" + key + "\":\"" + value + "\"}";
+    getSecretRequest = new GetSecretValueRequest().withSecretId(fullSecretName);
+    getSecretValueResult = new GetSecretValueResult().withSecretString(result);
+    when(awsSecretsManager.getSecretValue(getSecretRequest)).thenReturn(getSecretValueResult);
+    encryptedRecord = builder().path(fullSecretNameAndKey).build();
+    returnedValue = awsSecretsManagerEncryptor.fetchSecretValue(
+        awsSecretsManagerConfig.getAccountId(), encryptedRecord, awsSecretsManagerConfig);
+    assertThat(returnedValue).isEqualTo(value.toCharArray());
   }
 
   @Test

--- a/931-encryption-service/src/test/io/harness/encryptors/clients/AwsSecretsManagerEncryptorTest.java
+++ b/931-encryption-service/src/test/io/harness/encryptors/clients/AwsSecretsManagerEncryptorTest.java
@@ -751,6 +751,51 @@ public class AwsSecretsManagerEncryptorTest extends CategoryTest {
     returnedValue = awsSecretsManagerEncryptor.fetchSecretValue(
         awsSecretsManagerConfig.getAccountId(), encryptedRecord, awsSecretsManagerConfig);
     assertThat(returnedValue).isEqualTo(value.toCharArray());
+
+    result = "{01dkd7}op910";
+    getSecretRequest = new GetSecretValueRequest().withSecretId(fullSecretName);
+    getSecretValueResult = new GetSecretValueResult().withSecretString(result);
+    when(awsSecretsManager.getSecretValue(getSecretRequest)).thenReturn(getSecretValueResult);
+    encryptedRecord = builder().path(fullSecretName).build();
+    returnedValue = awsSecretsManagerEncryptor.fetchSecretValue(
+        awsSecretsManagerConfig.getAccountId(), encryptedRecord, awsSecretsManagerConfig);
+    assertThat(returnedValue).isEqualTo(result.toCharArray());
+
+    result = "[,\":]";
+    getSecretRequest = new GetSecretValueRequest().withSecretId(fullSecretName);
+    getSecretValueResult = new GetSecretValueResult().withSecretString(result);
+    when(awsSecretsManager.getSecretValue(getSecretRequest)).thenReturn(getSecretValueResult);
+    encryptedRecord = builder().path(fullSecretName).build();
+    returnedValue = awsSecretsManagerEncryptor.fetchSecretValue(
+        awsSecretsManagerConfig.getAccountId(), encryptedRecord, awsSecretsManagerConfig);
+    assertThat(returnedValue).isEqualTo(result.toCharArray());
+
+    result = "[1,2,3]";
+    getSecretRequest = new GetSecretValueRequest().withSecretId(fullSecretName);
+    getSecretValueResult = new GetSecretValueResult().withSecretString(result);
+    when(awsSecretsManager.getSecretValue(getSecretRequest)).thenReturn(getSecretValueResult);
+    encryptedRecord = builder().path(fullSecretName).build();
+    returnedValue = awsSecretsManagerEncryptor.fetchSecretValue(
+        awsSecretsManagerConfig.getAccountId(), encryptedRecord, awsSecretsManagerConfig);
+    assertThat(returnedValue).isEqualTo(result.toCharArray());
+
+    result = "[\"adfd\"]";
+    getSecretRequest = new GetSecretValueRequest().withSecretId(fullSecretName);
+    getSecretValueResult = new GetSecretValueResult().withSecretString(result);
+    when(awsSecretsManager.getSecretValue(getSecretRequest)).thenReturn(getSecretValueResult);
+    encryptedRecord = builder().path(fullSecretName).build();
+    returnedValue = awsSecretsManagerEncryptor.fetchSecretValue(
+        awsSecretsManagerConfig.getAccountId(), encryptedRecord, awsSecretsManagerConfig);
+    assertThat(returnedValue).isEqualTo(result.toCharArray());
+
+    result = "[\"adfd:asdf\"]";
+    getSecretRequest = new GetSecretValueRequest().withSecretId(fullSecretName);
+    getSecretValueResult = new GetSecretValueResult().withSecretString(result);
+    when(awsSecretsManager.getSecretValue(getSecretRequest)).thenReturn(getSecretValueResult);
+    encryptedRecord = builder().path(fullSecretName).build();
+    returnedValue = awsSecretsManagerEncryptor.fetchSecretValue(
+        awsSecretsManagerConfig.getAccountId(), encryptedRecord, awsSecretsManagerConfig);
+    assertThat(returnedValue).isEqualTo(result.toCharArray());
   }
 
   @Test

--- a/931-encryption-service/src/test/io/harness/encryptors/clients/AzureVaultEncryptorTest.java
+++ b/931-encryption-service/src/test/io/harness/encryptors/clients/AzureVaultEncryptorTest.java
@@ -599,6 +599,22 @@ public class AzureVaultEncryptorTest extends CategoryTest {
     when(keyVaultClient.getSecretWithResponse(any(), any(), any(Context.class))).thenReturn(response);
     char[] value = azureVaultEncryptor.fetchSecretValue(azureVaultConfig.getAccountId(), record, azureVaultConfig);
     assertThat(value).isEqualTo(plainText.toCharArray());
+
+    String valueWithCurlyBraces = "{01dkd7}op910";
+    record = EncryptedRecordData.builder().name(name).path(UUIDGenerator.generateUuid()).build();
+    keyVaultSecret = mockKeyVaultSecret(name, valueWithCurlyBraces);
+    response = new SimpleResponse(null, 200, null, keyVaultSecret);
+    when(keyVaultClient.getSecretWithResponse(any(), any(), any(Context.class))).thenReturn(response);
+    value = azureVaultEncryptor.fetchSecretValue(azureVaultConfig.getAccountId(), record, azureVaultConfig);
+    assertThat(value).isEqualTo(valueWithCurlyBraces.toCharArray());
+
+    String emptyValue = "";
+    record = EncryptedRecordData.builder().name(name).path(UUIDGenerator.generateUuid()).build();
+    keyVaultSecret = mockKeyVaultSecret(name, emptyValue);
+    response = new SimpleResponse(null, 200, null, keyVaultSecret);
+    when(keyVaultClient.getSecretWithResponse(any(), any(), any(Context.class))).thenReturn(response);
+    value = azureVaultEncryptor.fetchSecretValue(azureVaultConfig.getAccountId(), record, azureVaultConfig);
+    assertThat(value).isEqualTo(emptyValue.toCharArray());
   }
 
   @Test

--- a/931-encryption-service/src/test/io/harness/encryptors/clients/AzureVaultEncryptorTest.java
+++ b/931-encryption-service/src/test/io/harness/encryptors/clients/AzureVaultEncryptorTest.java
@@ -615,6 +615,38 @@ public class AzureVaultEncryptorTest extends CategoryTest {
     when(keyVaultClient.getSecretWithResponse(any(), any(), any(Context.class))).thenReturn(response);
     value = azureVaultEncryptor.fetchSecretValue(azureVaultConfig.getAccountId(), record, azureVaultConfig);
     assertThat(value).isEqualTo(emptyValue.toCharArray());
+
+    String valueWithSpecialCharacters = "[,\":]";
+    record = EncryptedRecordData.builder().name(name).path(UUIDGenerator.generateUuid()).build();
+    keyVaultSecret = mockKeyVaultSecret(name, valueWithSpecialCharacters);
+    response = new SimpleResponse(null, 200, null, keyVaultSecret);
+    when(keyVaultClient.getSecretWithResponse(any(), any(), any(Context.class))).thenReturn(response);
+    value = azureVaultEncryptor.fetchSecretValue(azureVaultConfig.getAccountId(), record, azureVaultConfig);
+    assertThat(value).isEqualTo(valueWithSpecialCharacters.toCharArray());
+
+    String someValue = "[1,2,3]";
+    record = EncryptedRecordData.builder().name(name).path(UUIDGenerator.generateUuid()).build();
+    keyVaultSecret = mockKeyVaultSecret(name, someValue);
+    response = new SimpleResponse(null, 200, null, keyVaultSecret);
+    when(keyVaultClient.getSecretWithResponse(any(), any(), any(Context.class))).thenReturn(response);
+    value = azureVaultEncryptor.fetchSecretValue(azureVaultConfig.getAccountId(), record, azureVaultConfig);
+    assertThat(value).isEqualTo(someValue.toCharArray());
+
+    someValue = "[\"adfd\"]";
+    record = EncryptedRecordData.builder().name(name).path(UUIDGenerator.generateUuid()).build();
+    keyVaultSecret = mockKeyVaultSecret(name, someValue);
+    response = new SimpleResponse(null, 200, null, keyVaultSecret);
+    when(keyVaultClient.getSecretWithResponse(any(), any(), any(Context.class))).thenReturn(response);
+    value = azureVaultEncryptor.fetchSecretValue(azureVaultConfig.getAccountId(), record, azureVaultConfig);
+    assertThat(value).isEqualTo(someValue.toCharArray());
+
+    someValue = "[\"adfd:asdf\"]";
+    record = EncryptedRecordData.builder().name(name).path(UUIDGenerator.generateUuid()).build();
+    keyVaultSecret = mockKeyVaultSecret(name, someValue);
+    response = new SimpleResponse(null, 200, null, keyVaultSecret);
+    when(keyVaultClient.getSecretWithResponse(any(), any(), any(Context.class))).thenReturn(response);
+    value = azureVaultEncryptor.fetchSecretValue(azureVaultConfig.getAccountId(), record, azureVaultConfig);
+    assertThat(value).isEqualTo(someValue.toCharArray());
   }
 
   @Test

--- a/931-encryption-service/src/test/io/harness/encryptors/clients/GcpSecretsManagerEncryptorTest.java
+++ b/931-encryption-service/src/test/io/harness/encryptors/clients/GcpSecretsManagerEncryptorTest.java
@@ -227,6 +227,40 @@ public class GcpSecretsManagerEncryptorTest extends CategoryTest {
   @Test
   @Owner(developers = ASHISHSANODIA)
   @Category(UnitTests.class)
+  public void test_itShouldFetchSecretValue() {
+    String secretValue = "";
+    doReturn(AccessSecretVersionResponse.newBuilder()
+                 .setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8(secretValue)).build())
+                 .build())
+        .when(secretManagerServiceClient)
+        .accessSecretVersion(any(SecretVersionName.class));
+
+    EncryptedRecordData.EncryptedRecordDataBuilder encryptedRecordDataBuilder =
+        EncryptedRecordData.builder()
+            .encryptionKey(mockedSecret.getName())
+            .path(mockedSecrectVersion.getName())
+            .additionalMetadata(AdditionalMetadata.builder().value(VERSION, "v1").build())
+            .encryptedValue(mockedSecrectVersion.getName().toCharArray());
+
+    char[] fetchedSecretValue = gcpSecretsManagerEncryptor.fetchSecretValue(
+        accountId, encryptedRecordDataBuilder.build(), gcpSecretsManagerConfig);
+    assertThat(valueOf(fetchedSecretValue)).isEqualTo(secretValue);
+
+    secretValue = "{01dkd7}op910";
+    doReturn(AccessSecretVersionResponse.newBuilder()
+                 .setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8(secretValue)).build())
+                 .build())
+        .when(secretManagerServiceClient)
+        .accessSecretVersion(any(SecretVersionName.class));
+
+    fetchedSecretValue = gcpSecretsManagerEncryptor.fetchSecretValue(
+        accountId, encryptedRecordDataBuilder.build(), gcpSecretsManagerConfig);
+    assertThat(valueOf(fetchedSecretValue)).isEqualTo(secretValue);
+  }
+
+  @Test
+  @Owner(developers = ASHISHSANODIA)
+  @Category(UnitTests.class)
   public void test_itShouldFetchJsonSecretValueByKeyAndPath() throws IOException {
     String jsonText =
         "{\"key1\":\"value1\",\"key2\":{\"key21\":\"value21\",\"key22\":\"value22\"},\"key3\":{\"key31\":{\"key311\":\"value311\"}}}";

--- a/931-encryption-service/src/test/io/harness/encryptors/clients/GcpSecretsManagerEncryptorTest.java
+++ b/931-encryption-service/src/test/io/harness/encryptors/clients/GcpSecretsManagerEncryptorTest.java
@@ -256,6 +256,50 @@ public class GcpSecretsManagerEncryptorTest extends CategoryTest {
     fetchedSecretValue = gcpSecretsManagerEncryptor.fetchSecretValue(
         accountId, encryptedRecordDataBuilder.build(), gcpSecretsManagerConfig);
     assertThat(valueOf(fetchedSecretValue)).isEqualTo(secretValue);
+
+    secretValue = "[,\":]";
+    doReturn(AccessSecretVersionResponse.newBuilder()
+                 .setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8(secretValue)).build())
+                 .build())
+        .when(secretManagerServiceClient)
+        .accessSecretVersion(any(SecretVersionName.class));
+
+    fetchedSecretValue = gcpSecretsManagerEncryptor.fetchSecretValue(
+        accountId, encryptedRecordDataBuilder.build(), gcpSecretsManagerConfig);
+    assertThat(valueOf(fetchedSecretValue)).isEqualTo(secretValue);
+
+    secretValue = "[1,2,3]";
+    doReturn(AccessSecretVersionResponse.newBuilder()
+                 .setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8(secretValue)).build())
+                 .build())
+        .when(secretManagerServiceClient)
+        .accessSecretVersion(any(SecretVersionName.class));
+
+    fetchedSecretValue = gcpSecretsManagerEncryptor.fetchSecretValue(
+        accountId, encryptedRecordDataBuilder.build(), gcpSecretsManagerConfig);
+    assertThat(valueOf(fetchedSecretValue)).isEqualTo(secretValue);
+
+    secretValue = "[\"adfd\"]";
+    doReturn(AccessSecretVersionResponse.newBuilder()
+                 .setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8(secretValue)).build())
+                 .build())
+        .when(secretManagerServiceClient)
+        .accessSecretVersion(any(SecretVersionName.class));
+
+    fetchedSecretValue = gcpSecretsManagerEncryptor.fetchSecretValue(
+        accountId, encryptedRecordDataBuilder.build(), gcpSecretsManagerConfig);
+    assertThat(valueOf(fetchedSecretValue)).isEqualTo(secretValue);
+
+    secretValue = "[\"adfd:asdf\"]";
+    doReturn(AccessSecretVersionResponse.newBuilder()
+                 .setPayload(SecretPayload.newBuilder().setData(ByteString.copyFromUtf8(secretValue)).build())
+                 .build())
+        .when(secretManagerServiceClient)
+        .accessSecretVersion(any(SecretVersionName.class));
+
+    fetchedSecretValue = gcpSecretsManagerEncryptor.fetchSecretValue(
+        accountId, encryptedRecordDataBuilder.build(), gcpSecretsManagerConfig);
+    assertThat(valueOf(fetchedSecretValue)).isEqualTo(secretValue);
   }
 
   @Test

--- a/931-encryption-service/src/test/io/harness/encryptors/clients/HashicorpVaultEncryptorTest.java
+++ b/931-encryption-service/src/test/io/harness/encryptors/clients/HashicorpVaultEncryptorTest.java
@@ -675,6 +675,26 @@ public class HashicorpVaultEncryptorTest extends CategoryTest {
     value = hashicorpVaultEncryptor.fetchSecretValue(vaultConfig.getAccountId(), encryptedRecord, vaultConfig);
     assertThat(valueOf(value)).isEqualTo("{01dkd7}op910");
 
+    data = Map.of("key-having-special-characters-in-value-1", "[,\":]");
+    encryptedRecord = setupJsonResponseMockingV2(data, "key-having-special-characters-in-value-1");
+    value = hashicorpVaultEncryptor.fetchSecretValue(vaultConfig.getAccountId(), encryptedRecord, vaultConfig);
+    assertThat(valueOf(value)).isEqualTo("[,\":]");
+
+    data = Map.of("key-having-special-characters-in-value-2", "[1,2,3]");
+    encryptedRecord = setupJsonResponseMockingV2(data, "key-having-special-characters-in-value-2");
+    value = hashicorpVaultEncryptor.fetchSecretValue(vaultConfig.getAccountId(), encryptedRecord, vaultConfig);
+    assertThat(valueOf(value)).isEqualTo("[1,2,3]");
+
+    data = Map.of("key-having-special-characters-in-value-3", "[\"adfd\"]");
+    encryptedRecord = setupJsonResponseMockingV2(data, "key-having-special-characters-in-value-3");
+    value = hashicorpVaultEncryptor.fetchSecretValue(vaultConfig.getAccountId(), encryptedRecord, vaultConfig);
+    assertThat(valueOf(value)).isEqualTo("[\"adfd\"]");
+
+    data = Map.of("key-having-special-characters-in-value-4", "[\"adfd:asdf\"]");
+    encryptedRecord = setupJsonResponseMockingV2(data, "key-having-special-characters-in-value-4");
+    value = hashicorpVaultEncryptor.fetchSecretValue(vaultConfig.getAccountId(), encryptedRecord, vaultConfig);
+    assertThat(valueOf(value)).isEqualTo("[\"adfd:asdf\"]");
+
     data = Map.of("key-1", "value-1", "key-2", Map.of("key-21", "value-21"), "key-3",
         Map.of("key-31", Map.of("key-311", "value-311")));
 

--- a/931-encryption-service/src/test/io/harness/encryptors/clients/HashicorpVaultEncryptorTest.java
+++ b/931-encryption-service/src/test/io/harness/encryptors/clients/HashicorpVaultEncryptorTest.java
@@ -670,6 +670,11 @@ public class HashicorpVaultEncryptorTest extends CategoryTest {
     char[] value = hashicorpVaultEncryptor.fetchSecretValue(vaultConfig.getAccountId(), encryptedRecord, vaultConfig);
     assertThat(valueOf(value)).isEqualTo("value-for-key-with-dot");
 
+    data = Map.of("key-having-value-with-curly-braces", "{01dkd7}op910");
+    encryptedRecord = setupJsonResponseMockingV2(data, "key-having-value-with-curly-braces");
+    value = hashicorpVaultEncryptor.fetchSecretValue(vaultConfig.getAccountId(), encryptedRecord, vaultConfig);
+    assertThat(valueOf(value)).isEqualTo("{01dkd7}op910");
+
     data = Map.of("key-1", "value-1", "key-2", Map.of("key-21", "value-21"), "key-3",
         Map.of("key-31", Map.of("key-311", "value-311")));
 

--- a/931-secret-providers/src/java/io/harness/helpers/GlobalSecretManagerUtils.java
+++ b/931-secret-providers/src/java/io/harness/helpers/GlobalSecretManagerUtils.java
@@ -23,6 +23,9 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
 import lombok.experimental.UtilityClass;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 @UtilityClass
 @OwnedBy(PL)
@@ -39,6 +42,14 @@ public class GlobalSecretManagerUtils {
     return ngSecretManagerMetadata != null
         && (Boolean.TRUE.equals(ngSecretManagerMetadata.getHarnessManaged())
             || HARNESS_SECRET_MANAGER_IDENTIFIER.equals(ngSecretManagerMetadata.getIdentifier()));
+  }
+
+  public static String getValueByJsonPath(Object input, String key) throws JsonProcessingException {
+    return isValidJson(input) ? getValueByJsonPath(parse(input), key) : input.toString();
+  }
+
+  public static String getValueByJsonPath(String input, String key) throws JsonProcessingException {
+    return isValidJson(input) ? getValueByJsonPath(parse(input), key) : input;
   }
 
   public static String getValueByJsonPath(DocumentContext context, String key) throws JsonProcessingException {
@@ -66,5 +77,31 @@ public class GlobalSecretManagerUtils {
 
   public static DocumentContext parse(String json) {
     return JsonPath.using(configuration).parse(json);
+  }
+
+  public boolean isValidJson(Object json) {
+    try {
+      new JSONObject(json);
+    } catch (JSONException e) {
+      try {
+        new JSONArray(json);
+      } catch (JSONException ne) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public boolean isValidJson(String json) {
+    try {
+      new JSONObject(json);
+    } catch (JSONException e) {
+      try {
+        new JSONArray(json);
+      } catch (JSONException ne) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/931-vault-beans/src/java/software/wings/helpers/ext/vault/VaultRestClientFactory.java
+++ b/931-vault-beans/src/java/software/wings/helpers/ext/vault/VaultRestClientFactory.java
@@ -15,7 +15,6 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.exception.runtime.hashicorp.HashiCorpVaultRuntimeException;
-import io.harness.helpers.GlobalSecretManagerUtils;
 import io.harness.network.Http;
 
 import software.wings.beans.VaultConfig;
@@ -195,7 +194,7 @@ public class VaultRestClientFactory {
       }
       return response == null || response.getData() == null
           ? null
-          : getValueByJsonPath(GlobalSecretManagerUtils.parse(response.getData()), pathAndKey.keyName);
+          : getValueByJsonPath(response.getData(), pathAndKey.keyName);
     }
 
     @Override
@@ -257,7 +256,7 @@ public class VaultRestClientFactory {
         VaultReadResponseV2 response = result.body();
         return response == null || response.getData() == null
             ? null
-            : getValueByJsonPath(GlobalSecretManagerUtils.parse(response.getData().getData()), pathAndKey.keyName);
+            : getValueByJsonPath(response.getData().getData(), pathAndKey.keyName);
       }
       logAndThrowErrorIfRequestFailed(result, "V2Impl-readSecret");
       return null;


### PR DESCRIPTION
## Describe your changes
Fixes decryption issue for secret value with curl braces

Tests:
- Added unit test for secret value with curly braces `{01dkd7}op910`
- Validated azure key vault inline secret decryption having curly braces in value 
 - CG
![Screenshot 2023-10-13 at 8 57 31 PM](https://github.com/harness/harness-core/assets/96102774/73f17f80-7054-4b14-a39c-17ab3ae3c8b5)

 - NG
![Screenshot 2023-10-13 at 8 58 52 PM](https://github.com/harness/harness-core/assets/96102774/e2d30f02-9b15-4475-9b82-0b569aab3613)

 
## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions


## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/54133)
<!-- Reviewable:end -->
