### PR TITLE
fix:[CDS-86601]:Nexus logs for npm deployment type showing image path is null

### DIFF
--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/artifacts/nexus/NexusArtifactDelegateResponse.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/artifacts/nexus/NexusArtifactDelegateResponse.java
@@ -69,9 +69,9 @@ public class NexusArtifactDelegateResponse extends ArtifactDelegateResponse {
             + getBuildDetails().getMetadata().get("package") + "\ntag: " + getTag() + "\nrepository type: "
             + getRepositoryFormat() + (EmptyPredicate.isNotEmpty(dockerPullCommand) ? dockerPullCommand : "");
       case raw:
-        return "raw-specific description: "
-            + "\nrepository: " + getRepositoryName() + "\ntag: " + getTag() + "\nrepository type: "
-            + getRepositoryFormat() + (EmptyPredicate.isNotEmpty(dockerPullCommand) ? dockerPullCommand : "");
+        return "type: " + getSourceType().getDisplayName() + "\nrepository: " + getRepositoryName()
+            + "\ntag: " + getTag() + "\nrepository type: " + getRepositoryFormat()
+            + (EmptyPredicate.isNotEmpty(dockerPullCommand) ? dockerPullCommand : "");
 
       default:
         return "Unknown Type Description: "

--- a/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/artifacts/nexus/NexusArtifactDelegateResponse.java
+++ b/950-delegate-tasks-beans/src/main/java/io/harness/delegate/task/artifacts/nexus/NexusArtifactDelegateResponse.java
@@ -52,8 +52,30 @@ public class NexusArtifactDelegateResponse extends ArtifactDelegateResponse {
                                    && getBuildDetails() != null && getBuildDetails().getMetadata() != null)
         ? "\nTo pull image use: docker pull " + getBuildDetails().getMetadata().get(ArtifactMetadataKeys.IMAGE)
         : null;
-    return "type: " + (getSourceType() != null ? getSourceType().getDisplayName() : null) + "\nrepository: "
-        + getRepositoryName() + "\nimagePath: " + getArtifactPath() + "\ntag: " + getTag() + "\nrepository type: "
-        + getRepositoryFormat() + (EmptyPredicate.isNotEmpty(dockerPullCommand) ? dockerPullCommand : "");
+    switch (RepositoryFormat.valueOf(getRepositoryFormat())) {
+      case docker:
+        return "type: " + getSourceType().getDisplayName() + "\nrepository: " + getRepositoryName()
+            + "\nimagePath: " + getArtifactPath() + "\ntag: " + getTag() + "\nrepository type: " + getRepositoryFormat()
+            + (EmptyPredicate.isNotEmpty(dockerPullCommand) ? dockerPullCommand : "");
+      case maven:
+        return "type: " + getSourceType().getDisplayName() + "\nrepository: " + getRepositoryName()
+            + "\nGroupId: " + getBuildDetails().getMetadata().get("groupId") + "\nArtifactPath: " + getArtifactPath()
+            + "\ntag: " + getTag() + "\nrepository type: " + getRepositoryFormat()
+            + (EmptyPredicate.isNotEmpty(dockerPullCommand) ? dockerPullCommand : "");
+
+      case npm:
+      case nuget:
+        return "type: " + getSourceType().getDisplayName() + "\nrepository: " + getRepositoryName() + "\npackageName: "
+            + getBuildDetails().getMetadata().get("package") + "\ntag: " + getTag() + "\nrepository type: "
+            + getRepositoryFormat() + (EmptyPredicate.isNotEmpty(dockerPullCommand) ? dockerPullCommand : "");
+      case raw:
+        return "raw-specific description: "
+            + "\nrepository: " + getRepositoryName() + "\ntag: " + getTag() + "\nrepository type: "
+            + getRepositoryFormat() + (EmptyPredicate.isNotEmpty(dockerPullCommand) ? dockerPullCommand : "");
+
+      default:
+        return "Unknown Type Description: "
+            + "\nrepository: " + null + (EmptyPredicate.isNotEmpty(dockerPullCommand) ? dockerPullCommand : "");
+    }
   }
 }

