### PR TITLE
feat: [CDS-87039]: Add support for overrideInputs in Triggers Yaml

### DIFF
--- a/pipeline-service/contracts/openapi/v1/openapi.yaml
+++ b/pipeline-service/contracts/openapi/v1/openapi.yaml
@@ -1586,6 +1586,9 @@ components:
         inputs:
           type: string
           description: input yaml to be used in the pipeline
+        override_inputs:
+          type: string
+          description: input yaml to override values provided by input sets
         name:
           type: string
           pattern: '^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$'
@@ -3079,6 +3082,9 @@ components:
         inputs:
           type: string
           description: input yaml to be used in the pipeline
+        override_inputs:
+          type: string
+          description: input yaml to override inputs provided by input sets
         pipeline_branch_name:
           type: string
         source:

--- a/pipeline-service/modules/ng-triggers/contracts/src/main/java/io/harness/ngtriggers/beans/config/NGTriggerConfigV2.java
+++ b/pipeline-service/modules/ng-triggers/contracts/src/main/java/io/harness/ngtriggers/beans/config/NGTriggerConfigV2.java
@@ -40,4 +40,5 @@ public class NGTriggerConfigV2 implements NGTriggerInterface {
   @Builder.Default Boolean enabled = Boolean.TRUE;
   String encryptedWebhookSecretIdentifier;
   List<String> stagesToExecute;
+  String overrideInputs;
 }

--- a/pipeline-service/modules/ng-triggers/src/main/java/io/harness/ngtriggers/beans/entity/TriggerConfigWrapper.java
+++ b/pipeline-service/modules/ng-triggers/src/main/java/io/harness/ngtriggers/beans/entity/TriggerConfigWrapper.java
@@ -24,4 +24,5 @@ public class TriggerConfigWrapper {
   NGTriggerSourceV2 source;
   String pipelineBranchName;
   List<String> inputSetRefs;
+  String overrideInputs;
 }

--- a/pipeline-service/modules/ng-triggers/src/main/java/io/harness/ngtriggers/mapper/NGTriggerElementMapper.java
+++ b/pipeline-service/modules/ng-triggers/src/main/java/io/harness/ngtriggers/mapper/NGTriggerElementMapper.java
@@ -174,6 +174,7 @@ public class NGTriggerElementMapper {
         .tags(TagMapper.convertToMap(entity.getTags()))
         .source(entity.getTriggerConfigWrapper().getSource())
         .stagesToExecute(entity.getStagesToExecute())
+        .overrideInputs(entity.getTriggerConfigWrapper().getOverrideInputs())
         .build();
   }
 

--- a/pipeline-service/modules/ng-triggers/src/test/java/io/harness/ngtriggers/mapper/NGTriggerElementMapperV2Test.java
+++ b/pipeline-service/modules/ng-triggers/src/test/java/io/harness/ngtriggers/mapper/NGTriggerElementMapperV2Test.java
@@ -63,6 +63,7 @@ import io.harness.category.element.UnitTests;
 import io.harness.connector.ConnectorDTO;
 import io.harness.connector.ConnectorInfoDTO;
 import io.harness.connector.ConnectorResourceClient;
+import io.harness.data.structure.HarnessStringUtils;
 import io.harness.delegate.beans.connector.ConnectorType;
 import io.harness.delegate.beans.connector.artifactoryconnector.ArtifactoryConnectorDTO;
 import io.harness.exception.ArtifactoryRegistryException;
