### PR TITLE
feat: [PL-42614]: two settings allow local testing

### DIFF
--- a/260-delegate/src/main/java/io/harness/delegate/service/core/litek8s/ContainerFactory.java
+++ b/260-delegate/src/main/java/io/harness/delegate/service/core/litek8s/ContainerFactory.java
@@ -49,6 +49,7 @@ public class ContainerFactory {
   private static final String DELEGATE_SERVICE_ENDPOINT_VARIABLE = "DELEGATE_SERVICE_ENDPOINT";
   private static final String DELEGATE_SERVICE_ID_VARIABLE = "DELEGATE_SERVICE_ID";
   private static final String HARNESS_ACCOUNT_ID_VARIABLE = "HARNESS_ACCOUNT_ID";
+  private static final String LOCAL_DEV_SKIP_SSL_VERIFY = "LE_SKIP_VERIFY_MANAGER";
   private static final String TASK_DATA_PATH = "TASK_DATA_PATH";
   private static final String DELEGATE_TOKEN = "DELEGATE_TOKEN";
   private static final String TASK_ID = "TASK_ID";
@@ -137,6 +138,7 @@ public class ContainerFactory {
     //    envVars.put(HARNESS_BUILD_ID_VARIABLE, String.valueOf(buildNumber));
     //    envVars.put(HARNESS_STAGE_ID_VARIABLE, stageID);
     //    envVars.put(HARNESS_EXECUTION_ID_VARIABLE, executionID);
+    envVars.put(LOCAL_DEV_SKIP_SSL_VERIFY, "true");
     return envVars.build();
   }
 


### PR DESCRIPTION
## Describe your changes
Set this PR allows local testing. 
1. Set LE env, this will allow LE to talk to local manager and skip ssl verification
2. Set LE endpoint to localhost:20001, This option relies on kubectl port forward @AnupamIO  will add
3. Set manager url to be docker.host.internal. This rely on local k8s cluster using 'kind'. We should create a env called LE_MANAGER_HOST_AND_PORT, to allow setting manager url only on LE. This env will take effective only in 'local' testing mode
4. @AnupamIO  will add the portforward part, and modularize all the local settings into one java module

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

### Rebase Instructions:
To rebase your branch onto the latest changes in the target branch, simply use the following command in a comment: `/rebase`



## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