--- a/950-delegate-tasks-beans/src/test/java/io/harness/delegate/task/artifacts/nexus/NexusArtifactDelegateResponseTest.java
+++ b/950-delegate-tasks-beans/src/test/java/io/harness/delegate/task/artifacts/nexus/NexusArtifactDelegateResponseTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.delegate.task.artifacts.nexus;
+
+import static io.harness.rule.OwnerRule.RAKSHIT_AGARWAL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.harness.category.element.UnitTests;
+import io.harness.delegate.task.artifacts.ArtifactSourceType;
+import io.harness.delegate.task.artifacts.response.ArtifactBuildDetailsNG;
+import io.harness.rule.Owner;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InjectMocks;
+
+public class NexusArtifactDelegateResponseTest {
+  public final String TAG = "tag";
+  public final String ARTIFACT_PATH = "artifactPath";
+  public final String REPOSITORY_NAME = "repositoryName";
+
+  @InjectMocks NexusArtifactDelegateResponse nexusArtifactDelegateResponse;
+  @Before
+  public void setup() throws Exception {}
+
+  @Test
+  @Owner(developers = RAKSHIT_AGARWAL)
+  @Category(UnitTests.class)
+  public void TestDescribe_Docker() {
+    ArtifactBuildDetailsNG buildDetailsNG = ArtifactBuildDetailsNG.builder().build();
+    nexusArtifactDelegateResponse = new NexusArtifactDelegateResponse(buildDetailsNG,
+        ArtifactSourceType.NEXUS3_REGISTRY, REPOSITORY_NAME, ARTIFACT_PATH, "docker", TAG, new HashMap<>());
+    String resp = nexusArtifactDelegateResponse.describe();
+    String[] values = resp.split("\n");
+    assertThat(resp).isNotNull();
+    assertThat(values[0]).contains("type:");
+    assertThat(values[1]).contains("repository:");
+    assertThat(values[2]).contains("imagePath:");
+    assertThat(values[3]).contains("tag:");
+    assertThat(values[4]).contains("repository type:");
+  }
+  @Test
+  @Owner(developers = RAKSHIT_AGARWAL)
+  @Category(UnitTests.class)
+  public void TestDescribe_Maven() {
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("key1", "value1");
+    metadata.put("key2", "value2");
+
+    ArtifactBuildDetailsNG buildDetailsNG = ArtifactBuildDetailsNG.builder().metadata(metadata).build();
+
+    nexusArtifactDelegateResponse = new NexusArtifactDelegateResponse(buildDetailsNG,
+        ArtifactSourceType.NEXUS3_REGISTRY, REPOSITORY_NAME, ARTIFACT_PATH, "maven", TAG, new HashMap<>());
+    String resp = nexusArtifactDelegateResponse.describe();
+    String[] values = resp.split("\n");
+    assertThat(resp).isNotNull();
+    assertThat(values[0]).contains("type:");
+    assertThat(values[1]).contains("repository:");
+    assertThat(values[2]).contains("GroupId:");
+    assertThat(values[3]).contains("ArtifactPath:");
+    assertThat(values[4]).contains("tag:");
+    assertThat(values[5]).contains("repository type:");
+  }
+  @Test
+  @Owner(developers = RAKSHIT_AGARWAL)
+  @Category(UnitTests.class)
+  public void TestDescribe_Npm() {
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("key1", "value1");
+    metadata.put("key2", "value2");
+
+    ArtifactBuildDetailsNG buildDetailsNG = ArtifactBuildDetailsNG.builder().metadata(metadata).build();
+    nexusArtifactDelegateResponse = new NexusArtifactDelegateResponse(buildDetailsNG,
+        ArtifactSourceType.NEXUS3_REGISTRY, REPOSITORY_NAME, ARTIFACT_PATH, "npm", TAG, new HashMap<>());
+    String resp = nexusArtifactDelegateResponse.describe();
+    String[] values = resp.split("\n");
+    assertThat(resp).isNotNull();
+    assertThat(values[0]).contains("type:");
+    assertThat(values[1]).contains("repository:");
+    assertThat(values[2]).contains("packageName:");
+    assertThat(values[3]).contains("tag:");
+    assertThat(values[4]).contains("repository type:");
+  }
+  @Test
+  @Owner(developers = RAKSHIT_AGARWAL)
+  @Category(UnitTests.class)
+  public void TestDescribe_Raw() {
+    ArtifactBuildDetailsNG buildDetailsNG = ArtifactBuildDetailsNG.builder().build();
+    nexusArtifactDelegateResponse = new NexusArtifactDelegateResponse(buildDetailsNG,
+        ArtifactSourceType.NEXUS3_REGISTRY, REPOSITORY_NAME, ARTIFACT_PATH, "raw", TAG, new HashMap<>());
+    String resp = nexusArtifactDelegateResponse.describe();
+    String[] values = resp.split("\n");
+    assertThat(resp).isNotNull();
+    assertThat(values[0]).contains("type:");
+    assertThat(values[1]).contains("repository:");
+    assertThat(values[2]).contains("tag:");
+    assertThat(values[3]).contains("repository type:");
+  }
+}