@@ -203,6 +204,8 @@ public class NGTriggerElementMapperV2Test extends CategoryTest {
 
   private String ngTriggerYaml_gitpolling;
 
+  private String ngTriggerYaml_withOverrideInputs;
+
   private List<TriggerEventDataCondition> payloadConditions;
   private List<TriggerEventDataCondition> headerConditions;
   private static final String inputYaml = "pipeline:\n"
@@ -296,6 +299,10 @@ public class NGTriggerElementMapperV2Test extends CategoryTest {
     ngTriggerYaml_multi_region_artifact =
         Resources.toString(Objects.requireNonNull(classLoader.getResource("ng-trigger-multi-region-artifact.yaml")),
             StandardCharsets.UTF_8);
+
+    ngTriggerYaml_withOverrideInputs = Resources.toString(
+        Objects.requireNonNull(classLoader.getResource("ng-trigger-custom-with-override-inputs.yaml")),
+        StandardCharsets.UTF_8);
 
     payloadConditions = asList(TriggerEventDataCondition.builder().key("k1").operator(EQUALS).value("v1").build(),
         TriggerEventDataCondition.builder().key("k2").operator(NOT_EQUALS).value("v2").build(),
@@ -1366,6 +1373,37 @@ public class NGTriggerElementMapperV2Test extends CategoryTest {
     assertThat(acrSpec.getRegistry()).isEqualTo("test-registry");
     assertThat(acrSpec.getRepository()).isEqualTo("test-repository");
     assertThat(acrSpec.getTag()).isEqualTo("<+trigger.artifact.build>");
+  }
+
+  @Test
+  @Owner(developers = VINICIUS)
+  @Category(UnitTests.class)
+  public void testWithOverrideInputs() throws Exception {
+    NGTriggerConfigV2 ngTriggerConfigV2 = ngTriggerElementMapper.toTriggerConfigV2(ngTriggerYaml_withOverrideInputs);
+
+    assertRootLevelProperties(ngTriggerConfigV2);
+
+    NGTriggerSourceV2 ngTriggerSourceV2 = ngTriggerConfigV2.getSource();
+    assertThat(ngTriggerSourceV2).isNotNull();
+    assertThat(ngTriggerSourceV2.getType()).isEqualTo(WEBHOOK);
+    NGTriggerSpecV2 ngTriggerSpecV2 = ngTriggerSourceV2.getSpec();
+    assertThat(WebhookTriggerConfigV2.class.isAssignableFrom(ngTriggerSpecV2.getClass())).isTrue();
+    WebhookTriggerConfigV2 webhookTriggerConfigV2 = (WebhookTriggerConfigV2) ngTriggerSpecV2;
+    assertThat(webhookTriggerConfigV2.getType()).isEqualTo(WebhookTriggerType.CUSTOM);
+    assertThat(CustomTriggerSpec.class.isAssignableFrom(webhookTriggerConfigV2.getSpec().getClass())).isTrue();
+    CustomTriggerSpec spec = (CustomTriggerSpec) webhookTriggerConfigV2.getSpec();
+    assertThat(spec.fetchPayloadAware().fetchPayloadConditions()).isEmpty();
+    assertThat(spec.fetchPayloadAware().fetchHeaderConditions()).isEmpty();
+    assertThat(spec.fetchPayloadAware().fetchJexlCondition()).isNull();
+    assertThat(ngTriggerConfigV2.getOverrideInputs().replace("\n", "\\n"))
+        .isEqualTo(HarnessStringUtils.removeLeadingAndTrailingQuotesBothOrNone(
+            YamlUtils.readTree(ngTriggerYaml_withOverrideInputs)
+                .getNode()
+                .getField("trigger")
+                .getNode()
+                .getCurrJsonNode()
+                .get("overrideInputs")
+                .toString()));
   }
 
   private void assertCommonPathForArtifactTriggers(NGTriggerSourceV2 ngTriggerSourceV2, ArtifactType artifactType) {

--- a/pipeline-service/modules/ng-triggers/src/test/resources/ng-trigger-custom-with-override-inputs.yaml
+++ b/pipeline-service/modules/ng-triggers/src/test/resources/ng-trigger-custom-with-override-inputs.yaml
@@ -1,0 +1,55 @@
+trigger:
+  name: first trigger
+  identifier: first_trigger
+  enabled: true
+  description: ""
+  tags: {}
+  stagesToExecute: []
+  orgIdentifier: org
+  projectIdentifier: proj
+  pipelineIdentifier: pipeline
+  source:
+    type: Webhook
+    spec:
+      type: Custom
+      spec:
+        payloadConditions: []
+        headerConditions: []
+  inputSetRefs:
+    - myInputSet
+  overrideInputs: |
+    pipeline:
+      identifier: pipeline
+      stages:
+        - stage:
+            identifier: stage2
+            type: Deployment
+            spec:
+              service:
+                serviceInputs:
+                  serviceDefinition:
+                    type: Kubernetes
+                    spec:
+                      artifacts:
+                        primary:
+                          primaryArtifactRef: gfgjhjh
+                          sources:
+                            - identifier: gfgjhjh
+                              type: Gcr
+                              spec:
+                                tag: v0.5
+      variables:
+        - name: var2
+          type: String
+          value: overridenValue
+  inputYaml: |
+    pipeline:
+      identifier: secrethttp1
+      stages:
+        - stage:
+            identifier: qaStage
+            spec:
+              infrastructure:
+                infrastructureDefinition:
+                  spec:
+                    releaseName: releaseName1

--- a/pipeline-service/service/src/main/java/io/harness/pms/triggers/TriggerExecutionHelper.java
+++ b/pipeline-service/service/src/main/java/io/harness/pms/triggers/TriggerExecutionHelper.java
@@ -518,11 +518,16 @@ public class TriggerExecutionHelper {
     }
 
     List<String> inputSetRefs = triggerConfigV2.getInputSetRefs();
+    String overrideInputs = triggerConfigV2.getOverrideInputs();
     MergeInputSetResponseDTOPMS mergeInputSetResponseDTOPMS =
         NGRestUtils.getResponse(pipelineServiceClient.getMergeInputSetFromPipelineTemplate(
             ngTriggerEntity.getAccountId(), ngTriggerEntity.getOrgIdentifier(), ngTriggerEntity.getProjectIdentifier(),
             ngTriggerEntity.getTargetIdentifier(), branch,
-            MergeInputSetRequestDTOPMS.builder().inputSetReferences(inputSetRefs).getOnlyFileContent(true).build()));
+            MergeInputSetRequestDTOPMS.builder()
+                .inputSetReferences(inputSetRefs)
+                .lastYamlToMerge(overrideInputs)
+                .getOnlyFileContent(true)
+                .build()));
 
     return mergeInputSetResponseDTOPMS.getPipelineYaml();
   }

--- a/pipeline-service/service/src/main/java/io/harness/pms/triggers/v1/NGTriggerApiUtils.java
+++ b/pipeline-service/service/src/main/java/io/harness/pms/triggers/v1/NGTriggerApiUtils.java
@@ -160,6 +160,7 @@ public class NGTriggerApiUtils {
         .tags(body.getTags())
         .source(toNGTriggerSourceV2(body.getSource()))
         .stagesToExecute(body.getStagesToExecute())
+        .overrideInputs(body.getOverrideInputs())
         .build();
   }
 
@@ -269,6 +270,7 @@ public class NGTriggerApiUtils {
     triggerBody.setStagesToExecute(triggerEntity.getStagesToExecute());
     triggerBody.setTags(TagMapper.convertToMap(triggerEntity.getTags()));
     triggerBody.setSource(toTriggerSource(triggerEntity.getTriggerConfigWrapper().getSource()));
+    triggerBody.setOverrideInputs(triggerEntity.getTriggerConfigWrapper().getOverrideInputs());
     return triggerBody;
   }
 

--- a/pipeline-service/service/src/test/java/io/harness/pms/triggers/TriggerExecutionHelperTest.java
+++ b/pipeline-service/service/src/test/java/io/harness/pms/triggers/TriggerExecutionHelperTest.java
@@ -92,6 +92,7 @@ import io.harness.pms.contracts.triggers.TriggerPayload;
 import io.harness.pms.contracts.triggers.Type;
 import io.harness.pms.gitsync.PmsGitSyncBranchContextGuard;
 import io.harness.pms.gitsync.PmsGitSyncHelper;
+import io.harness.pms.inputset.MergeInputSetRequestDTOPMS;
 import io.harness.pms.inputset.MergeInputSetResponseDTOPMS;
 import io.harness.pms.pipeline.PipelineEntity;
 import io.harness.pms.pipeline.service.PMSPipelineService;
@@ -384,12 +385,13 @@ public class TriggerExecutionHelperTest extends CategoryTest {
                                                  .type(NGTriggerType.WEBHOOK)
                                                  .version(0L)
                                                  .build();
-
+    List<String> inputSetRefs = Arrays.asList("inputSet1", "inputSet2");
     TriggerDetails triggerDetails = TriggerDetails.builder()
                                         .ngTriggerEntity(ngTriggerEntityGitSync)
                                         .ngTriggerConfigV2(NGTriggerConfigV2.builder()
-                                                               .inputSetRefs(Arrays.asList("inputSet1", "inputSet2"))
+                                                               .inputSetRefs(inputSetRefs)
                                                                .pipelineBranchName("pipelineBranchName")
+                                                               .overrideInputs("overrideInputsYaml")
                                                                .build())
                                         .build();
 
@@ -397,7 +399,13 @@ public class TriggerExecutionHelperTest extends CategoryTest {
     when(ngTriggerElementMapper.toTriggerConfigV2(ngTriggerEntityGitSync))
         .thenReturn(triggerDetails.getNgTriggerConfigV2());
 
-    when(pipelineServiceClient.getMergeInputSetFromPipelineTemplate(any(), any(), any(), any(), any(), any()))
+    when(pipelineServiceClient.getMergeInputSetFromPipelineTemplate("ACCOUNT_ID", "ORG_IDENTIFIER", "PROJ_IDENTIFIER",
+             "PIPELINE_IDENTIFIER", "pipelineBranchName",
+             MergeInputSetRequestDTOPMS.builder()
+                 .inputSetReferences(inputSetRefs)
+                 .lastYamlToMerge("overrideInputsYaml")
+                 .getOnlyFileContent(true)
+                 .build()))
         .thenReturn(mergeInputSetResponseDTOPMS);
     when(mergeInputSetResponseDTOPMS.execute())
         .thenReturn(Response.success(ResponseDTO.newResponse(


### PR DESCRIPTION
## Describe your changes
In this PR, we are adding support for a new field in Triggers Yaml, namely `overrideInputs`. This field contains a yaml string which will be used to override input values provided by the input sets present in the `inputSetRefs` field in a trigger.

****Tested in local:****

***Trigger with Input Set, no input overrides:***
```
trigger:
  name: triggerWithInputSet
  identifier: triggerWithInputSet
  enabled: true
  description: ""
  tags: {}
  stagesToExecute: []
  orgIdentifier: default
  projectIdentifier: test
  pipelineIdentifier: testTriggerOverrideInputs
  source:
    type: Webhook
    spec:
      type: Custom
      spec:
        payloadConditions: []
        headerConditions: []
  inputSetRefs:
    - myInputSet
```

**Input Set:**
```
inputSet:
  name: myInputSet
  tags: {}
  identifier: myInputSet
  orgIdentifier: default
  projectIdentifier: test
  pipeline:
    identifier: testTriggerOverrideInputs
    stages:
      - stage:
          identifier: stage2
          type: Deployment
          spec:
            service:
              serviceInputs:
                serviceDefinition:
                  type: Kubernetes
                  spec:
                    artifacts:
                      primary:
                        primaryArtifactRef: gfgjhjh
                        sources:
                          - identifier: gfgjhjh
                            type: Gcr
                            spec:
                              tag: v0.4
    variables:
      - name: var1
        type: String
        value: abc
      - name: var2
        type: String
        value: def
```

**Execution inputs:**

<img width="1136" alt="image" src="https://github.com/harness/harness-core/assets/109106581/fc297c6c-3f08-452e-bb69-ee29c52cf5b8">

We observe that the artifact tag, as well as `var1` and `var2` are coming from the input set.


***Trigger with Input Set and input overrides:***
```
trigger:
  name: triggerWithInputSetOverrides
  identifier: triggerWithInputSetOverrides
  enabled: true
  description: ""
  tags: {}
  stagesToExecute: []
  orgIdentifier: default
  projectIdentifier: test
  pipelineIdentifier: testTriggerOverrideInputs
  source:
    type: Webhook
    spec:
      type: Custom
      spec:
        payloadConditions: []
        headerConditions: []
  inputSetRefs:
    - myInputSet
  overrideInputs: |
    pipeline:
      identifier: triggerWithInputSetOverrides
      stages:
        - stage:
            identifier: stage2
            type: Deployment
            spec:
              service:
                serviceInputs:
                  serviceDefinition:
                    type: Kubernetes
                    spec:
                      artifacts:
                        primary:
                          primaryArtifactRef: gfgjhjh
                          sources:
                            - identifier: gfgjhjh
                              type: Gcr
                              spec:
                                tag: v0.5
      variables:
        - name: var2
          type: String
          value: overridenValue
```

**Execution inputs:**

<img width="1120" alt="image" src="https://github.com/harness/harness-core/assets/109106581/a82a5b41-7ddc-415c-92e6-fa9240560ae7">

We observe that the artifact tag and `var2` are coming from the override inputs. `var1` is still coming from the input set, since we didn't override it in the trigger's yaml.





## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.
- [x] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

### Rebase Instructions:
To rebase your branch onto the latest changes in the target branch, simply use the following command in a comment: `/rebase`



## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/56846)
<!-- Reviewable:end -->
