### PR TITLE
[fix]: [CDS-85299]: Fix for not clearing the cache while updating the webhook trigger time

### DIFF
--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/gitxwebhooks/service/GitXWebhookEventServiceImpl.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/gitxwebhooks/service/GitXWebhookEventServiceImpl.java
@@ -282,10 +282,7 @@ public class GitXWebhookEventServiceImpl implements GitXWebhookEventService {
               .scope(Scope.of(gitXWebhook.getAccountIdentifier(), gitXWebhook.getOrgIdentifier(),
                   gitXWebhook.getProjectIdentifier()))
               .build(),
-          UpdateGitXWebhookRequestDTO.builder()
-              .lastEventTriggerTime(triggerEventTime)
-              .folderPaths(gitXWebhook.getFolderPaths())
-              .build());
+          UpdateGitXWebhookRequestDTO.builder().lastEventTriggerTime(triggerEventTime).build());
     });
   }
 

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/gitxwebhooks/service/GitXWebhookEventServiceImpl.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/gitxwebhooks/service/GitXWebhookEventServiceImpl.java
@@ -276,11 +276,12 @@ public class GitXWebhookEventServiceImpl implements GitXWebhookEventService {
 
   private void updateGitXWebhook(List<GitXWebhook> gitXWebhookList, long triggerEventTime) {
     gitXWebhookList.forEach(gitXWebhook -> {
-      gitXWebhookService.updateGitXWebhook(UpdateGitXWebhookCriteriaDTO.builder()
-                                               .webhookIdentifier(gitXWebhook.getIdentifier())
-                                               .scope(Scope.of(gitXWebhook.getAccountIdentifier(),
-                                                   gitXWebhook.getOrgIdentifier(), gitXWebhook.getProjectIdentifier()))
-                                               .build(),
+      gitXWebhookService.updateGitXWebhookTriggerTime(
+          UpdateGitXWebhookCriteriaDTO.builder()
+              .webhookIdentifier(gitXWebhook.getIdentifier())
+              .scope(Scope.of(gitXWebhook.getAccountIdentifier(), gitXWebhook.getOrgIdentifier(),
+                  gitXWebhook.getProjectIdentifier()))
+              .build(),
           UpdateGitXWebhookRequestDTO.builder()
               .lastEventTriggerTime(triggerEventTime)
               .folderPaths(gitXWebhook.getFolderPaths())

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/gitxwebhooks/service/GitXWebhookService.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/gitxwebhooks/service/GitXWebhookService.java
@@ -45,6 +45,9 @@ public interface GitXWebhookService {
   UpdateGitXWebhookResponseDTO updateGitXWebhook(UpdateGitXWebhookCriteriaDTO updateGitXWebhookCriteriaDTO,
       UpdateGitXWebhookRequestDTO updateGitXWebhookRequestDTO);
 
+  UpdateGitXWebhookResponseDTO updateGitXWebhookTriggerTime(UpdateGitXWebhookCriteriaDTO updateGitXWebhookCriteriaDTO,
+      UpdateGitXWebhookRequestDTO updateGitXWebhookRequestDTO);
+
   ListGitXWebhookResponseDTO listGitXWebhooks(ListGitXWebhookRequestDTO listGitXWebhookRequestDTO);
 
   DeleteGitXWebhookResponseDTO deleteGitXWebhook(DeleteGitXWebhookRequestDTO deleteGitXWebhookRequestDTO);

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/gitxwebhooks/service/GitXWebhookServiceImpl.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/gitxwebhooks/service/GitXWebhookServiceImpl.java
@@ -212,32 +212,23 @@ public class GitXWebhookServiceImpl implements GitXWebhookService {
   public UpdateGitXWebhookResponseDTO updateGitXWebhookTriggerTime(
       UpdateGitXWebhookCriteriaDTO updateGitXWebhookCriteriaDTO,
       UpdateGitXWebhookRequestDTO updateGitXWebhookRequestDTO) {
-    try (GitXWebhookLogContext context =
-             new GitXWebhookLogContext(updateGitXWebhookCriteriaDTO, updateGitXWebhookRequestDTO)) {
-      try {
-        log.info(String.format("Updating Webhook tigger time with identifier %s in account %s",
-            updateGitXWebhookCriteriaDTO.getWebhookIdentifier(),
-            updateGitXWebhookCriteriaDTO.getScope().getAccountIdentifier()));
-        Criteria criteria =
-            buildCriteria(updateGitXWebhookCriteriaDTO.getScope(), updateGitXWebhookCriteriaDTO.getWebhookIdentifier());
-        Query query = new Query(criteria);
-        Update update = buildUpdate(updateGitXWebhookRequestDTO);
-        GitXWebhook updatedGitXWebhook = gitXWebhookRepository.update(query, update);
-        if (updatedGitXWebhook == null) {
-          log.error(String.format(
-              "Error while updating webhook [%s] in DB", updateGitXWebhookCriteriaDTO.getWebhookIdentifier()));
-          throw new InternalServerErrorException(String.format(
-              "Error while updating webhook [%s] in DB", updateGitXWebhookCriteriaDTO.getWebhookIdentifier()));
-        }
-        return UpdateGitXWebhookResponseDTO.builder().webhookIdentifier(updatedGitXWebhook.getIdentifier()).build();
-      } catch (InternalServerErrorException exception) {
-        log.error("Unexpected error occurred while updating the GitX webhook {}",
-            updateGitXWebhookCriteriaDTO.getWebhookIdentifier(), exception);
-        throw exception;
-      } catch (Exception exception) {
-        log.error(String.format(WEBHOOK_FAILURE_ERROR_MESSAGE, UPDATING), exception);
-        throw new InternalServerErrorException(String.format(WEBHOOK_FAILURE_ERROR_MESSAGE, UPDATING));
-      }
+    try {
+      log.info(String.format("Updating Webhook tigger time with identifier %s in account %s",
+          updateGitXWebhookCriteriaDTO.getWebhookIdentifier(),
+          updateGitXWebhookCriteriaDTO.getScope().getAccountIdentifier()));
+      Criteria criteria =
+          buildCriteria(updateGitXWebhookCriteriaDTO.getScope(), updateGitXWebhookCriteriaDTO.getWebhookIdentifier());
+      Query query = new Query(criteria);
+      Update update = buildUpdate(updateGitXWebhookRequestDTO);
+      GitXWebhook updatedGitXWebhook = gitXWebhookRepository.update(query, update);
+      return UpdateGitXWebhookResponseDTO.builder().webhookIdentifier(updatedGitXWebhook.getIdentifier()).build();
+    } catch (InternalServerErrorException exception) {
+      log.error("Unexpected error occurred while updating the GitX webhook {}",
+          updateGitXWebhookCriteriaDTO.getWebhookIdentifier(), exception);
+      throw exception;
+    } catch (Exception exception) {
+      log.error(String.format(WEBHOOK_FAILURE_ERROR_MESSAGE, UPDATING), exception);
+      throw new InternalServerErrorException(String.format(WEBHOOK_FAILURE_ERROR_MESSAGE, UPDATING));
     }
   }
 
@@ -350,7 +341,9 @@ public class GitXWebhookServiceImpl implements GitXWebhookService {
   private Update buildUpdate(UpdateGitXWebhookRequestDTO updateGitXWebhookRequestDTO) {
     long currentTimeInMilliseconds = System.currentTimeMillis();
     Update update = new Update();
-    update.set(GitXWebhookKeys.folderPaths, updateGitXWebhookRequestDTO.getFolderPaths());
+    if (isNotEmpty(updateGitXWebhookRequestDTO.getFolderPaths())) {
+      update.set(GitXWebhookKeys.folderPaths, updateGitXWebhookRequestDTO.getFolderPaths());
+    }
     if (isNotEmpty(updateGitXWebhookRequestDTO.getRepoName())) {
       update.set(GitXWebhookKeys.repoName, updateGitXWebhookRequestDTO.getRepoName());
     }

--- a/136-git-sync-manager/src/main/java/io/harness/gitsync/gitxwebhooks/service/GitXWebhookServiceImpl.java
+++ b/136-git-sync-manager/src/main/java/io/harness/gitsync/gitxwebhooks/service/GitXWebhookServiceImpl.java
@@ -177,8 +177,10 @@ public class GitXWebhookServiceImpl implements GitXWebhookService {
         log.info(String.format("Updating Webhook with identifier %s in account %s",
             updateGitXWebhookCriteriaDTO.getWebhookIdentifier(),
             updateGitXWebhookCriteriaDTO.getScope().getAccountIdentifier()));
-        clearCache(
-            updateGitXWebhookCriteriaDTO.getScope().getAccountIdentifier(), updateGitXWebhookRequestDTO.getRepoName());
+        if (updateGitXWebhookRequestDTO.getLastEventTriggerTime() == null) {
+          clearCache(updateGitXWebhookCriteriaDTO.getScope().getAccountIdentifier(),
+              updateGitXWebhookRequestDTO.getRepoName());
+        }
         Criteria criteria =
             buildCriteria(updateGitXWebhookCriteriaDTO.getScope(), updateGitXWebhookCriteriaDTO.getWebhookIdentifier());
         Query query = new Query(criteria);


### PR DESCRIPTION
## Describe your changes
We are clearing the cache every time we are updating the webhook. On receiving an event, we are updating the webhook db with the trigger time stamp, due to this we are clearing the cache. In this pr, a fix for not clearing the cache while updating the webhook trigger time. Have tested out the following:
1. Webhook update, during which we are clearing the cache.
2. Webhook trigger time update, during which we are not clearing the cache.


## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

### Rebase Instructions:
To rebase your branch onto the latest changes in the target branch, simply use the following command in a comment: `/rebase`



## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/55867)
<!-- Reviewable:end -->
