### PR TITLE
[fix]: [CDS-84967]: Fix Infrastructure References for Entity deserialisation

### DIFF
--- a/970-ng-commons/src/main/java/io/harness/beans/InfraDefReference.java
+++ b/970-ng-commons/src/main/java/io/harness/beans/InfraDefReference.java
@@ -14,6 +14,7 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.encryption.Scope;
 import io.harness.utils.FullyQualifiedIdentifierHelper;
 
+import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
 
@@ -51,4 +52,6 @@ public class InfraDefReference implements EntityReference {
     }
     return Scope.of(accountIdentifier, orgIdentifier, projectIdentifier);
   }
+
+  public void setMetadata(Map<String, String> metadata) {}
 }

--- a/970-ng-commons/src/main/java/io/harness/ng/core/entitydetail/EntityDetailDeserializer.java
+++ b/970-ng-commons/src/main/java/io/harness/ng/core/entitydetail/EntityDetailDeserializer.java
@@ -10,6 +10,7 @@ package io.harness.ng.core.entitydetail;
 import io.harness.EntityType;
 import io.harness.beans.EntityReference;
 import io.harness.beans.IdentifierRef;
+import io.harness.beans.InfraDefReference;
 import io.harness.beans.InputSetReference;
 import io.harness.beans.NGTemplateReference;
 import io.harness.ng.core.EntityDetail;
@@ -45,6 +46,8 @@ public class EntityDetailDeserializer extends StdDeserializer<EntityDetail> {
       reference = mapper.readValue(entityRefNode.toString(), InputSetReference.class);
     } else if (type == EntityType.TEMPLATE) {
       reference = mapper.readValue(entityRefNode.toString(), NGTemplateReference.class);
+    } else if (type == EntityType.INFRASTRUCTURE) {
+      reference = mapper.readValue(entityRefNode.toString(), InfraDefReference.class);
     } else {
       reference = mapper.readValue(entityRefNode.toString(), IdentifierRef.class);
     }


### PR DESCRIPTION
## Describe your changes
Earlier, Infrastructure entity json was getting deserialised into an entity of type IdentifierRef. IdentifierRef does not contain the field enviornmentRef and thus we were not able to get environmentRef of the infrastructure entity which is required by some API calls and should be present ideally. Now, we fixed it to properly deserialise the entity json to an object of type InfraDefReference only. 

We also added an empty void setter for metadata field in InfraDefReference because otherwise the entity json string which contains metadata field cannot be deserialised. It fails with error of format - com.fasterxml.jackson.databind.exc.ValueInstantiationException: Cannot construct instance of `io.harness.beans.InfraDefReference`, problem: Should never call `set()` on setterless property ('metadata')

## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

### Rebase Instructions:
To rebase your branch onto the latest changes in the target branch, simply use the following command in a comment: `/rebase`



## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/56598)
<!-- Reviewable:end -->
