### PR TITLE
fix: [CDS-78675-1]: Make PipelineExecutionFunctor use planExecutionMetadata to populate data

### DIFF
--- a/clients/pipeline-service/pms-sdk-core/src/main/java/io/harness/utils/RetryExecutionUtils.java
+++ b/clients/pipeline-service/pms-sdk-core/src/main/java/io/harness/utils/RetryExecutionUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.utils;
+
+import io.harness.annotations.dev.CodePulse;
+import io.harness.annotations.dev.HarnessModuleComponent;
+import io.harness.annotations.dev.ProductModule;
+import io.harness.pms.contracts.ambiance.Ambiance;
+import io.harness.pms.contracts.plan.RetryExecutionInfo;
+
+import lombok.experimental.UtilityClass;
+
+@CodePulse(module = ProductModule.CDS, unitCoverageRequired = true, components = {HarnessModuleComponent.CDS_TRIGGERS})
+@UtilityClass
+public class RetryExecutionUtils {
+  public String getRootExecutionId(Ambiance ambiance, RetryExecutionInfo retryExecutionInfo) {
+    String rootExecutionId = ambiance.getPlanExecutionId();
+    if (isRetry(retryExecutionInfo)) {
+      rootExecutionId = retryExecutionInfo.getRootExecutionId();
+    }
+    return rootExecutionId;
+  }
+
+  public String getParentExecutionId(Ambiance ambiance, RetryExecutionInfo retryExecutionInfo) {
+    String parentExecutionId = ambiance.getPlanExecutionId();
+    if (isRetry(retryExecutionInfo)) {
+      parentExecutionId = retryExecutionInfo.getParentRetryId();
+    }
+    return parentExecutionId;
+  }
+
+  private boolean isRetry(RetryExecutionInfo retryExecutionInfo) {
+    if (retryExecutionInfo != null && retryExecutionInfo.getIsRetry()) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/pipeline-service/service/src/main/java/io/harness/pms/expressions/PMSExpressionEvaluator.java
+++ b/pipeline-service/service/src/main/java/io/harness/pms/expressions/PMSExpressionEvaluator.java
@@ -38,10 +38,9 @@ import io.harness.pms.expressions.functors.PipelineExecutionFunctor;
 import io.harness.pms.expressions.functors.ProjectFunctor;
 import io.harness.pms.expressions.functors.RemoteExpressionFunctor;
 import io.harness.pms.expressions.functors.ServiceVariableOverridesFunctor;
+import io.harness.pms.gitsync.PmsGitSyncHelper;
 import io.harness.pms.helpers.PipelineExpressionHelper;
 import io.harness.pms.plan.execution.SetupAbstractionKeys;
-import io.harness.pms.plan.execution.service.PMSExecutionService;
-import io.harness.pms.plan.execution.service.PmsExecutionSummaryService;
 import io.harness.pms.sdk.PmsSdkInstance;
 import io.harness.pms.sdk.PmsSdkInstanceService;
 import io.harness.pms.sdk.core.plan.creation.yaml.StepOutcomeGroup;
@@ -64,13 +63,10 @@ public class PMSExpressionEvaluator extends AmbianceExpressionEvaluator {
   @Inject @Named("PRIVILEGED") private OrganizationClient organizationClient;
   @Inject @Named("PRIVILEGED") private ProjectClient projectClient;
   @Inject private PlanExecutionMetadataService planExecutionMetadataService;
-  @Inject private PMSExecutionService pmsExecutionService;
+  @Inject PmsGitSyncHelper pmsGitSyncHelper;
   @Inject PmsSdkInstanceService pmsSdkInstanceService;
   @Inject PipelineExpressionHelper pipelineExpressionHelper;
   @Inject ExecutionInputService executionInputService;
-
-  @Inject PmsExecutionSummaryService pmsExecutionSummaryService;
-
   @Inject PmsEngineExpressionService pmsEngineExpressionService;
   @Inject ApprovalInstanceService approvalInstanceService;
   @Inject PmsFeatureFlagHelper pmsFeatureFlagHelper;
@@ -91,7 +87,7 @@ public class PMSExpressionEvaluator extends AmbianceExpressionEvaluator {
 
     addToContext("pipeline",
         new PipelineExecutionFunctor(
-            pmsExecutionService, pipelineExpressionHelper, planExecutionMetadataService, ambiance));
+            pipelineExpressionHelper, planExecutionMetadataService, pmsGitSyncHelper, ambiance));
     addToContext("executionInput", new ExecutionInputExpressionFunctor(executionInputService, ambiance));
 
     addToContext("strategy", new StrategyFunctor(ambiance, nodeExecutionsCache, getNodeExecutionInfoService()));

--- a/pipeline-service/service/src/test/java/io/harness/pms/expressions/functors/PipelineExecutionFunctorTest.java
+++ b/pipeline-service/service/src/test/java/io/harness/pms/expressions/functors/PipelineExecutionFunctorTest.java
@@ -13,7 +13,6 @@ import static io.harness.rule.OwnerRule.BRIJESH;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNull;
 import static org.joor.Reflect.on;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 
 import io.harness.CategoryTest;
@@ -21,19 +20,18 @@ import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.category.element.UnitTests;
 import io.harness.engine.executions.plan.PlanExecutionMetadataService;
-import io.harness.engine.executions.retry.RetryExecutionMetadata;
 import io.harness.execution.PlanExecutionMetadata;
 import io.harness.gitsync.beans.StoreType;
-import io.harness.gitsync.sdk.EntityGitDetails;
 import io.harness.pms.contracts.ambiance.Ambiance;
-import io.harness.pms.contracts.plan.*;
-import io.harness.pms.gitsync.PmsGitSyncHelper;
+import io.harness.pms.contracts.plan.ExecutionMetadata;
+import io.harness.pms.contracts.plan.ExecutionTriggerInfo;
+import io.harness.pms.contracts.plan.PipelineStoreType;
+import io.harness.pms.contracts.plan.RetryExecutionInfo;
+import io.harness.pms.contracts.plan.TriggerType;
+import io.harness.pms.contracts.plan.TriggeredBy;
 import io.harness.pms.helpers.PipelineExpressionHelper;
-import io.harness.pms.plan.execution.beans.PipelineExecutionSummaryEntity;
-import io.harness.pms.plan.execution.service.PMSExecutionService;
 import io.harness.rule.Owner;
 
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.Before;
@@ -45,7 +43,6 @@ import org.mockito.MockitoAnnotations;
 
 @OwnedBy(HarnessTeam.PIPELINE)
 public class PipelineExecutionFunctorTest extends CategoryTest {
-  @Mock private PmsGitSyncHelper pmsGitSyncHelper;
   @Mock PipelineExpressionHelper pipelineExpressionHelper;
   @Mock private PlanExecutionMetadataService planExecutionMetadataService;
   @InjectMocks private PipelineExecutionFunctor pipelineExecutionFunctor;


### PR DESCRIPTION
## Describe your changes
This PR makes `PipelineExecutionFunctor` use `planExecutionMetadata` and `ambiance` to populate its data, instead of using `pipelineExecutionSummaryEntity`. In this way, we avoid errors when this functor is called during plan execution time, and we also store the resolved `<+pipeline...>` expressions in `PipelineExecutionSummaryEntity`'s field `resolvedUserInputYaml`.

**Test Example**:
When running a pipeline having the following shell script:
<img width="556" alt="image" src="https://github.com/harness/harness-core/assets/109106581/a0656104-b462-4179-9188-8b4e8269782c">

Output before these changes:
![image](https://github.com/harness/harness-core/assets/109106581/19f1f462-3bcd-4da8-bfc5-bde28fcbf645)

Output after these changes:
![image](https://github.com/harness/harness-core/assets/109106581/b045c22e-89d1-427e-a2b7-edc43189d097)

Thus we see that the outputs are the same, so no changes in the values resolved in this functor's data.

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [x] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

### Rebase Instructions:
To rebase your branch onto the latest changes in the target branch, simply use the following command in a comment: `/rebase`



## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/54568)
<!-- Reviewable:end -->