### PR DESCRIPTION
## Describe your changes
Initially the Logs were added specific to Docker type. Changed the log according to different type for Maven, npm, nuget, raw.
Changes logs for NPM type:
<img width="1694" alt="Screenshot 2023-12-26 at 5 26 25 PM" src="https://github.com/harness/harness-core/assets/142882849/534edd43-ebec-4944-815a-b2c7051c5cf3">

Changes logs for MAVEN type:
<img width="1792" alt="Screenshot 2023-12-26 at 5 28 47 PM" src="https://github.com/harness/harness-core/assets/142882849/3116a222-87d0-4cdd-b352-be7753f81b6d">

Changes logs for RAW type:
<img width="1792" alt="Screenshot 2023-12-26 at 5 34 37 PM" src="https://github.com/harness/harness-core/assets/142882849/46b3bcf3-5333-4c3f-90d4-9fe8e0b76c52">



## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.
- [ ] If hashcheck failed I followed [the checklist](https://harness.atlassian.net/wiki/spaces/DEL/pages/21016838831/PR+Codebasehash+Check+merge+checklist) and updated this PR description with my answers to make sure I'm not introducing any breaking changes.

## Comment Triggers
<details>
  <summary>Build triggers</summary>

- Feature build: `trigger feature-build`
- 
  Specific builds
  - `trigger manager`
  - `trigger dms`
  - `trigger ng_manager`
  - `trigger cvng `
  - `trigger cmdlib`
  - `trigger template_svc`
  - `trigger events_fmwrk_monitor`
  - `trigger event_server`
  - `trigger change_data_capture`
  -  Trigger multiple builds together: For eg: `trigger dms, manager`
- Immutable delegate `trigger publish-delegate`
</details>

## [Latest PR Check Triggers](https://github.com/harness/harness-core/blob/develop/.github/pull_request_template.md)

<details>
  <summary>PR Check triggers</summary>
You can run multiple PR check triggers by comma separating them in a single comment. e.g. `trigger ut0, ut1`

- Compile: `trigger compile`
- CodeformatCheckstyle: `trigger checkstylecodeformat`
  - CodeFormat: `trigger codeformat`
  - Checkstyle: `trigger checkstyle`
- MessageMetadata: `trigger messagecheck`
- File-Permission-Check: `trigger checkpermission`
- Recency: `trigger recency`
- BuildNumberMetadata: `trigger buildnum`
- Trigger CommonChecks: `trigger commonchecks`
- PMD: `trigger pmd`
- Copyright Check: `trigger copyrightcheck`
- Feature Name Check: `trigger featurenamecheck`
- UnitTests-ALL: `trigger uts`
- UnitTests-0: `trigger ut0`
- UnitTests-1: `trigger ut1`
- UnitTests-2: `trigger ut2`
- UnitTests-3: `trigger ut3`
- UnitTests-4: `trigger ut4`
- UnitTests-5: `trigger ut5`
- UnitTests-6: `trigger ut6`
- UnitTests-7: `trigger ut7`
- UnitTests-8: `trigger ut8`
- UnitTests-9: `trigger ut9`
- CodeBaseHash: `trigger codebasehash`
- CodeFormatCheckstyle: `trigger checkstylecodeformat`
- SonarScan: `trigger ss`
- GitLeaks: `trigger gitleaks`
- Trigger all Checks: `trigger smartchecks`
- Go Build: `trigger gobuild`
- Validate_Reviews: `trigger review`
- Module Dependency Check: `trigger mdc`
</details>

## PR check failures and solutions
https://harness.atlassian.net/wiki/spaces/BT/pages/21106884744/PR+Checks+-+Failures+and+Solutions

### Rebase Instructions:
To rebase your branch onto the latest changes in the target branch, simply use the following command in a comment: `/rebase`



## [Contributor license agreement](https://github.com/harness/harness-core/blob/develop/CONTRIBUTOR_LICENSE_AGREEMENT.md)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/harness/harness-core/57110)
<!-- Reviewable:end -->
